### PR TITLE
docs(skill): full command coverage and tool boundary fix

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,86 +1,284 @@
 ---
 name: tgcli
-description: Telegram CLI for reading/searching messages, syncing archives, and sending or downloading files. Use when the user asks about Telegram chats, messages, contacts, groups, or files.
+description: >
+  Use when user wants to read/search/send/analyze Telegram messages via tgcli CLI.
+  Trigger on requests about channel/chat history, digests/news, mentions, files, topics,
+  contacts, groups, tags, media downloads, and archive/sync status.
+  Also covers group admin (rename, members, invite links, join/leave).
+  For reply/edit/delete/reactions/inline buttons, use telegram-mcp instead.
 ---
 
 # tgcli
 
-Telegram CLI with background sync.
-
-## When to Use
-
-Use this skill when the user:
-- Wants to read or search Telegram messages
-- Needs recent updates or an inbox-style view of chats
-- Asks to send a Telegram message or file
-- Wants to download media or files from Telegram
-- Wants to look up channels, groups, or contacts
-- Needs archive/backfill sync for a chat
+Telegram CLI skill for AI agents.
 
 ## Install
 
+Install this skill from GitHub:
+
 ```bash
-npm install -g @kfastov/tgcli
+npx skills add dapi/tgcli --skill tgcli --agent '*' -y
 ```
 
-Or:
+Install CLI (dapi fork):
+
 ```bash
-brew install kfastov/tap/tgcli
+npm install -g github:dapi/tgcli
 ```
 
-## Authentication
-
-First-time setup needs Telegram API credentials from https://my.telegram.org/apps
+Authenticate once:
 
 ```bash
 tgcli auth
 ```
 
-## Common Commands
+## Tool Boundary: tgcli vs telegram-mcp
 
-### Reading
-```bash
-tgcli channels list --limit 20
-tgcli messages list --chat @username --limit 50
-tgcli messages search "query" --chat @channel --source archive
-tgcli topics list --chat @channel --limit 20
-```
+| Use tgcli for | Use telegram-mcp for |
+|-|-|
+| Read/search/archive messages | reply/edit/delete/forward |
+| Send text/files and topic posts | reactions |
+| Forum topics listing/search | inline bot buttons |
+| Download media from messages | advanced interactive actions |
+| Group admin (rename, members, invite, join/leave) | ban/kick/promote with granular permissions |
+| Channel/contact tags and metadata | |
+| Sync jobs and archive monitoring | |
+| JSON output for automation | |
 
-### Files & Media
-```bash
-tgcli media download --chat @channel --id 12345
-tgcli send file --to @channel --file ./report.pdf --caption "FYI"
-```
+## Execution Rules
 
-### Writing
-```bash
-tgcli send text --to @username --message "Hello"
-```
+- If `tgcli` is not found, install it: `npm install -g github:dapi/tgcli` then run `tgcli auth` for first-time login.
+- Always add `--json` for agent workflows.
+- Add `--timeout 30s` by default; use `--timeout 90s` for heavy archive fallback reads.
+- Prefer explicit `--source archive|live|both` instead of relying on defaults.
+- For sending format control:
+  - `--parse-mode markdown|html|none` (case-insensitive)
+  - for `send file`, `--parse-mode` requires `--caption`
+- Never delete lock files (`LOCK`, `database is locked`): wait and retry.
 
-### Sync & Service
-```bash
-tgcli sync --follow
-tgcli sync jobs add --chat @channel --min-date 2024-01-01T00:00:00Z
-tgcli service install
-tgcli service start
-```
+## Core Command Patterns
 
-### Contacts & Groups
-```bash
-tgcli contacts search "alex"
-tgcli groups list --query "Nha Trang"
-```
-
-## Output Formats
-
-All commands support `--json` for structured output:
+### Read
 
 ```bash
-tgcli messages list --chat @username --limit 5 --json
-tgcli channels list --limit 10 --json
+tgcli messages list --chat <id|@username> --limit 50 --source archive --json --timeout 30s
+tgcli messages list --chat <id|@username> --chat <id2> --limit 50 --source archive --json --timeout 30s
+tgcli messages list --chat <id|@username> --topic <topicId> --after 2025-01-01T00:00:00Z --limit 100 --source archive --json --timeout 30s
+tgcli messages show --chat <id|@username> --id <msgId> --source archive --json --timeout 30s
+tgcli messages context --chat <id|@username> --id <msgId> --before 5 --after 5 --source archive --json --timeout 30s
 ```
 
-## Notes
+### Search
 
