### PR TITLE
feat: add chat folders CRUD commands

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -464,12 +464,100 @@ function buildProgram() {
     .option('--chat <id|username>', 'Group identifier')
     .action(withGlobalOptions((globalFlags, options) => runGroupsLeave(globalFlags, options)));
 
+  // --- Folders ---
+  const folders = program.command('folders').description('Chat folder management');
+  folders
+    .command('list')
+    .description('List all folders')
+    .action(withGlobalOptions((globalFlags) => runFoldersList(globalFlags)));
+  folders
+    .command('show')
+    .description('Show folder details')
+    .argument('<folder>', 'Folder ID or title')
+    .option('--resolve', 'Resolve peer IDs to names (slower, requires API calls)')
+    .action(withGlobalOptions((globalFlags, folder, opts) => runFoldersShow(globalFlags, folder, opts)));
+  folders
+    .command('create')
+    .description('Create a new folder')
+    .requiredOption('--title <name>', 'Folder name (max 12 chars)')
+    .option('--emoji <emoji>', 'Emoji icon')
+    .option('--include-contacts', 'Include contacts')
+    .option('--include-non-contacts', 'Include non-contacts')
+    .option('--include-groups', 'Include groups')
+    .option('--include-channels', 'Include channels')
+    .option('--include-bots', 'Include bots')
+    .option('--exclude-muted', 'Exclude muted')
+    .option('--exclude-read', 'Exclude read')
+    .option('--exclude-archived', 'Exclude archived')
+    .option('--chat <id>', 'Chat to include (repeatable)', collectOption, [])
+    .option('--exclude-chat <id>', 'Chat to exclude (repeatable)', collectOption, [])
+    .option('--pin-chat <id>', 'Pin chat in folder (repeatable)', collectOption, [])
+    .action(withGlobalOptions((globalFlags, options) => runFoldersCreate(globalFlags, options)));
+  folders
+    .command('edit')
+    .description('Edit an existing folder')
+    .argument('<folder>', 'Folder ID or title')
+    .option('--title <name>', 'Folder name (max 12 chars)')
+    .option('--emoji <emoji>', 'Emoji icon')
+    .option('--include-contacts', 'Include contacts')
+    .option('--no-include-contacts', 'Do not include contacts')
+    .option('--include-non-contacts', 'Include non-contacts')
+    .option('--no-include-non-contacts', 'Do not include non-contacts')
+    .option('--include-groups', 'Include groups')
+    .option('--no-include-groups', 'Do not include groups')
+    .option('--include-channels', 'Include channels')
+    .option('--no-include-channels', 'Do not include channels')
+    .option('--include-bots', 'Include bots')
+    .option('--no-include-bots', 'Do not include bots')
+    .option('--exclude-muted', 'Exclude muted')
+    .option('--no-exclude-muted', 'Do not exclude muted')
+    .option('--exclude-read', 'Exclude read')
+    .option('--no-exclude-read', 'Do not exclude read')
+    .option('--exclude-archived', 'Exclude archived')
+    .option('--no-exclude-archived', 'Do not exclude archived')
+    .option('--chat <id>', 'Chat to include (repeatable)', collectOption, [])
+    .option('--exclude-chat <id>', 'Chat to exclude (repeatable)', collectOption, [])
+    .option('--pin-chat <id>', 'Pin chat in folder (repeatable)', collectOption, [])
+    .action(withGlobalOptions((globalFlags, folder, options) => runFoldersEdit(globalFlags, folder, options)));
+  folders
+    .command('delete')
+    .description('Delete a folder')
+    .argument('<folder>', 'Folder ID or title')
+    .action(withGlobalOptions((globalFlags, folder) => runFoldersDelete(globalFlags, folder)));
+  folders
+    .command('reorder')
+    .description('Reorder folders')
+    .requiredOption('--ids <id1,id2,...>', 'Comma-separated folder IDs in desired order')
+    .action(withGlobalOptions((globalFlags, options) => runFoldersReorder(globalFlags, options)));
+  const foldersChats = folders.command('chats').description('Manage chats in a folder');
+  foldersChats
+    .command('add')
+    .description('Add chat to folder')
+    .argument('<folder>', 'Folder ID or title')
+    .requiredOption('--chat <chatId>', 'Chat identifier')
+    .action(withGlobalOptions((globalFlags, folder, options) => runFoldersChatsAdd(globalFlags, folder, options)));
+  foldersChats
+    .command('remove')
+    .description('Remove chat from folder')
+    .argument('<folder>', 'Folder ID or title')
+    .requiredOption('--chat <chatId>', 'Chat identifier')
+    .action(withGlobalOptions((globalFlags, folder, options) => runFoldersChatsRemove(globalFlags, folder, options)));
+  folders
+    .command('join')
+    .description('Join shared folder via invite link')
+    .argument('<link>', 'Shared folder invite link')
+    .action(withGlobalOptions((globalFlags, link) => runFoldersJoin(globalFlags, link)));
+
   disableHelpCommand(program);
   program.addHelpText('after', '\nUse "tgcli [command] --help" for more information about a command.');
   program.action(() => {
     program.help();
   });
   return program;
+}
+
+function collectOption(value, previous) {
+  return previous.concat([value]);
 }
 
 function disableHelpCommand(command) {
@@ -3800,6 +3888,298 @@ async function runGroupsLeave(globalFlags, options = {}) {
         writeJson({ channelId: options.chat, left: true });
       } else {
         console.log(`Left ${options.chat}`);
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+// --- Folders handlers ---
+
+async function runFoldersList(globalFlags) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireReadLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const folders = await telegramClient.getFolders();
+      if (globalFlags.json) {
+        writeJson(folders);
+      } else {
+        for (const f of folders) {
+          console.log(`${f.title} (id=${f.id}, type=${f.type})`);
+        }
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersShow(globalFlags, folder, opts = {}) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireReadLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const info = await telegramClient.showFolder(folder, { resolve: opts.resolve });
+      if (globalFlags.json) {
+        writeJson(info);
+      } else {
+        console.log(`${info.title} (id=${info.id}, type=${info.type})`);
+        if (info.emoji) console.log(`  emoji: ${info.emoji}`);
+        const flags = ['contacts', 'nonContacts', 'groups', 'broadcasts', 'bots'].filter((f) => info[f]);
+        if (flags.length) console.log(`  includes: ${flags.join(', ')}`);
+        const excludes = ['excludeMuted', 'excludeRead', 'excludeArchived'].filter((f) => info[f]);
+        if (excludes.length) console.log(`  excludes: ${excludes.join(', ')}`);
+
+        if (opts.resolve) {
+          const printResolvedPeers = (peers, label) => {
+            if (!peers?.length) return;
+            if (label) console.log(`  ${label}:`);
+            const indent = label ? '    ' : '  ';
+            const grouped = {};
+            for (const p of peers) {
+              const group = p.type + 's';
+              if (!grouped[group]) grouped[group] = [];
+              const displayName = p.name ?? p.title ?? '(unresolved)';
+              grouped[group].push(`${displayName} (${p.id})`);
+            }
+            for (const [group, items] of Object.entries(grouped)) {
+              console.log(`${indent}${group}:`);
+              for (const item of items) console.log(`${indent}  - ${item}`);
+            }
+          };
+          printResolvedPeers(info.includePeers);
+          printResolvedPeers(info.excludePeers, 'excluded');
+          printResolvedPeers(info.pinnedPeers, 'pinned');
+        } else {
+          const printPeers = (peers, label) => {
+            if (!peers?.length) {
+              console.log(`  ${label}: (none)`);
+              return;
+            }
+            console.log(`  ${label}:`);
+            for (const p of peers) console.log(`    - ${p.type}:${p.id}`);
+          };
+          printPeers(info.includePeers, 'includePeers');
+          printPeers(info.excludePeers, 'excludePeers');
+          printPeers(info.pinnedPeers, 'pinnedPeers');
+        }
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersCreate(globalFlags, options) {
+  if (!options.title || options.title.length > 12) throw new Error('Folder title must be 1-12 characters');
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const result = await telegramClient.createFolder({
+        title: options.title,
+        emoji: options.emoji,
+        contacts: options.includeContacts,
+        nonContacts: options.includeNonContacts,
+        groups: options.includeGroups,
+        broadcasts: options.includeChannels,
+        bots: options.includeBots,
+        excludeMuted: options.excludeMuted,
+        excludeRead: options.excludeRead,
+        excludeArchived: options.excludeArchived,
+        includePeers: options.chat?.length ? options.chat : undefined,
+        excludePeers: options.excludeChat?.length ? options.excludeChat : undefined,
+        pinnedPeers: options.pinChat?.length ? options.pinChat : undefined,
+      });
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log(`Created folder: ${result.title} (id=${result.id})`);
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersEdit(globalFlags, folder, options) {
+  if (options.title !== undefined && (options.title.length === 0 || options.title.length > 12)) throw new Error('Folder title must be 1-12 characters');
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const modification = {};
+      if (options.title !== undefined) modification.title = options.title;
+      if (options.emoji !== undefined) modification.emoji = options.emoji;
+      if (options.includeContacts !== undefined) modification.contacts = options.includeContacts;
+      if (options.includeNonContacts !== undefined) modification.nonContacts = options.includeNonContacts;
+      if (options.includeGroups !== undefined) modification.groups = options.includeGroups;
+      if (options.includeChannels !== undefined) modification.broadcasts = options.includeChannels;
+      if (options.includeBots !== undefined) modification.bots = options.includeBots;
+      if (options.excludeMuted !== undefined) modification.excludeMuted = options.excludeMuted;
+      if (options.excludeRead !== undefined) modification.excludeRead = options.excludeRead;
+      if (options.excludeArchived !== undefined) modification.excludeArchived = options.excludeArchived;
+      if (options.chat?.length) modification.includePeers = options.chat;
+      if (options.excludeChat?.length) modification.excludePeers = options.excludeChat;
+      if (options.pinChat?.length) modification.pinnedPeers = options.pinChat;
+      const result = await telegramClient.editFolder(folder, modification);
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log(`Updated folder: ${result.title} (id=${result.id})`);
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersDelete(globalFlags, folder) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const result = await telegramClient.deleteFolder(folder);
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log(`Deleted folder id=${result.id}`);
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersReorder(globalFlags, options) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const ids = options.ids.split(',').map((s) => s.trim()).filter((s) => s !== '').map(Number);
+      const result = await telegramClient.setFoldersOrder(ids);
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log('Folders reordered');
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersChatsAdd(globalFlags, folder, options) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    if (!options.chat) throw new Error('--chat is required');
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const result = await telegramClient.addChatToFolder(folder, options.chat);
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log(`Chat added to folder id=${result.folderId}`);
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersChatsRemove(globalFlags, folder, options) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    if (!options.chat) throw new Error('--chat is required');
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const result = await telegramClient.removeChatFromFolder(folder, options.chat);
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log(`Chat removed from folder id=${result.folderId}`);
+      }
+    } finally {
+      await messageSyncService.shutdown();
+      await telegramClient.destroy();
+      release();
+    }
+  }, timeoutMs);
+}
+
+async function runFoldersJoin(globalFlags, link) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    const { telegramClient, messageSyncService } = createServices({ storeDir });
+    try {
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+      const result = await telegramClient.joinChatlist(link);
+      if (globalFlags.json) {
+        writeJson(result);
+      } else {
+        console.log(`Joined folder: ${result.title} (id=${result.id})`);
       }
     } finally {
       await messageSyncService.shutdown();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,3 +129,16 @@ Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 - groups invite revoke --chat <id>
 - groups join --code <invite-code>
 - groups leave --chat <id>
+
+## folders
+- folders list
+- folders show <folder> [--resolve]
+- folders create --title <name> [--emoji] [--include-contacts] [--include-non-contacts] [--include-groups] [--include-channels] [--include-bots] [--exclude-muted] [--exclude-read] [--exclude-archived] [--chat <id>...] [--exclude-chat <id>...] [--pin-chat <id>...]
+- folders edit <folder> [--title] [--emoji] [flags...] [--chat <id>...] [--exclude-chat <id>...] [--pin-chat <id>...]
+- folders delete <folder>
+- folders reorder --ids <id1,id2,...>
+- folders chats add <folder> --chat <id>
+- folders chats remove <folder> --chat <id>
+- folders join <link>
+
+`<folder>` can be a numeric folder ID or folder title.

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -1462,6 +1462,243 @@ class TelegramClient {
       messages,
     };
   }
+  // --- Chat Folders ---
+
+  async getFolders() {
+    await this.ensureLogin();
+    const result = await this.client.getFolders();
+    const filters = result?.filters ?? [];
+    return filters.map((f) => {
+      if (f._ === 'dialogFilterDefault') return { id: 0, title: 'All Chats', type: 'default' };
+      return {
+        id: f.id,
+        title: typeof f.title === 'string' ? f.title : (f.title?.text ?? 'Unknown'),
+        emoji: f.emoticon ?? null,
+        color: f.color ?? null,
+        type: f._ === 'dialogFilterChatlist' ? 'chatlist' : 'filter',
+        contacts: f.contacts ?? false,
+        nonContacts: f.nonContacts ?? false,
+        groups: f.groups ?? false,
+        broadcasts: f.broadcasts ?? false,
+        bots: f.bots ?? false,
+        excludeMuted: f.excludeMuted ?? false,
+        excludeRead: f.excludeRead ?? false,
+        excludeArchived: f.excludeArchived ?? false,
+        includePeers: f.includePeers?.length ?? 0,
+        excludePeers: f.excludePeers?.length ?? 0,
+        pinnedPeers: f.pinnedPeers?.length ?? 0,
+      };
+    });
+  }
+
+  async findFolder(idOrName) {
+    await this.ensureLogin();
+    const trimmed = String(idOrName).trim();
+    if (trimmed === '') throw new Error('Folder identifier cannot be empty');
+    if (/^\d+$/.test(trimmed)) return this.client.findFolder({ id: Number(trimmed) });
+    return this.client.findFolder({ title: trimmed });
+  }
+
+  async showFolder(idOrName, options = {}) {
+    await this.ensureLogin();
+    const folder = await this.findFolder(idOrName);
+    if (!folder) throw new Error(`Folder not found: ${idOrName}`);
+
+    const normalizePeers = (peers) => (peers ?? []).map((p) => this._normalizePeer(p));
+
+    const resolvePeers = async (peers) => {
+      const normalized = normalizePeers(peers);
+      if (!options.resolve) return normalized;
+
+      return Promise.all(normalized.map(async (peer) => {
+        const name = await this._resolvePeerName(peer.type, peer.id);
+        const nameField = peer.type === 'user' ? 'name' : 'title';
+        return { ...peer, [nameField]: name ?? '(unresolved)' };
+      }));
+    };
+
+    return {
+      id: folder.id,
+      title: typeof folder.title === 'string' ? folder.title : (folder.title?.text ?? 'Unknown'),
+      emoji: folder.emoticon ?? null,
+      color: folder.color ?? null,
+      type: folder._ === 'dialogFilterChatlist' ? 'chatlist' : folder._ === 'dialogFilterDefault' ? 'default' : 'filter',
+      contacts: folder.contacts ?? false,
+      nonContacts: folder.nonContacts ?? false,
+      groups: folder.groups ?? false,
+      broadcasts: folder.broadcasts ?? false,
+      bots: folder.bots ?? false,
+      excludeMuted: folder.excludeMuted ?? false,
+      excludeRead: folder.excludeRead ?? false,
+      excludeArchived: folder.excludeArchived ?? false,
+      includePeers: await resolvePeers(folder.includePeers),
+      excludePeers: await resolvePeers(folder.excludePeers),
+      pinnedPeers: await resolvePeers(folder.pinnedPeers),
+    };
+  }
+
+  async createFolder(options) {
+    await this.ensureLogin();
+    if (!options.title) throw new Error('Folder title is required');
+    const params = { title: options.title };
+    if (options.emoji) params.emoticon = options.emoji;
+    if (options.contacts !== undefined) params.contacts = options.contacts;
+    if (options.nonContacts !== undefined) params.nonContacts = options.nonContacts;
+    if (options.groups !== undefined) params.groups = options.groups;
+    if (options.broadcasts !== undefined) params.broadcasts = options.broadcasts;
+    if (options.bots !== undefined) params.bots = options.bots;
+    if (options.excludeMuted !== undefined) params.excludeMuted = options.excludeMuted;
+    if (options.excludeRead !== undefined) params.excludeRead = options.excludeRead;
+    if (options.excludeArchived !== undefined) params.excludeArchived = options.excludeArchived;
+    if (options.includePeers?.length) params.includePeers = options.includePeers;
+    if (options.excludePeers?.length) params.excludePeers = options.excludePeers;
+    if (options.pinnedPeers?.length) params.pinnedPeers = options.pinnedPeers;
+    const result = await this.client.createFolder(params);
+    return { id: result.id, title: typeof result.title === 'string' ? result.title : (result.title?.text ?? 'Unknown') };
+  }
+
+  async editFolder(idOrName, modification) {
+    await this.ensureLogin();
+    const folder = await this.findFolder(idOrName);
+    if (!folder) throw new Error(`Folder not found: ${idOrName}`);
+    if (this._isDefaultFolder(folder)) throw new Error('Cannot modify the default "All Chats" folder');
+    const mod = {};
+    if (modification.title !== undefined) mod.title = modification.title;
+    if (modification.emoji !== undefined) mod.emoticon = modification.emoji;
+    if (modification.contacts !== undefined) mod.contacts = modification.contacts;
+    if (modification.nonContacts !== undefined) mod.nonContacts = modification.nonContacts;
+    if (modification.groups !== undefined) mod.groups = modification.groups;
+    if (modification.broadcasts !== undefined) mod.broadcasts = modification.broadcasts;
+    if (modification.bots !== undefined) mod.bots = modification.bots;
+    if (modification.excludeMuted !== undefined) mod.excludeMuted = modification.excludeMuted;
+    if (modification.excludeRead !== undefined) mod.excludeRead = modification.excludeRead;
+    if (modification.excludeArchived !== undefined) mod.excludeArchived = modification.excludeArchived;
+    if (modification.includePeers !== undefined) mod.includePeers = modification.includePeers;
+    if (modification.excludePeers !== undefined) mod.excludePeers = modification.excludePeers;
+    if (modification.pinnedPeers !== undefined) mod.pinnedPeers = modification.pinnedPeers;
+    const result = await this.client.editFolder({ folder, modification: mod });
+    return { id: result.id, title: typeof result.title === 'string' ? result.title : (result.title?.text ?? 'Unknown') };
+  }
+
+  async deleteFolder(idOrName) {
+    await this.ensureLogin();
+    const folder = await this.findFolder(idOrName);
+    if (!folder) throw new Error(`Folder not found: ${idOrName}`);
+    if (this._isDefaultFolder(folder)) throw new Error('Cannot delete the default "All Chats" folder');
+    await this.client.deleteFolder(folder.id);
+    return { deleted: true, id: folder.id };
+  }
+
+  async setFoldersOrder(ids) {
+    await this.ensureLogin();
+    if (!ids.length) throw new Error('At least one folder ID is required');
+    const numericIds = ids.map((id) => {
+      const n = Number(id);
+      if (!Number.isInteger(n) || n < 0) throw new Error(`Invalid folder ID: ${id}`);
+      return n;
+    });
+    const unique = new Set(numericIds);
+    if (unique.size !== numericIds.length) throw new Error('Duplicate folder IDs are not allowed');
+    await this.client.setFoldersOrder(numericIds);
+    return { ok: true };
+  }
+
+  async addChatToFolder(idOrName, chatId) {
+    await this.ensureLogin();
+    const folder = await this.findFolder(idOrName);
+    if (!folder) throw new Error(`Folder not found: ${idOrName}`);
+    if (this._isDefaultFolder(folder)) throw new Error('Cannot modify the default "All Chats" folder');
+    const peers = folder.includePeers ? [...folder.includePeers] : [];
+    const chatIdStr = String(chatId);
+    const alreadyIncluded = peers.some((p) => {
+      const id = this._extractPeerId(p);
+      return id === chatIdStr;
+    });
+    if (alreadyIncluded) throw new Error(`Chat ${chatId} already in folder ${folder.id}`);
+    peers.push(chatId);
+    await this.client.editFolder({ folder, modification: { includePeers: peers } });
+    return { ok: true, folderId: folder.id };
+  }
+
+  async removeChatFromFolder(idOrName, chatId) {
+    await this.ensureLogin();
+    const folder = await this.findFolder(idOrName);
+    if (!folder) throw new Error(`Folder not found: ${idOrName}`);
+    if (this._isDefaultFolder(folder)) throw new Error('Cannot modify the default "All Chats" folder');
+    const chatIdStr = String(chatId);
+    const originalPeers = folder.includePeers ?? [];
+    const peers = originalPeers.filter((p) => {
+      const peerId = this._extractPeerId(p);
+      return peerId !== chatIdStr;
+    });
+    if (peers.length === originalPeers.length) {
+      throw new Error(`Chat ${chatId} not found in folder ${folder.id}`);
+    }
+    await this.client.editFolder({ folder, modification: { includePeers: peers } });
+    return { ok: true, folderId: folder.id };
+  }
+
+  async joinChatlist(link) {
+    await this.ensureLogin();
+    if (!/^https?:\/\/t\.me\/addlist\/[a-zA-Z0-9_-]+\/?(\?[^\s]*)?$/.test(link)) {
+      throw new Error(`Invalid chatlist link: ${link}. Expected format: https://t.me/addlist/<slug>`);
+    }
+    const result = await this.client.joinChatlist(link);
+    if (!result) throw new Error(`Failed to join chatlist: no result returned for ${link}`);
+    return {
+      id: result.id,
+      title: typeof result.title === 'string' ? result.title : (result.title?.text ?? 'Unknown'),
+      type: 'chatlist',
+    };
+  }
+
+  // --- Folder helper methods ---
+
+  _isDefaultFolder(folder) {
+    return folder.id === 0 || folder._ === 'dialogFilterDefault';
+  }
+
+  _extractPeerId(peer) {
+    if (peer == null) throw new Error(`Peer is ${peer}, cannot extract ID`);
+    if (typeof peer !== 'object') return String(peer);
+    const id = peer.userId ?? peer.channelId ?? peer.chatId;
+    if (id == null) throw new Error(`Peer object has no recognizable ID field: ${JSON.stringify(peer)}`);
+    return String(id);
+  }
+
+  _normalizePeer(peer) {
+    if (peer == null) throw new Error(`Peer is ${peer}, cannot normalize`);
+    if (typeof peer !== 'object') throw new Error(`Peer must be an object, got ${typeof peer}`);
+
+    let type, id;
+    if (peer.userId != null) {
+      type = 'user';
+      id = Number(peer.userId);
+    } else if (peer.channelId != null) {
+      type = 'channel';
+      id = Number(peer.channelId);
+    } else if (peer.chatId != null) {
+      type = 'chat';
+      id = Number(peer.chatId);
+    } else {
+      throw new Error(`Peer object has no recognizable ID field: ${JSON.stringify(peer)}`);
+    }
+
+    return { type, id };
+  }
+
+  async _resolvePeerName(type, id) {
+    try {
+      if (type === 'user') {
+        const user = await this.client.getFullUser(id);
+        return user.displayName || user.firstName || null;
+      }
+      const chat = await this.client.getChat(id);
+      return chat.displayName || chat.title || null;
+    } catch {
+      return null;
+    }
+  }
 }
 
 export default TelegramClient;

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -1,0 +1,637 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test folder methods by creating a minimal TelegramClient instance
+// with mocked internals (this.client, this.ensureLogin).
+// The class constructor has heavy deps, so we import and override prototype.
+
+import TelegramClient from '../telegram-client.js';
+
+function createMockClient() {
+  // Create instance bypassing constructor
+  const tc = Object.create(TelegramClient.prototype);
+  tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
+  tc.client = {
+    getFolders: vi.fn(),
+    findFolder: vi.fn(),
+    createFolder: vi.fn(),
+    editFolder: vi.fn(),
+    deleteFolder: vi.fn(),
+    setFoldersOrder: vi.fn(),
+    joinChatlist: vi.fn(),
+    getChat: vi.fn(),
+    getFullUser: vi.fn(),
+  };
+  return tc;
+}
+
+describe('getFolders', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('maps dialogFilterDefault to id=0', async () => {
+    tc.client.getFolders.mockResolvedValue({
+      filters: [{ _: 'dialogFilterDefault' }],
+    });
+    const result = await tc.getFolders();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 0, title: 'All Chats', type: 'default' });
+  });
+
+  it('maps dialogFilterChatlist type', async () => {
+    tc.client.getFolders.mockResolvedValue({
+      filters: [{ _: 'dialogFilterChatlist', id: 5, title: 'Shared', emoticon: null }],
+    });
+    const result = await tc.getFolders();
+    expect(result[0].type).toBe('chatlist');
+  });
+
+  it('maps regular filter type', async () => {
+    tc.client.getFolders.mockResolvedValue({
+      filters: [{ _: 'dialogFilter', id: 1, title: 'Work', contacts: true, groups: true }],
+    });
+    const result = await tc.getFolders();
+    expect(result[0]).toMatchObject({ id: 1, title: 'Work', type: 'filter', contacts: true, groups: true });
+  });
+
+  it('handles title as object with text field', async () => {
+    tc.client.getFolders.mockResolvedValue({
+      filters: [{ _: 'dialogFilter', id: 2, title: { text: 'Custom' } }],
+    });
+    const result = await tc.getFolders();
+    expect(result[0].title).toBe('Custom');
+  });
+
+  it('handles null filters', async () => {
+    tc.client.getFolders.mockResolvedValue({ filters: null });
+    const result = await tc.getFolders();
+    expect(result).toEqual([]);
+  });
+
+  it('handles undefined result', async () => {
+    tc.client.getFolders.mockResolvedValue(undefined);
+    const result = await tc.getFolders();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getFolders - error handling', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('propagates MTProto errors from getFolders', async () => {
+    tc.client.getFolders.mockRejectedValue(new Error('FLOOD_WAIT_30'));
+    await expect(tc.getFolders()).rejects.toThrow('FLOOD_WAIT_30');
+  });
+});
+
+describe('createFolder - error handling', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('propagates MTProto errors from createFolder', async () => {
+    tc.client.createFolder.mockRejectedValue(new Error('FILTER_TITLE_EMPTY'));
+    await expect(tc.createFolder({ title: 'Test' })).rejects.toThrow('FILTER_TITLE_EMPTY');
+  });
+});
+
+describe('editFolder - error handling', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('propagates MTProto errors from editFolder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 1, _: 'dialogFilter' });
+    tc.client.editFolder.mockRejectedValue(new Error('FLOOD_WAIT_60'));
+    await expect(tc.editFolder('1', { title: 'New' })).rejects.toThrow('FLOOD_WAIT_60');
+  });
+});
+
+describe('deleteFolder - error handling', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('propagates MTProto errors from deleteFolder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 2, _: 'dialogFilter' });
+    tc.client.deleteFolder.mockRejectedValue(new Error('FILTER_ID_INVALID'));
+    await expect(tc.deleteFolder('2')).rejects.toThrow('FILTER_ID_INVALID');
+  });
+});
+
+describe('findFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('searches by numeric id', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 3 });
+    const result = await tc.findFolder('3');
+    expect(tc.client.findFolder).toHaveBeenCalledWith({ id: 3 });
+    expect(result).toEqual({ id: 3 });
+  });
+
+  it('searches by title for non-numeric input', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 1, title: 'Work' });
+    await tc.findFolder('Work');
+    expect(tc.client.findFolder).toHaveBeenCalledWith({ title: 'Work' });
+  });
+
+  it('throws on empty string', async () => {
+    await expect(tc.findFolder('')).rejects.toThrow('Folder identifier cannot be empty');
+  });
+
+  it('throws on whitespace-only string', async () => {
+    await expect(tc.findFolder('   ')).rejects.toThrow('Folder identifier cannot be empty');
+  });
+
+  it('searches id=0 by numeric path', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 0, _: 'dialogFilterDefault' });
+    await tc.findFolder('0');
+    expect(tc.client.findFolder).toHaveBeenCalledWith({ id: 0 });
+  });
+});
+
+describe('showFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('returns folder info', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, title: 'Work', _: 'dialogFilter',
+      contacts: true, groups: true,
+      includePeers: [{ userId: 123 }], excludePeers: [], pinnedPeers: [],
+    });
+    const result = await tc.showFolder('1');
+    expect(result).toMatchObject({ id: 1, title: 'Work', type: 'filter', contacts: true });
+    expect(result.includePeers).toEqual([{ type: 'user', id: 123 }]);
+  });
+
+  it('returns type=default for dialogFilterDefault', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 0, title: 'All Chats', _: 'dialogFilterDefault',
+    });
+    const result = await tc.showFolder('0');
+    expect(result.type).toBe('default');
+  });
+
+  it('throws when folder not found', async () => {
+    tc.client.findFolder.mockResolvedValue(null);
+    await expect(tc.showFolder('999')).rejects.toThrow('Folder not found: 999');
+  });
+});
+
+describe('createFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('creates a folder with all optional params', async () => {
+    tc.client.createFolder.mockResolvedValue({ id: 5, title: 'Dev' });
+    const result = await tc.createFolder({
+      title: 'Dev',
+      emoji: '💻',
+      contacts: true,
+      nonContacts: false,
+      groups: true,
+      broadcasts: false,
+      bots: true,
+      excludeMuted: true,
+      excludeRead: false,
+      excludeArchived: true,
+      includePeers: [1, 2],
+      excludePeers: [3],
+      pinnedPeers: [4],
+    });
+    expect(tc.client.createFolder).toHaveBeenCalledWith({
+      title: 'Dev',
+      emoticon: '💻',
+      contacts: true,
+      nonContacts: false,
+      groups: true,
+      broadcasts: false,
+      bots: true,
+      excludeMuted: true,
+      excludeRead: false,
+      excludeArchived: true,
+      includePeers: [1, 2],
+      excludePeers: [3],
+      pinnedPeers: [4],
+    });
+    expect(result).toEqual({ id: 5, title: 'Dev' });
+  });
+
+  it('handles title as object in result', async () => {
+    tc.client.createFolder.mockResolvedValue({ id: 6, title: { text: 'FromObj' } });
+    const result = await tc.createFolder({ title: 'Test' });
+    expect(result.title).toBe('FromObj');
+  });
+
+  it('throws when title is missing', async () => {
+    await expect(tc.createFolder({})).rejects.toThrow('Folder title is required');
+  });
+
+  it('throws when title is empty string', async () => {
+    await expect(tc.createFolder({ title: '' })).rejects.toThrow('Folder title is required');
+  });
+
+  it('omits undefined optional params', async () => {
+    tc.client.createFolder.mockResolvedValue({ id: 7, title: 'Min' });
+    await tc.createFolder({ title: 'Min' });
+    expect(tc.client.createFolder).toHaveBeenCalledWith({ title: 'Min' });
+  });
+
+  it('passes boolean false values correctly', async () => {
+    tc.client.createFolder.mockResolvedValue({ id: 8, title: 'Test' });
+    await tc.createFolder({ title: 'Test', contacts: false, groups: false });
+    expect(tc.client.createFolder).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Test', contacts: false, groups: false }),
+    );
+  });
+});
+
+describe('editFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('edits a regular folder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 1, title: 'Old', _: 'dialogFilter' });
+    tc.client.editFolder.mockResolvedValue({ id: 1, title: 'New' });
+    const result = await tc.editFolder('1', { title: 'New' });
+    expect(tc.client.editFolder).toHaveBeenCalledWith({
+      folder: { id: 1, title: 'Old', _: 'dialogFilter' },
+      modification: { title: 'New' },
+    });
+    expect(result.title).toBe('New');
+  });
+
+  it('throws on default folder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 0, _: 'dialogFilterDefault' });
+    await expect(tc.editFolder('0', { title: 'X' })).rejects.toThrow('Cannot modify the default "All Chats" folder');
+  });
+
+  it('throws when folder not found', async () => {
+    tc.client.findFolder.mockResolvedValue(null);
+    await expect(tc.editFolder('99', { title: 'X' })).rejects.toThrow('Folder not found: 99');
+  });
+
+  it('passes empty modification object', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 1, _: 'dialogFilter' });
+    tc.client.editFolder.mockResolvedValue({ id: 1, title: 'Same' });
+    const result = await tc.editFolder('1', {});
+    expect(tc.client.editFolder).toHaveBeenCalledWith({
+      folder: { id: 1, _: 'dialogFilter' },
+      modification: {},
+    });
+    expect(result.title).toBe('Same');
+  });
+
+  it('maps emoji to emoticon in modification', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 1, _: 'dialogFilter' });
+    tc.client.editFolder.mockResolvedValue({ id: 1, title: 'T' });
+    await tc.editFolder('1', { emoji: '🎮' });
+    expect(tc.client.editFolder).toHaveBeenCalledWith({
+      folder: { id: 1, _: 'dialogFilter' },
+      modification: { emoticon: '🎮' },
+    });
+  });
+
+  it('passes boolean false correctly', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 1, _: 'dialogFilter' });
+    tc.client.editFolder.mockResolvedValue({ id: 1, title: 'T' });
+    await tc.editFolder('1', { contacts: false });
+    expect(tc.client.editFolder).toHaveBeenCalledWith({
+      folder: { id: 1, _: 'dialogFilter' },
+      modification: { contacts: false },
+    });
+  });
+});
+
+describe('deleteFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('deletes a regular folder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 2, _: 'dialogFilter' });
+    tc.client.deleteFolder.mockResolvedValue(undefined);
+    const result = await tc.deleteFolder('2');
+    expect(result).toEqual({ deleted: true, id: 2 });
+  });
+
+  it('throws on default folder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 0, _: 'dialogFilterDefault' });
+    await expect(tc.deleteFolder('0')).rejects.toThrow('Cannot delete the default "All Chats" folder');
+  });
+
+  it('throws when folder not found', async () => {
+    tc.client.findFolder.mockResolvedValue(null);
+    await expect(tc.deleteFolder('999')).rejects.toThrow('Folder not found: 999');
+  });
+});
+
+describe('setFoldersOrder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('reorders folders', async () => {
+    tc.client.setFoldersOrder.mockResolvedValue(undefined);
+    const result = await tc.setFoldersOrder([1, 2, 3]);
+    expect(tc.client.setFoldersOrder).toHaveBeenCalledWith([1, 2, 3]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('throws on empty array', () => {
+    return expect(tc.setFoldersOrder([])).rejects.toThrow('At least one folder ID is required');
+  });
+
+  it('throws on negative id', () => {
+    return expect(tc.setFoldersOrder([-1, 2])).rejects.toThrow('Invalid folder ID: -1');
+  });
+
+  it('throws on NaN string', () => {
+    return expect(tc.setFoldersOrder(['abc'])).rejects.toThrow('Invalid folder ID: abc');
+  });
+
+  it('throws on non-integer', () => {
+    return expect(tc.setFoldersOrder([1.5])).rejects.toThrow('Invalid folder ID: 1.5');
+  });
+
+  it('throws on duplicate ids', () => {
+    return expect(tc.setFoldersOrder([1, 2, 1])).rejects.toThrow('Duplicate folder IDs');
+  });
+
+  it('accepts id=0 (default folder)', async () => {
+    tc.client.setFoldersOrder.mockResolvedValue(undefined);
+    const result = await tc.setFoldersOrder([0, 1, 2]);
+    expect(tc.client.setFoldersOrder).toHaveBeenCalledWith([0, 1, 2]);
+    expect(result).toEqual({ ok: true });
+  });
+});
+
+describe('addChatToFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('adds a chat to folder', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, _: 'dialogFilter', includePeers: [],
+    });
+    tc.client.editFolder.mockResolvedValue({ id: 1 });
+    const result = await tc.addChatToFolder('1', 123);
+    expect(tc.client.editFolder).toHaveBeenCalledWith({
+      folder: expect.objectContaining({ id: 1 }),
+      modification: { includePeers: [123] },
+    });
+    expect(result).toEqual({ ok: true, folderId: 1 });
+  });
+
+  it('adds chat when includePeers is null', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, _: 'dialogFilter', includePeers: null,
+    });
+    tc.client.editFolder.mockResolvedValue({ id: 1 });
+    const result = await tc.addChatToFolder('1', 123);
+    expect(result).toEqual({ ok: true, folderId: 1 });
+  });
+
+  it('throws if chat already in folder', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, _: 'dialogFilter',
+      includePeers: [{ userId: 123 }],
+    });
+    await expect(tc.addChatToFolder('1', 123)).rejects.toThrow('Chat 123 already in folder 1');
+  });
+
+  it('detects duplicate by channelId', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, _: 'dialogFilter',
+      includePeers: [{ channelId: 456 }],
+    });
+    await expect(tc.addChatToFolder('1', 456)).rejects.toThrow('Chat 456 already in folder 1');
+  });
+
+  it('throws when folder not found', async () => {
+    tc.client.findFolder.mockResolvedValue(null);
+    await expect(tc.addChatToFolder('999', 123)).rejects.toThrow('Folder not found: 999');
+  });
+
+  it('throws on default folder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 0, _: 'dialogFilterDefault' });
+    await expect(tc.addChatToFolder('0', 123)).rejects.toThrow('Cannot modify the default');
+  });
+});
+
+describe('removeChatFromFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('removes a chat from folder', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, _: 'dialogFilter',
+      includePeers: [{ userId: 123 }, { userId: 456 }],
+    });
+    tc.client.editFolder.mockResolvedValue({ id: 1 });
+    const result = await tc.removeChatFromFolder('1', 123);
+    expect(tc.client.editFolder).toHaveBeenCalledWith({
+      folder: expect.objectContaining({ id: 1 }),
+      modification: { includePeers: [{ userId: 456 }] },
+    });
+    expect(result).toEqual({ ok: true, folderId: 1 });
+  });
+
+  it('throws if chat not found in folder', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, _: 'dialogFilter', includePeers: [{ userId: 456 }],
+    });
+    await expect(tc.removeChatFromFolder('1', 123)).rejects.toThrow('Chat 123 not found in folder 1');
+  });
+
+  it('throws on default folder', async () => {
+    tc.client.findFolder.mockResolvedValue({ id: 0, _: 'dialogFilterDefault' });
+    await expect(tc.removeChatFromFolder('0', 123)).rejects.toThrow('Cannot modify the default');
+  });
+});
+
+describe('_isDefaultFolder', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('returns true for id=0', () => {
+    expect(tc._isDefaultFolder({ id: 0 })).toBe(true);
+  });
+
+  it('returns true for dialogFilterDefault type', () => {
+    expect(tc._isDefaultFolder({ id: 0, _: 'dialogFilterDefault' })).toBe(true);
+  });
+
+  it('returns false for regular folder', () => {
+    expect(tc._isDefaultFolder({ id: 1, _: 'dialogFilter' })).toBe(false);
+  });
+});
+
+describe('_extractPeerId', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('extracts userId', () => {
+    expect(tc._extractPeerId({ userId: 123 })).toBe('123');
+  });
+
+  it('extracts channelId', () => {
+    expect(tc._extractPeerId({ channelId: 456 })).toBe('456');
+  });
+
+  it('extracts chatId', () => {
+    expect(tc._extractPeerId({ chatId: 789 })).toBe('789');
+  });
+
+  it('returns string for primitive', () => {
+    expect(tc._extractPeerId(123)).toBe('123');
+  });
+
+  it('throws for null peer', () => {
+    expect(() => tc._extractPeerId(null)).toThrow('Peer is null, cannot extract ID');
+  });
+
+  it('throws for object without recognized fields', () => {
+    expect(() => tc._extractPeerId({ foo: 'bar' })).toThrow('Peer object has no recognizable ID field');
+  });
+});
+
+describe('_normalizePeer', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('normalizes channel peer', () => {
+    expect(tc._normalizePeer({ _: 'inputPeerChannel', channelId: 1951583351 }))
+      .toEqual({ type: 'channel', id: 1951583351 });
+  });
+
+  it('normalizes user peer', () => {
+    expect(tc._normalizePeer({ _: 'inputPeerUser', userId: 272066824 }))
+      .toEqual({ type: 'user', id: 272066824 });
+  });
+
+  it('normalizes chat peer', () => {
+    expect(tc._normalizePeer({ _: 'inputPeerChat', chatId: 555 }))
+      .toEqual({ type: 'chat', id: 555 });
+  });
+
+  it('throws for null peer', () => {
+    expect(() => tc._normalizePeer(null)).toThrow();
+  });
+
+  it('throws for peer without recognizable fields', () => {
+    expect(() => tc._normalizePeer({ foo: 'bar' })).toThrow();
+  });
+});
+
+describe('joinChatlist', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('joins a valid chatlist link', async () => {
+    tc.client.joinChatlist.mockResolvedValue({ id: 10, title: 'Shared List' });
+    const result = await tc.joinChatlist('https://t.me/addlist/abc123');
+    expect(result).toMatchObject({ id: 10, title: 'Shared List', type: 'chatlist' });
+  });
+
+  it('accepts link with trailing slash', async () => {
+    tc.client.joinChatlist.mockResolvedValue({ id: 10, title: 'Shared' });
+    const result = await tc.joinChatlist('https://t.me/addlist/abc123/');
+    expect(result).toMatchObject({ id: 10, type: 'chatlist' });
+  });
+
+  it('throws on invalid link', async () => {
+    await expect(tc.joinChatlist('https://t.me/invalid')).rejects.toThrow('Invalid chatlist link');
+  });
+
+  it('throws when API returns null', async () => {
+    tc.client.joinChatlist.mockResolvedValue(null);
+    await expect(tc.joinChatlist('https://t.me/addlist/abc123')).rejects.toThrow('Failed to join chatlist');
+  });
+
+  it('rejects path traversal in slug', async () => {
+    await expect(tc.joinChatlist('https://t.me/addlist/abc/../../evil')).rejects.toThrow('Invalid chatlist link');
+  });
+});
+
+describe('showFolder - peer normalization', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('normalizes peers by default (no resolve)', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, title: 'AI', _: 'dialogFilter',
+      includePeers: [{ channelId: 1951583351 }, { userId: 272066824 }],
+      excludePeers: [{ chatId: 555 }],
+      pinnedPeers: [],
+    });
+    const result = await tc.showFolder('1');
+    expect(result.includePeers).toEqual([
+      { type: 'channel', id: 1951583351 },
+      { type: 'user', id: 272066824 },
+    ]);
+    expect(result.excludePeers).toEqual([{ type: 'chat', id: 555 }]);
+    expect(result.pinnedPeers).toEqual([]);
+  });
+
+  it('resolves peer names with resolve=true', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, title: 'AI', _: 'dialogFilter',
+      includePeers: [{ channelId: 1951583351 }, { userId: 272066824 }],
+      excludePeers: [], pinnedPeers: [],
+    });
+    tc.client.getChat.mockResolvedValue({ displayName: 'ИИшница' });
+    tc.client.getFullUser.mockResolvedValue({ displayName: 'Иван Иванов' });
+
+    const result = await tc.showFolder('1', { resolve: true });
+    expect(result.includePeers).toEqual([
+      { type: 'channel', id: 1951583351, title: 'ИИшница' },
+      { type: 'user', id: 272066824, name: 'Иван Иванов' },
+    ]);
+  });
+
+  it('marks unresolved peers with (unresolved)', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, title: 'AI', _: 'dialogFilter',
+      includePeers: [{ channelId: 999 }],
+      excludePeers: [], pinnedPeers: [],
+    });
+    tc.client.getChat.mockRejectedValue(new Error('PEER_NOT_FOUND'));
+
+    const result = await tc.showFolder('1', { resolve: true });
+    expect(result.includePeers).toEqual([
+      { type: 'channel', id: 999, title: '(unresolved)' },
+    ]);
+  });
+
+  it('handles empty peer arrays', async () => {
+    tc.client.findFolder.mockResolvedValue({
+      id: 1, title: 'AI', _: 'dialogFilter',
+      includePeers: [], excludePeers: null, pinnedPeers: undefined,
+    });
+    const result = await tc.showFolder('1');
+    expect(result.includePeers).toEqual([]);
+    expect(result.excludePeers).toEqual([]);
+    expect(result.pinnedPeers).toEqual([]);
+  });
+});
+
+describe('_resolvePeerName', () => {
+  let tc;
+  beforeEach(() => { tc = createMockClient(); });
+
+  it('resolves channel name via getChat', async () => {
+    tc.client.getChat.mockResolvedValue({ displayName: 'ИИшница' });
+    const result = await tc._resolvePeerName('channel', 1951583351);
+    expect(result).toBe('ИИшница');
+  });
+
+  it('resolves user name via getFullUser', async () => {
+    tc.client.getFullUser.mockResolvedValue({ displayName: 'Иван Иванов' });
+    const result = await tc._resolvePeerName('user', 272066824);
+    expect(result).toBe('Иван Иванов');
+  });
+
+  it('returns null on error', async () => {
+    tc.client.getChat.mockRejectedValue(new Error('PEER_NOT_FOUND'));
+    const result = await tc._resolvePeerName('channel', 999);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Backported from [dapi/tgcli](https://github.com/dapi/tgcli)

Full CRUD for Telegram chat folders — lets AI agents organize chats programmatically.

### New CLI commands:
- `folders list` — list all folders
- `folders show <folder> [--resolve]` — show folder details (--resolve converts peer IDs to names)
- `folders create --title <name> [options]` — create folder with filters
- `folders edit <folder> [options]` — edit existing folder
- `folders delete <folder>` — delete folder
- `folders reorder --ids <id1,id2,...>` — reorder folders
- `folders chats add <folder> --chat <id>` — add chat to folder
- `folders chats remove <folder> --chat <id>` — remove chat from folder
- `folders join <link>` — join shared folder via invite link

### Internals:
- 10 folder domain methods + 4 private helpers in telegram-client.js
- Self-contained feature — no changes to existing functionality
- mcp-server.js not touched (MCP folder tools out of scope for now)
- 75 tests

### Credit
Based on work by [@dapi](https://github.com/dapi) in their fork of tgcli.