### PR TITLE
Switch dialog cache to Postgres

### DIFF
--- a/LIBRARY.md
+++ b/LIBRARY.md
@@ -31,13 +31,13 @@ async function main() {
   // Login to Telegram (will prompt for code/password if needed)
   await client.login();
 
-  // Load dialog cache (optional, but recommended for performance)
+  // Load dialog cache from PostgreSQL (optional, but recommended for performance)
   // Or use getAllDialogs() to fetch and populate the cache
-  await client.loadDialogCache(); // Default path: './data/dialog_cache.json'
+  await client.loadDialogCache(db);
   if (client.dialogCache.size === 0) {
     console.log("Cache empty, fetching all dialogs to build cache...");
     await client.getAllDialogs(); // Fetches all dialogs and populates cache
-    await client.saveDialogCache(); // Save cache for next time
+    await client.saveDialogCache(db); // Save cache for next time
   }
 
   // Get dialogs from the cache
@@ -90,7 +90,7 @@ const client = new TelegramClient(apiId, apiHash, phoneNumber, sessionPath);
 - `getChatMessages(chatObject, limit)`: Gets messages from a specific chat _object_ (less commonly used now).
 - `getMessagesByChannelId(channelId, limit)`: Gets messages from a specific chat/channel using its ID (uses cached peer info).
 - `filterMessagesByPattern(messages, pattern)`: Filters an array of message _strings_ by a regex pattern.
-- `saveDialogCache(cachePath)`: Saves the internal `dialogCache` Map to a JSON file (default: `./data/dialog_cache.json`).
-- `loadDialogCache(cachePath)`: Loads the `dialogCache` Map from a JSON file.
+- `saveDialogCache(db)`: Saves the internal `dialogCache` Map to the `chats` table in PostgreSQL.
+- `loadDialogCache(db)`: Loads the `dialogCache` Map from the database.
 - `saveDialogsToDb(db)`: Saves all cached chats to a PostgreSQL database using the helper from `db.js`.
 - `saveChatMessagesToDb(chatId, db, options)`: Incrementally fetches messages from a chat and stores them in the database. `options` may include `batchSize` and `after` (UNIX timestamp) for continuous updates.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ await db.connect();
 await db.init();
 
 const client = new TelegramClient(...);
-await client.initializeDialogCache();
+await client.initializeDialogCache(db);
 await client.saveDialogsToDb(db); // store chats
 await client.saveChatMessagesToDb(chatId, db, { batchSize: 100, after: 0 });
 ```
@@ -121,7 +121,7 @@ await client.saveChatMessagesToDb(chatId, db, { batchSize: 100, after: 0 });
     - The server will use the credentials from your `.env` file.
     - It will prompt you in the terminal to enter the login code sent to your Telegram account and your 2FA password if required.
     - Upon successful login, a session file (`./data/session.json`) will be created. This file allows the server to log in automatically in the future without requiring codes/passwords.
-    - The server will also attempt to build or load a cache of your chats (`./data/dialog_cache.json`). This can take some time on the first run, especially with many chats. Subsequent starts will be faster if the cache exists.
+    - The server will build or load a cache of your chats from the `chats` table in PostgreSQL. This can take some time on the first run, especially with many chats. Subsequent starts will be faster if the database already contains chat data.
 
 2.  **Normal Operation:**
     You'll need to start the server manually by running `npm start` in the project directory.
@@ -131,7 +131,7 @@ await client.saveChatMessagesToDb(chatId, db, { batchSize: 100, after: 0 });
 ## Troubleshooting
 
 - **Login Prompts:** If the server keeps prompting for login codes/passwords when started by the MCP client, ensure the `data/session.json` file exists and is valid. You might need to run `npm start` manually once to refresh the session. Also, check that the file permissions allow the user running the MCP client to read/write the `data` directory.
-- **Cache Issues:** If channels seem outdated or missing, you can delete `./data/dialog_cache.json` and restart the server (run `npm start` manually) to force a full refresh. This might take time.
+- **Cache Issues:** If channels seem outdated or missing, try clearing the `chats` table in your PostgreSQL database and restart the server to rebuild the cache.
 - **Cannot Find Module:** Ensure you run `npm install` in the project directory. If the MCP client starts the server, make sure the working directory is set correctly or use absolute paths.
 - **Other Issues:** If you encounter any other problems, feel free to open an issue in [this server repo](https://github.com/kfastov/telegram-mcp-server).
 

--- a/db.js
+++ b/db.js
@@ -55,4 +55,11 @@ export class Database {
       [id, chat_id, date, text, from_id || null]
     );
   }
+
+  async getAllChats() {
+    const res = await this.client.query(
+      'SELECT id, title, type, access_hash FROM chats'
+    );
+    return res.rows;
+  }
 }

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1,13 +1,16 @@
 import { FastMCP } from "fastmcp";
 import { z } from "zod"; // Or any validation library that supports Standard Schema
 import TelegramClient from './telegram-client.js';
+import { Database } from './db.js';
 import dotenv from 'dotenv';
 
 // Load environment variables
 dotenv.config();
 
-// Cache path for dialog data
-const DIALOG_CACHE_PATH = './data/dialog_cache.json';
+
+const db = new Database(process.env.DATABASE_URL);
+await db.connect();
+await db.init();
 
 // Initialize Telegram client
 const telegramClient = new TelegramClient(
@@ -137,7 +140,7 @@ server.addTool({
 
 // Initialize dialog cache at server startup
 console.log('Starting server and initializing Telegram dialog cache...');
-telegramClient.initializeDialogCache(DIALOG_CACHE_PATH).then(success => {
+telegramClient.initializeDialogCache(db).then(success => {
   if (success) {
     console.log('Dialog cache initialization complete, starting server...');
     server.start({


### PR DESCRIPTION
## Summary
- store chats in Postgres via `saveDialogCache` and `loadDialogCache`
- read/write chats table during startup
- adjust docs for database-backed cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e4abaea408322815232112d467d43