-- Use `--source live|archive|both` when listing or searching messages.
-- `--json` is best for AI/tooling pipelines.
+```bash
+tgcli messages search "Claude Code" --chat <id|@username> --source archive --json --timeout 30s
+tgcli messages search --query "Claude Code" --chat <id|@username> --source archive --json --timeout 30s
+tgcli messages search --regex "claude\\s+(code|agent)" --chat <id|@username> --source archive --json --timeout 30s
+tgcli messages search --tag ai --chat <id|@username> --source archive --json --timeout 30s
+tgcli messages search --tags "ai,dev" --chat <id|@username> --source archive --json --timeout 30s
+tgcli messages search "release" --chat <id|@username> --after 2025-06-01T00:00:00Z --before 2025-06-30T00:00:00Z --source archive --json --timeout 30s
+tgcli messages search "Release" --case-sensitive --chat <id|@username> --source archive --json --timeout 30s
+```
+
+Both positional query and `--query` flag work. `--chat` accepts multiple values. Use `--regex` for pattern matching, `--tag`/`--tags` to filter by channel tags, `--after`/`--before` for date range, `--case-sensitive` to disable case-insensitive search.
+
+### Send Text/File
+
+```bash
+tgcli send text --to <id|@username> --message "Hello" --json --timeout 30s
+tgcli send text --to <id|@username> --topic <topicId> --message "**Hello**" --parse-mode markdown --json --timeout 30s
+
+tgcli send file --to <id|@username> --file /path/to/file --caption "Report" --json --timeout 30s
+tgcli send file --to <id|@username> --file /path/to/file --caption "<b>Report</b>" --parse-mode html --json --timeout 30s
+tgcli send file --to <id|@username> --file /path/to/file --filename custom-name.pdf --json --timeout 30s
+```
+
+### Media Download
+
+```bash
+tgcli media download --chat <id|@username> --id <msgId> --json --timeout 30s
+tgcli media download --chat <id|@username> --id <msgId> --output /path/to/save --json --timeout 30s
+```
+
+### Channels
+
+```bash
+tgcli channels list --query "ai" --limit 20 --json --timeout 30s
+tgcli channels show --chat <id|@username> --json --timeout 30s
+tgcli channels sync --chat <id|@username> --enable --json --timeout 30s
+tgcli channels sync --chat <id|@username> --disable --json --timeout 30s
+```
+
+### Topics
+
+```bash
+tgcli topics list --chat <id|@username> --limit 50 --json --timeout 30s
+tgcli topics search --chat <id|@username> --query "release" --limit 20 --json --timeout 30s
+```
+
+### Contacts
+
+```bash
+tgcli contacts search "alex" --limit 20 --json --timeout 30s
+tgcli contacts show --user <id> --json --timeout 30s
+tgcli contacts alias set --user <id> --alias "Alex" --json --timeout 30s
+tgcli contacts alias rm --user <id> --json --timeout 30s
+tgcli contacts tags add --user <id> --tag coworker --tag ai --json --timeout 30s
+tgcli contacts tags rm --user <id> --tag ai --json --timeout 30s
+tgcli contacts notes set --user <id> --notes "Met at meetup" --json --timeout 30s
+```
+
+### Groups
+
+```bash
+tgcli groups list --query "dev" --limit 20 --json --timeout 30s
+tgcli groups info --chat <id|@username> --json --timeout 30s
+tgcli groups rename --chat <id|@username> --name "New Name" --json --timeout 30s
+tgcli groups members add --chat <id|@username> --user <userId> --user <userId2> --json --timeout 30s
+tgcli groups members remove --chat <id|@username> --user <userId> --json --timeout 30s
+tgcli groups invite get --chat <id|@username> --json --timeout 30s
+tgcli groups invite revoke --chat <id|@username> --json --timeout 30s
+tgcli groups join --code <invite-code> --json --timeout 30s
+tgcli groups leave --chat <id|@username> --json --timeout 30s
+```
+
+### Tags (Channel Classification)
+
+```bash
+tgcli tags list --chat <id|@username> --json --timeout 30s
+tgcli tags set --chat <id|@username> --tag ai --tag dev --json --timeout 30s
+tgcli tags search --tag ai --limit 20 --json --timeout 30s
+tgcli tags auto --limit 50 --json --timeout 90s            # AI-powered: generates tags from channel metadata/content
+tgcli tags auto --chat <id|@username> --source manual --json --timeout 90s
+tgcli tags auto --limit 50 --no-refresh-metadata --json --timeout 90s
+```
+
+### Metadata (Channel Cache)
+
+```bash
+tgcli metadata get --chat <id|@username> --json --timeout 30s
+tgcli metadata refresh --chat <id|@username> --force --json --timeout 30s
+tgcli metadata refresh --only-missing --limit 50 --json --timeout 90s
+```
+
+### Sync Jobs
+
+```bash
+tgcli sync status --json --timeout 30s
+tgcli sync jobs list --json --timeout 30s
+tgcli sync jobs list --status error --json --timeout 30s
+tgcli sync jobs list --channel <id|@username> --json --timeout 30s
+tgcli sync jobs add --chat <id|@username> --depth 500 --json --timeout 30s
+tgcli sync jobs add --chat <id|@username> --min-date 2025-01-01T00:00:00Z --json --timeout 30s
+tgcli sync jobs retry --all-errors --json --timeout 30s
+tgcli sync jobs retry --job-id <id> --json --timeout 30s
+tgcli sync jobs retry --channel <id|@username> --json --timeout 30s
+tgcli sync jobs cancel --job-id <id> --json --timeout 30s
+tgcli sync jobs cancel --channel <id|@username> --json --timeout 30s
+```
+
+### Service (Background Sync Daemon)
+
+```bash
+tgcli service status --json --timeout 30s
+tgcli service install --json --timeout 30s
+tgcli service start --json --timeout 30s
+tgcli service stop --json --timeout 30s
+tgcli service logs --json --timeout 30s
+```
+
+### Config & Auth
+
+```bash
+tgcli auth status --json --timeout 30s
+tgcli auth logout --json --timeout 30s
+tgcli config list --json --timeout 30s
+tgcli config get <key> --json --timeout 30s
+tgcli config set <key> <value> --json --timeout 30s
+tgcli config unset <key> --json --timeout 30s
+tgcli doctor --json --timeout 30s
+tgcli doctor --connect --json --timeout 30s
+```
+
+## Archive + Analysis Workflow
+
+For tasks like "analyze chat history", "what happened this week", "digest/news":
+
+1. Resolve chat:
+   - `tgcli channels list --query "<name>" --json --timeout 30s`
+   - optionally `tgcli groups list --query "<name>" --json --timeout 30s`
+2. Ensure archive flow:
+   - `tgcli channels sync --chat <id> --enable`
+   - `tgcli sync jobs add --chat <id> --depth 500`
+   - `tgcli service status --json --timeout 30s` — check if running
+   - `tgcli service install --json --timeout 30s` — if not installed yet
+   - `tgcli service start --json --timeout 30s` — start daemon
+3. Read archive first:
+   - `tgcli messages list --chat <id> --source archive --limit 500 --json --timeout 30s`
+4. If archive is still empty, fallback to live:
+   - `tgcli messages list --chat <id> --source live --limit 500 --json --timeout 90s`
+5. Build digest/synthesis from JSON payload.
+
+## Continuous Sync Workflow
+
+For tasks like "monitor these channels", "keep syncing my subscriptions":
+
+Architecture: `channels sync --enable` marks channels for watching → `sync jobs add` creates backfill tasks → `service start` runs a persistent daemon that processes jobs and pulls realtime updates.
+
+1. Enable sync for each channel:
+   - `tgcli channels sync --chat <id|@username> --enable --json --timeout 30s`
+   - repeat for each channel to monitor
+2. Add backfill jobs (optional, pulls history):
+   - `tgcli sync jobs add --chat <id|@username> --depth 1000 --json --timeout 30s`
+3. Start the background daemon:
+   - `tgcli service install --json --timeout 30s` — first time only
+   - `tgcli service start --json --timeout 30s`
+4. Verify it's running:
+   - `tgcli service status --json --timeout 30s`
+   - `tgcli sync status --json --timeout 30s` — shows per-channel sync progress
+5. Check for errors:
+   - `tgcli sync jobs list --status error --json --timeout 30s`
+   - `tgcli sync jobs retry --all-errors --json --timeout 30s`
+6. Stop monitoring a channel:
+   - `tgcli channels sync --chat <id|@username> --disable --json --timeout 30s`
+
+Alternative without systemd service (one-shot or foreground):
+- `tgcli sync --once` — run one sync pass and exit
+- `tgcli sync --follow` — keep syncing in foreground (ctrl-c to stop)
+- `tgcli sync --follow --idle-exit 5m` — auto-exit after 5 minutes idle
+
+## Sync Semantics
+
+- "My channels/subscriptions" -> `tgcli channels list ...`
+- "Monitored/synced channels" -> `tgcli sync status --json --timeout 30s`
+
+## Trigger Examples
+
+### Should trigger
+
+- "read messages in <channel>"
+- "search telegram for <query>"
+- "send this text/file to telegram"
+- "download file from telegram message"
+- "summarize what was discussed this week"
+- "what's new in <chat>?"
+- "show my mentions in <channel>"
+- "tag channels by topic"
+- "add user to telegram group"
+- "get invite link for group"
+- "start syncing this channel"
+- "monitor my telegram channels"
+- "прочитай сообщения в канале"
+- "найди в телеграме про релиз"
+- "отправь сообщение в канал"
+- "дай сводку по чату"
+- "скачай файл из сообщения"
+
+### Should not trigger
+
+- "reply/edit/delete/forward telegram message"
+- "react with emoji to message"
+- "click inline button in bot"
+- "ban/kick/promote user with granular permissions"
+
+Use `telegram-mcp` for those operations.


### PR DESCRIPTION
## Summary
- Add all missing CLI commands to SKILL.md: media download, tags, metadata, sync jobs, service, config/auth/doctor, group admin
- Fix tool boundary table: group admin (rename, members, invite, join/leave) correctly attributed to tgcli
- Add Continuous Sync Workflow section explaining architecture and step-by-step persistent monitoring setup
- Add `sync --once/--follow/--idle-exit` alternatives for non-systemd usage
- Add auto-install rule when `tgcli` is not found
- Add multi-chat, multi-user, date filters, `--tags`, `--case-sensitive` examples
- Consistent `--json --timeout` flags on all command examples

All documented flags cross-verified against `cli.js` command definitions.

## Test plan
- [ ] Verify documented commands match `cli.js` signatures
- [ ] Spot-check 3-5 commands with `tgcli <cmd> --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)