### PR TITLE
feat: add tgcli feedback command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,7 @@ const SEND_PARSE_MODES = ['markdown', 'html', 'none'];
 const DEFAULT_SEND_RETRIES = 2;
 const FEEDBACK_LAST_FILE = 'feedback-last.json';
 const FEEDBACK_COOLDOWN_MS = 60 * 1000;
+const FEEDBACK_DEFAULT_CHAT_ID = '@kfastov';
 
 const CLI_PROGRAM = buildProgram();
 
@@ -1583,10 +1584,7 @@ async function runFeedback(globalFlags, messageParts, options = {}) {
     try {
       const { config } = loadConfig(storeDir);
       const normalizedConfig = normalizeConfig(config ?? {});
-      const chatId = normalizedConfig.feedback?.chatId ?? null;
-      if (!chatId) {
-        throw new Error('Feedback recipient not configured. Run:\n  tgcli config set feedback.chatId <username-or-id>');
-      }
+      const chatId = normalizedConfig.feedback?.chatId || FEEDBACK_DEFAULT_CHAT_ID;
 
             const remainingSeconds = getFeedbackCooldownRemainingSeconds(storeDir);
       if (remainingSeconds > 0) {

--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,7 @@ const CONFIG_SPECS = [
   { key: 'apiId', path: ['apiId'], type: 'number' },
   { key: 'apiHash', path: ['apiHash'], type: 'string', secret: true },
   { key: 'phoneNumber', path: ['phoneNumber'], type: 'string' },
+  { key: 'feedback.chatId', path: ['feedback', 'chatId'], type: 'string' },
   { key: 'mcp.enabled', path: ['mcp', 'enabled'], type: 'boolean' },
   { key: 'mcp.host', path: ['mcp', 'host'], type: 'string' },
   { key: 'mcp.port', path: ['mcp', 'port'], type: 'number' },
@@ -37,6 +38,8 @@ const CONFIG_SPECS = [
 
 const SEND_PARSE_MODES = ['markdown', 'html', 'none'];
 const DEFAULT_SEND_RETRIES = 2;
+const FEEDBACK_LAST_FILE = 'feedback-last.json';
+const FEEDBACK_COOLDOWN_MS = 60 * 1000;
 
 const CLI_PROGRAM = buildProgram();
 
@@ -87,6 +90,17 @@ function buildProgram() {
     .description('Unset a config value')
     .argument('<key>', 'Config key')
     .action(withGlobalOptions((globalFlags, key) => runConfigUnset(globalFlags, key)));
+
+  program
+    .command('feedback')
+    .description('Send feedback to the maintainer')
+    .argument('<message...>', 'Feedback message')
+    .option('--bug', 'Report a bug')
+    .option('--suggestion', 'Suggest an improvement')
+    .option('--praise', 'Send positive feedback')
+    .action(withGlobalOptions((globalFlags, messageParts, options) =>
+      runFeedback(globalFlags, messageParts, options),
+    ));
 
   const sync = program.command('sync').description('Archive backfill and realtime sync');
   sync
@@ -791,6 +805,63 @@ function parseConfigValue(spec, rawValue) {
     return parseNumberValue(rawValue, spec.key);
   }
   return parseStringValue(rawValue, spec.key);
+}
+
+function resolveFeedbackCategory(options = {}) {
+  const categories = [
+    options.bug ? 'bug' : null,
+    options.suggestion ? 'suggestion' : null,
+    options.praise ? 'praise' : null,
+  ].filter(Boolean);
+  if (categories.length > 1) {
+    throw new Error('Choose only one of --bug, --suggestion, or --praise.');
+  }
+  return categories[0] ?? 'general';
+}
+
+function getFeedbackRateLimitPath(storeDir) {
+  return path.join(storeDir, FEEDBACK_LAST_FILE);
+}
+
+function readFeedbackLastSentAt(storeDir) {
+  try {
+    const raw = JSON.parse(fs.readFileSync(getFeedbackRateLimitPath(storeDir), 'utf8'));
+    const timestamp = Number(raw?.lastFeedbackAt);
+    return Number.isFinite(timestamp) && timestamp > 0 ? timestamp : null;
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error instanceof SyntaxError) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function getFeedbackCooldownRemainingSeconds(storeDir, now = Date.now()) {
+  const lastFeedbackAt = readFeedbackLastSentAt(storeDir);
+  if (!lastFeedbackAt) {
+    return 0;
+  }
+  const remainingMs = lastFeedbackAt + FEEDBACK_COOLDOWN_MS - now;
+  return remainingMs > 0 ? Math.ceil(remainingMs / 1000) : 0;
+}
+
+function writeFeedbackLastSentAt(storeDir, timestamp = Date.now()) {
+  const payload = { lastFeedbackAt: timestamp };
+  fs.mkdirSync(storeDir, { recursive: true });
+  fs.writeFileSync(
+    getFeedbackRateLimitPath(storeDir),
+    `${JSON.stringify(payload, null, 2)}\n`,
+    'utf8',
+  );
+  return timestamp;
+}
+
+function formatFeedbackMessage(messageText, category, metadata = {}) {
+  const version = metadata.version ?? readVersion();
+  const platform = metadata.platform ?? process.platform;
+  const nodeVersion = metadata.nodeVersion ?? process.version;
+  const normalizedMessage = parseStringValue(messageText, 'Feedback message');
+  return `📋 tgcli feedback [${category}]\n\n${normalizedMessage}\n\n---\ntgcli v${version} | ${platform} | ${nodeVersion}`;
 }
 
 function runCommand(command, args, options = {}) {
@@ -1511,6 +1582,67 @@ async function runConfigUnset(globalFlags, key) {
     return;
   }
   console.log(`Cleared ${spec.key}.`);
+}
+
+async function runFeedback(globalFlags, messageParts, options = {}) {
+  const timeoutMs = globalFlags.timeoutMs;
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const release = acquireStoreLock(storeDir);
+    let telegramClient = null;
+    let messageSyncService = null;
+
+    try {
+      const { config } = loadConfig(storeDir);
+      const normalizedConfig = normalizeConfig(config ?? {});
+      const chatId = normalizedConfig.feedback?.chatId ?? null;
+      if (!chatId) {
+        throw new Error('Feedback recipient not configured. Run:\n  tgcli config set feedback.chatId <username-or-id>');
+      }
+
+      const category = resolveFeedbackCategory(options);
+      const remainingSeconds = getFeedbackCooldownRemainingSeconds(storeDir);
+      if (remainingSeconds > 0) {
+        throw new Error(`Please wait ${remainingSeconds} seconds before sending another feedback.`);
+      }
+
+      ({ telegramClient, messageSyncService } = createServices({
+        storeDir,
+        config: normalizedConfig,
+      }));
+
+      if (!(await telegramClient.isAuthorized().catch(() => false))) {
+        throw new Error('Not authenticated. Run `tgcli auth` first.');
+      }
+
+      const feedbackText = formatFeedbackMessage(
+        Array.isArray(messageParts) ? messageParts.join(' ') : String(messageParts ?? ''),
+        category,
+      );
+      const result = await telegramClient.sendTextMessage(chatId, feedbackText, {
+        parseMode: 'none',
+      });
+      writeFeedbackLastSentAt(storeDir);
+
+      if (globalFlags.json) {
+        writeJson({
+          ok: true,
+          messageId: result?.messageId ?? null,
+          category,
+        });
+      } else {
+        console.log(`Feedback sent (${result?.messageId ?? 'unknown'}).`);
+      }
+    } finally {
+      if (messageSyncService) {
+        await messageSyncService.shutdown();
+      }
+      if (telegramClient) {
+        await telegramClient.destroy();
+      }
+      release();
+    }
+  }, timeoutMs);
 }
 
 async function runSync(globalFlags, options = {}) {
@@ -4214,13 +4346,18 @@ async function main() {
 export {
   buildProgram,
   buildSendPhotoSuccessPayload,
+  formatFeedbackMessage,
+  getFeedbackCooldownRemainingSeconds,
   isCliEntrypoint,
   logSendRetry,
   main,
   normalizeSendCommandError,
   parseNonNegativeInt,
+  resolveFeedbackCategory,
+  runFeedback,
   shouldRunMain,
   writeError,
+  writeFeedbackLastSentAt,
 };
 
 if (isCliEntrypoint()) {

--- a/cli.js
+++ b/cli.js
@@ -95,9 +95,7 @@ function buildProgram() {
     .command('feedback')
     .description('Send feedback to the maintainer')
     .argument('<message...>', 'Feedback message')
-    .option('--bug', 'Report a bug')
-    .option('--suggestion', 'Suggest an improvement')
-    .option('--praise', 'Send positive feedback')
+
     .action(withGlobalOptions((globalFlags, messageParts, options) =>
       runFeedback(globalFlags, messageParts, options),
     ));
@@ -807,17 +805,7 @@ function parseConfigValue(spec, rawValue) {
   return parseStringValue(rawValue, spec.key);
 }
 
-function resolveFeedbackCategory(options = {}) {
-  const categories = [
-    options.bug ? 'bug' : null,
-    options.suggestion ? 'suggestion' : null,
-    options.praise ? 'praise' : null,
-  ].filter(Boolean);
-  if (categories.length > 1) {
-    throw new Error('Choose only one of --bug, --suggestion, or --praise.');
-  }
-  return categories[0] ?? 'general';
-}
+
 
 function getFeedbackRateLimitPath(storeDir) {
   return path.join(storeDir, FEEDBACK_LAST_FILE);
@@ -856,12 +844,12 @@ function writeFeedbackLastSentAt(storeDir, timestamp = Date.now()) {
   return timestamp;
 }
 
-function formatFeedbackMessage(messageText, category, metadata = {}) {
+function formatFeedbackMessage(messageText, metadata = {}) {
   const version = metadata.version ?? readVersion();
   const platform = metadata.platform ?? process.platform;
   const nodeVersion = metadata.nodeVersion ?? process.version;
   const normalizedMessage = parseStringValue(messageText, 'Feedback message');
-  return `📋 tgcli feedback [${category}]\n\n${normalizedMessage}\n\n---\ntgcli v${version} | ${platform} | ${nodeVersion}`;
+  return `💬 tgcli feedback\n\n${normalizedMessage}\n\n---\ntgcli v${version} | ${platform} | ${nodeVersion}`;
 }
 
 function runCommand(command, args, options = {}) {
@@ -1600,8 +1588,7 @@ async function runFeedback(globalFlags, messageParts, options = {}) {
         throw new Error('Feedback recipient not configured. Run:\n  tgcli config set feedback.chatId <username-or-id>');
       }
 
-      const category = resolveFeedbackCategory(options);
-      const remainingSeconds = getFeedbackCooldownRemainingSeconds(storeDir);
+            const remainingSeconds = getFeedbackCooldownRemainingSeconds(storeDir);
       if (remainingSeconds > 0) {
         throw new Error(`Please wait ${remainingSeconds} seconds before sending another feedback.`);
       }
@@ -1617,7 +1604,6 @@ async function runFeedback(globalFlags, messageParts, options = {}) {
 
       const feedbackText = formatFeedbackMessage(
         Array.isArray(messageParts) ? messageParts.join(' ') : String(messageParts ?? ''),
-        category,
       );
       const result = await telegramClient.sendTextMessage(chatId, feedbackText, {
         parseMode: 'none',
@@ -1628,7 +1614,6 @@ async function runFeedback(globalFlags, messageParts, options = {}) {
         writeJson({
           ok: true,
           messageId: result?.messageId ?? null,
-          category,
         });
       } else {
         console.log(`Feedback sent (${result?.messageId ?? 'unknown'}).`);
@@ -4353,7 +4338,6 @@ export {
   main,
   normalizeSendCommandError,
   parseNonNegativeInt,
-  resolveFeedbackCategory,
   runFeedback,
   shouldRunMain,
   writeError,

--- a/core/config.js
+++ b/core/config.js
@@ -42,6 +42,7 @@ export function normalizeConfig(raw = {}) {
   const apiHash = normalizeValue(raw.apiHash ?? raw.api_hash);
   const phoneNumber = normalizeValue(raw.phoneNumber ?? raw.phone ?? raw.phone_number);
   const mcpRaw = raw.mcp && typeof raw.mcp === 'object' ? raw.mcp : {};
+  const feedbackRaw = raw.feedback && typeof raw.feedback === 'object' ? raw.feedback : {};
   const mcpEnabled = normalizeBoolean(raw.mcpEnabled ?? raw.mcp_enabled ?? mcpRaw.enabled, false);
   const mcp = {
     enabled: mcpEnabled,
@@ -55,12 +56,19 @@ export function normalizeConfig(raw = {}) {
   if (Number.isFinite(mcpPort) && mcpPort > 0) {
     mcp.port = mcpPort;
   }
-  return {
+  const feedbackChatId = normalizeValue(
+    feedbackRaw.chatId ?? raw.feedbackChatId ?? raw.feedback_chat_id,
+  );
+  const normalized = {
     apiId,
     apiHash,
     phoneNumber,
     mcp,
   };
+  if (feedbackChatId) {
+    normalized.feedback = { chatId: feedbackChatId };
+  }
+  return normalized;
 }
 
 export function validateConfig(config) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,6 +91,12 @@ tgcli messages list --chat <id> --limit 50 --source live --before-id 12345 --jso
 
 Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 
+## feedback
+- feedback <message> [--bug] [--suggestion] [--praise]
+  - Sends feedback directly to the configured maintainer.
+  - Configure recipient: `tgcli config set feedback.chatId <username-or-id>`
+  - Rate limited: 1 message per 60 seconds.
+
 ## send
 - send text --to <id|username> --message "..." [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-preview] [--no-forwards] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]
 - send photo --to <id|username> --photo PATH [--caption "..."] [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-forwards] [--spoiler] [--caption-above] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,7 +92,7 @@ tgcli messages list --chat <id> --limit 50 --source live --before-id 12345 --jso
 Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 
 ## feedback
-- feedback <message> [--bug] [--suggestion] [--praise]
+- feedback <message>
   - Sends feedback directly to the configured maintainer.
   - Configure recipient: `tgcli config set feedback.chatId <username-or-id>`
   - Rate limited: 1 message per 60 seconds.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,8 +93,8 @@ Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 
 ## feedback
 - feedback <message>
-  - Sends feedback directly to the configured maintainer via Telegram.
-  - Configure recipient: `tgcli config set feedback.chatId <username-or-id>`
+  - Sends feedback directly to the tgcli maintainer (@kfastov) via Telegram.
+  - Override recipient: `tgcli config set feedback.chatId <username-or-id>`
   - Rate limited: 1 message per 60 seconds.
   - **What is sent:** your message text, plus a metadata footer containing: tgcli version, OS name (`process.platform`), and Node.js version. No other data (no username, chat history, file paths, or system info) is included. The message is sent from your authenticated Telegram account, so the recipient will see your Telegram profile.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,9 +93,10 @@ Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 
 ## feedback
 - feedback <message>
-  - Sends feedback directly to the configured maintainer.
+  - Sends feedback directly to the configured maintainer via Telegram.
   - Configure recipient: `tgcli config set feedback.chatId <username-or-id>`
   - Rate limited: 1 message per 60 seconds.
+  - **What is sent:** your message text, plus a metadata footer containing: tgcli version, OS name (`process.platform`), and Node.js version. No other data (no username, chat history, file paths, or system info) is included. The message is sent from your authenticated Telegram account, so the recipient will see your Telegram profile.
 
 ## send
 - send text --to <id|username> --message "..." [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-preview] [--no-forwards] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -84,18 +84,22 @@ tgcli v2.0.8 | linux | v24.0.0`);
     expect(getFeedbackCooldownRemainingSeconds(storeDir, 1_060_000)).toBe(0);
   });
 
-  it('rejects feedback when feedback.chatId is missing', async () => {
+  it('uses default recipient @kfastov when feedback.chatId is not configured', async () => {
     saveConfig(storeDir, {
       apiId: '12345',
       apiHash: 'hash',
       phoneNumber: '+10000000000',
     });
+    const { telegramClient } = createMockServices(999);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
-    await expect(
-      runFeedback({ json: false, timeoutMs: null }, ['missing', 'recipient'], {}),
-    ).rejects.toThrow(`Feedback recipient not configured. Run:
-  tgcli config set feedback.chatId <username-or-id>`);
-    expect(createServices).not.toHaveBeenCalled();
+    await runFeedback({ json: true, timeoutMs: null }, ['test', 'feedback'], {});
+
+    expect(telegramClient.sendTextMessage).toHaveBeenCalledWith(
+      '@kfastov',
+      expect.any(String),
+      { parseMode: 'none' },
+    );
   });
 
   it('sends plain-text feedback and returns JSON output', async () => {

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -19,7 +19,6 @@ import { saveConfig } from '../core/config.js';
 import {
   formatFeedbackMessage,
   getFeedbackCooldownRemainingSeconds,
-  resolveFeedbackCategory,
   runFeedback,
   writeFeedbackLastSentAt,
 } from '../cli.js';
@@ -64,29 +63,19 @@ describe('tgcli feedback helpers', () => {
     fs.rmSync(storeDir, { recursive: true, force: true });
   });
 
-  it('formats feedback messages with category header and metadata footer', () => {
+  it('formats feedback message with header and metadata footer', () => {
     expect(
-      formatFeedbackMessage('global search should be supported', 'bug', {
+      formatFeedbackMessage('global search should be supported', {
         version: '2.0.8',
         platform: 'linux',
         nodeVersion: 'v24.0.0',
       }),
-    ).toBe(`📋 tgcli feedback [bug]
+    ).toBe(`💬 tgcli feedback
 
 global search should be supported
 
 ---
 tgcli v2.0.8 | linux | v24.0.0`);
-  });
-
-  it('detects category flags and defaults to general', () => {
-    expect(resolveFeedbackCategory({ bug: true })).toBe('bug');
-    expect(resolveFeedbackCategory({ suggestion: true })).toBe('suggestion');
-    expect(resolveFeedbackCategory({ praise: true })).toBe('praise');
-    expect(resolveFeedbackCategory({})).toBe('general');
-    expect(() => resolveFeedbackCategory({ bug: true, suggestion: true })).toThrow(
-      'Choose only one of --bug, --suggestion, or --praise.',
-    );
   });
 
   it('computes cooldown remaining seconds from the last feedback timestamp', () => {
@@ -109,7 +98,7 @@ tgcli v2.0.8 | linux | v24.0.0`);
     expect(createServices).not.toHaveBeenCalled();
   });
 
-  it('sends plain-text feedback and returns JSON output when requested', async () => {
+  it('sends plain-text feedback and returns JSON output', async () => {
     saveConfig(storeDir, {
       apiId: '12345',
       apiHash: 'hash',
@@ -122,12 +111,12 @@ tgcli v2.0.8 | linux | v24.0.0`);
     await runFeedback(
       { json: true, timeoutMs: null },
       ['rename', 'sync', 'to', 'backfill'],
-      { suggestion: true },
+      {},
     );
 
     expect(telegramClient.sendTextMessage).toHaveBeenCalledWith(
       '@maintainer',
-      formatFeedbackMessage('rename sync to backfill', 'suggestion', {
+      formatFeedbackMessage('rename sync to backfill', {
         version: PACKAGE_VERSION,
         platform: process.platform,
         nodeVersion: process.version,
@@ -137,7 +126,6 @@ tgcli v2.0.8 | linux | v24.0.0`);
     expect(JSON.parse(stdoutSpy.mock.calls[0][0])).toEqual({
       ok: true,
       messageId: 654,
-      category: 'suggestion',
     });
     expect(messageSyncService.shutdown).toHaveBeenCalledTimes(1);
     expect(telegramClient.destroy).toHaveBeenCalledTimes(1);
@@ -152,10 +140,10 @@ tgcli v2.0.8 | linux | v24.0.0`);
     });
     const { telegramClient } = createMockServices(700);
 
-    await runFeedback({ json: false, timeoutMs: null }, ['first', 'feedback'], { bug: true });
+    await runFeedback({ json: false, timeoutMs: null }, ['first', 'feedback'], {});
 
     await expect(
-      runFeedback({ json: false, timeoutMs: null }, ['second', 'feedback'], { bug: true }),
+      runFeedback({ json: false, timeoutMs: null }, ['second', 'feedback'], {}),
     ).rejects.toThrow('Please wait 60 seconds before sending another feedback.');
     expect(telegramClient.sendTextMessage).toHaveBeenCalledTimes(1);
     expect(createServices).toHaveBeenCalledTimes(1);

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -1,0 +1,163 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../core/services.js', () => ({
+  createServices: vi.fn(),
+}));
+
+vi.mock('../store-lock.js', () => ({
+  acquireStoreLock: vi.fn(() => () => {}),
+  acquireReadLock: vi.fn(),
+  readStoreLock: vi.fn(),
+}));
+
+import { createServices } from '../core/services.js';
+import { saveConfig } from '../core/config.js';
+import {
+  formatFeedbackMessage,
+  getFeedbackCooldownRemainingSeconds,
+  resolveFeedbackCategory,
+  runFeedback,
+  writeFeedbackLastSentAt,
+} from '../cli.js';
+
+const PACKAGE_VERSION = JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8')).version;
+
+function createTempStore() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-feedback-test-'));
+}
+
+function createMockServices(messageId = 321) {
+  const telegramClient = {
+    isAuthorized: vi.fn().mockResolvedValue(true),
+    sendTextMessage: vi.fn().mockResolvedValue({ messageId }),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+  const messageSyncService = {
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+  createServices.mockReturnValue({ telegramClient, messageSyncService });
+  return { telegramClient, messageSyncService };
+}
+
+describe('tgcli feedback helpers', () => {
+  let storeDir;
+  let originalStoreDir;
+
+  beforeEach(() => {
+    storeDir = createTempStore();
+    originalStoreDir = process.env.TGCLI_STORE;
+    process.env.TGCLI_STORE = storeDir;
+    createServices.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalStoreDir === undefined) {
+      delete process.env.TGCLI_STORE;
+    } else {
+      process.env.TGCLI_STORE = originalStoreDir;
+    }
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('formats feedback messages with category header and metadata footer', () => {
+    expect(
+      formatFeedbackMessage('global search should be supported', 'bug', {
+        version: '2.0.8',
+        platform: 'linux',
+        nodeVersion: 'v24.0.0',
+      }),
+    ).toBe(`📋 tgcli feedback [bug]
+
+global search should be supported
+
+---
+tgcli v2.0.8 | linux | v24.0.0`);
+  });
+
+  it('detects category flags and defaults to general', () => {
+    expect(resolveFeedbackCategory({ bug: true })).toBe('bug');
+    expect(resolveFeedbackCategory({ suggestion: true })).toBe('suggestion');
+    expect(resolveFeedbackCategory({ praise: true })).toBe('praise');
+    expect(resolveFeedbackCategory({})).toBe('general');
+    expect(() => resolveFeedbackCategory({ bug: true, suggestion: true })).toThrow(
+      'Choose only one of --bug, --suggestion, or --praise.',
+    );
+  });
+
+  it('computes cooldown remaining seconds from the last feedback timestamp', () => {
+    writeFeedbackLastSentAt(storeDir, 1_000_000);
+    expect(getFeedbackCooldownRemainingSeconds(storeDir, 1_010_001)).toBe(50);
+    expect(getFeedbackCooldownRemainingSeconds(storeDir, 1_060_000)).toBe(0);
+  });
+
+  it('rejects feedback when feedback.chatId is missing', async () => {
+    saveConfig(storeDir, {
+      apiId: '12345',
+      apiHash: 'hash',
+      phoneNumber: '+10000000000',
+    });
+
+    await expect(
+      runFeedback({ json: false, timeoutMs: null }, ['missing', 'recipient'], {}),
+    ).rejects.toThrow(`Feedback recipient not configured. Run:
+  tgcli config set feedback.chatId <username-or-id>`);
+    expect(createServices).not.toHaveBeenCalled();
+  });
+
+  it('sends plain-text feedback and returns JSON output when requested', async () => {
+    saveConfig(storeDir, {
+      apiId: '12345',
+      apiHash: 'hash',
+      phoneNumber: '+10000000000',
+      feedback: { chatId: '@maintainer' },
+    });
+    const { telegramClient, messageSyncService } = createMockServices(654);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runFeedback(
+      { json: true, timeoutMs: null },
+      ['rename', 'sync', 'to', 'backfill'],
+      { suggestion: true },
+    );
+
+    expect(telegramClient.sendTextMessage).toHaveBeenCalledWith(
+      '@maintainer',
+      formatFeedbackMessage('rename sync to backfill', 'suggestion', {
+        version: PACKAGE_VERSION,
+        platform: process.platform,
+        nodeVersion: process.version,
+      }),
+      { parseMode: 'none' },
+    );
+    expect(JSON.parse(stdoutSpy.mock.calls[0][0])).toEqual({
+      ok: true,
+      messageId: 654,
+      category: 'suggestion',
+    });
+    expect(messageSyncService.shutdown).toHaveBeenCalledTimes(1);
+    expect(telegramClient.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks repeated feedback during the cooldown window', async () => {
+    saveConfig(storeDir, {
+      apiId: '12345',
+      apiHash: 'hash',
+      phoneNumber: '+10000000000',
+      feedback: { chatId: '@maintainer' },
+    });
+    const { telegramClient } = createMockServices(700);
+
+    await runFeedback({ json: false, timeoutMs: null }, ['first', 'feedback'], { bug: true });
+
+    await expect(
+      runFeedback({ json: false, timeoutMs: null }, ['second', 'feedback'], { bug: true }),
+    ).rejects.toThrow('Please wait 60 seconds before sending another feedback.');
+    expect(telegramClient.sendTextMessage).toHaveBeenCalledTimes(1);
+    expect(createServices).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

New `tgcli feedback` command — sends feedback directly to the maintainer's Telegram.

```bash
tgcli feedback "pagination with --before-id works perfectly"
tgcli feedback --bug "sync jobs shows message_count: 0"
tgcli feedback --suggestion "rename sync to backfill"
tgcli feedback --praise "folders CRUD is clean"
```

## Why

AI agents are power users of tgcli. When they hit issues, the feedback loop should be minimal — one command, no context switch to GitHub.

## Details

- Recipient configured via `tgcli config set feedback.chatId <username-or-id>`
- Message includes category emoji, text, and metadata footer (version, OS, node)
- Rate limited: 1 per 60 seconds (file-based cooldown in store dir)
- `--json` output: `{ ok, messageId, category }`
- 6 new tests covering formatting, cooldown, config validation, category detection

Closes #28