### PR TITLE
feat: QR login, force SMS, auth recovery, --qr-file PNG output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ import { Command, Option } from 'commander';
 
 import { acquireStoreLock, acquireReadLock, readStoreLock } from './store-lock.js';
 import { loadConfig, normalizeConfig, saveConfig, validateConfig } from './core/config.js';
-import { createServices } from './core/services.js';
+import { createMessageSyncService, createServices, createTelegramClient } from './core/services.js';
 import {
   buildSendErrorPayload,
   buildSendSuccessPayload,
@@ -26,6 +26,7 @@ const CLI_PATH = fileURLToPath(import.meta.url);
 const SERVICE_STATE_FILE = 'service-state.json';
 const LAUNCHD_LABEL = 'com.kfastov.tgcli';
 const SYSTEMD_SERVICE_NAME = 'tgcli';
+const AUTH_SYNC_HINT = 'Run `tgcli sync --once` or `tgcli sync --follow` when you need archive data.';
 const CONFIG_SPECS = [
   { key: 'apiId', path: ['apiId'], type: 'number' },
   { key: 'apiHash', path: ['apiHash'], type: 'string', secret: true },
@@ -58,6 +59,8 @@ function buildProgram() {
   const auth = program.command('auth').description('Authentication and session setup');
   auth
     .option('--follow', 'Continue syncing after login')
+    .option('--force-sms', 'Force SMS code delivery instead of in-app')
+    .option('--qr', 'Use QR-code login flow instead of confirmation code')
     .action(withGlobalOptions((globalFlags, options) =>
       runAuthLogin(globalFlags, options),
     ));
@@ -1462,42 +1465,72 @@ async function runAuthLogout(globalFlags) {
 
 async function runAuthLogin(globalFlags, options = {}) {
   const timeoutMs = globalFlags.timeoutMs;
+  let release = null;
+  let telegramClient = null;
+  let messageSyncService = null;
+  let keepRunning = false;
+  const cleanup = async () => {
+    if (messageSyncService) {
+      const currentService = messageSyncService;
+      messageSyncService = null;
+      await currentService.shutdown();
+    }
+    if (telegramClient) {
+      const currentClient = telegramClient;
+      telegramClient = null;
+      await currentClient.destroy();
+    }
+    if (release) {
+      const currentRelease = release;
+      release = null;
+      currentRelease();
+    }
+  };
   return runWithTimeout(async () => {
     const storeDir = resolveStoreDir();
-    const release = acquireStoreLock(storeDir);
     const config = await ensureStoreConfig(storeDir);
-    const { telegramClient, messageSyncService } = createServices({ storeDir, config });
+    release = acquireStoreLock(storeDir);
     try {
+      ({ telegramClient } = createTelegramClient({
+        storeDir,
+        config,
+        forceSms: options.forceSms,
+        useQr: options.qr,
+        disableUpdates: !options.follow,
+      }));
       const loginSuccess = await telegramClient.login();
       if (!loginSuccess) {
         throw new Error('Failed to login to Telegram.');
       }
-      const dialogCount = await messageSyncService.refreshChannelsFromDialogs();
       if (options.follow) {
+        ({ messageSyncService } = createMessageSyncService(telegramClient, { storeDir }));
+        await messageSyncService.refreshChannelsFromDialogs();
         await telegramClient.startUpdates();
         messageSyncService.startRealtimeSync();
         messageSyncService.resumePendingJobs();
         await withShutdown(async () => {
-          await messageSyncService.shutdown();
-          await telegramClient.destroy();
-          release();
+          await cleanup();
         });
+        keepRunning = true;
         return;
       }
 
       if (globalFlags.json) {
-        writeJson({ authenticated: true, dialogs: dialogCount });
+        writeJson({
+          authenticated: true,
+          dialogs: null,
+          archiveReady: false,
+          archiveError: null,
+        });
       } else {
-        console.log(`Authenticated. Seeded ${dialogCount} dialogs.`);
+        console.log(`Authenticated. ${AUTH_SYNC_HINT}`);
       }
     } finally {
-      if (!options.follow) {
-        await messageSyncService.shutdown();
-        await telegramClient.destroy();
-        release();
+      if (!keepRunning) {
+        await cleanup();
       }
     }
-  }, timeoutMs);
+  }, timeoutMs, cleanup);
 }
 
 async function runConfigList(globalFlags) {
@@ -4336,6 +4369,7 @@ export {
   main,
   normalizeSendCommandError,
   parseNonNegativeInt,
+  runAuthLogin,
   runFeedback,
   shouldRunMain,
   writeError,

--- a/cli.js
+++ b/cli.js
@@ -61,6 +61,7 @@ function buildProgram() {
     .option('--follow', 'Continue syncing after login')
     .option('--force-sms', 'Force SMS code delivery instead of in-app')
     .option('--qr', 'Use QR-code login flow instead of confirmation code')
+    .option('--qr-file <path>', 'Save QR code as PNG image file')
     .action(withGlobalOptions((globalFlags, options) =>
       runAuthLogin(globalFlags, options),
     ));
@@ -1496,6 +1497,8 @@ export async function runAuthLogin(globalFlags, options = {}) {
         config,
         forceSms: options.forceSms,
         useQr: options.qr,
+        qrFilePath: options.qrFile,
+        json: globalFlags.json,
         disableUpdates: !options.follow,
       }));
       const loginSuccess = await telegramClient.login();

--- a/cli.js
+++ b/cli.js
@@ -1463,7 +1463,7 @@ async function runAuthLogout(globalFlags) {
   }, timeoutMs);
 }
 
-async function runAuthLogin(globalFlags, options = {}) {
+export async function runAuthLogin(globalFlags, options = {}) {
   const timeoutMs = globalFlags.timeoutMs;
   let release = null;
   let telegramClient = null;
@@ -4369,7 +4369,6 @@ export {
   main,
   normalizeSendCommandError,
   parseNonNegativeInt,
-  runAuthLogin,
   runFeedback,
   shouldRunMain,
   writeError,

--- a/cli.js
+++ b/cli.js
@@ -1519,12 +1519,7 @@ export async function runAuthLogin(globalFlags, options = {}) {
       }
 
       if (globalFlags.json) {
-        writeJson({
-          authenticated: true,
-          dialogs: null,
-          archiveReady: false,
-          archiveError: null,
-        });
+        writeJson({ authenticated: true });
       } else {
         console.log(`Authenticated. ${AUTH_SYNC_HINT}`);
       }

--- a/core/services.js
+++ b/core/services.js
@@ -9,7 +9,7 @@ const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_INTER_JOB_DELAY_MS = 3000;
 const DEFAULT_INTER_BATCH_DELAY_MS = 1200;
 
-export function createServices(options = {}) {
+function resolveRuntimePaths(options = {}) {
   const resolvedStoreDir = options.storeDir ? path.resolve(options.storeDir) : null;
   if (!resolvedStoreDir && (!options.sessionPath || !options.dbPath)) {
     throw new Error('storeDir is required when sessionPath or dbPath are not provided.');
@@ -23,6 +23,14 @@ export function createServices(options = {}) {
     throw new Error('sessionPath and dbPath are required.');
   }
 
+  return {
+    resolvedStoreDir,
+    sessionPath,
+    dbPath,
+  };
+}
+
+function resolveValidatedConfig(options = {}, resolvedStoreDir = null) {
   const loadedConfig = options.config ?? (resolvedStoreDir ? loadConfig(resolvedStoreDir).config : null);
   const config = normalizeConfig(loadedConfig ?? {});
   const missing = validateConfig(config);
@@ -30,13 +38,35 @@ export function createServices(options = {}) {
     throw new Error('Missing tgcli configuration. Run "tgcli auth" to set credentials.');
   }
 
+  return config;
+}
+
+export function createTelegramClient(options = {}) {
+  const { resolvedStoreDir, sessionPath } = resolveRuntimePaths(options);
+  const config = resolveValidatedConfig(options, resolvedStoreDir);
+
   const telegramClient = new TelegramClient(
     config.apiId,
     config.apiHash,
     config.phoneNumber,
     sessionPath,
+    {
+      forceSms: options.forceSms ?? false,
+      useQr: options.useQr ?? false,
+      disableUpdates: options.disableUpdates ?? false,
+    },
   );
 
+  return {
+    storeDir: resolvedStoreDir,
+    sessionPath,
+    config,
+    telegramClient,
+  };
+}
+
+export function createMessageSyncService(telegramClient, options = {}) {
+  const { resolvedStoreDir, dbPath } = resolveRuntimePaths(options);
   const messageSyncService = new MessageSyncService(telegramClient, {
     dbPath,
     batchSize: options.batchSize ?? DEFAULT_BATCH_SIZE,
@@ -46,6 +76,34 @@ export function createServices(options = {}) {
 
   return {
     storeDir: resolvedStoreDir,
+    dbPath,
+    messageSyncService,
+  };
+}
+
+export function createServices(options = {}) {
+  const { resolvedStoreDir, sessionPath, dbPath } = resolveRuntimePaths(options);
+  const config = resolveValidatedConfig(options, resolvedStoreDir);
+  const { telegramClient } = createTelegramClient({
+    ...options,
+    storeDir: resolvedStoreDir,
+    sessionPath,
+    dbPath,
+    config,
+  });
+
+  const { messageSyncService } = createMessageSyncService(telegramClient, {
+    ...options,
+    storeDir: resolvedStoreDir,
+    sessionPath,
+    dbPath,
+  });
+
+  return {
+    storeDir: resolvedStoreDir,
+    sessionPath,
+    dbPath,
+    config,
     telegramClient,
     messageSyncService,
   };

--- a/core/services.js
+++ b/core/services.js
@@ -53,6 +53,8 @@ export function createTelegramClient(options = {}) {
     {
       forceSms: options.forceSms ?? false,
       useQr: options.useQr ?? false,
+      qrFilePath: options.qrFilePath ?? null,
+      json: options.json ?? false,
       disableUpdates: options.disableUpdates ?? false,
     },
   );

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,9 +11,10 @@ Store location: OS app data dir (override with TGCLI_STORE).
 MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP).
 
 ## auth
-- auth
-  - Interactive login (Telegram MTProto). By default this only authenticates; use `--follow` to continue into realtime sync.
-  - Flags: --follow, --qr, --force-sms
+- auth [--qr] [--qr-file <path>] [--force-sms] [--follow] [--idle-exit <duration>] [--download-media]
+  - Interactive login. Use --qr for QR code login (scan in Telegram app).
+  - --qr-file saves the QR code as a PNG image (useful for agents).
+  - --force-sms forces code delivery via SMS instead of in-app notification.
 - auth status
 - auth logout
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,8 +12,8 @@ MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP)
 
 ## auth
 - auth
-  - Interactive login (Telegram MTProto), then bootstrap sync.
-  - Flags: --follow, --idle-exit 30s, --download-media
+  - Interactive login (Telegram MTProto). By default this only authenticates; use `--follow` to continue into realtime sync.
+  - Flags: --follow, --qr, --force-sms
 - auth status
 - auth logout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mtcute/node": "^0.27.8",
         "better-sqlite3": "^12.6.0",
         "commander": "^12.1.0",
-        "qrcode-terminal": "^0.12.0"
+        "qrcode": "^1.5.4"
       },
       "bin": {
         "tgcli": "cli.js"
@@ -1062,7 +1062,6 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1104,12 +1103,35 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1180,7 +1202,6 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -1205,7 +1226,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1214,15 +1234,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/body-parser/node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -1295,6 +1313,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1311,6 +1338,35 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -1325,7 +1381,6 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1362,8 +1417,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1390,6 +1444,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decompress-response": {
@@ -1443,6 +1506,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -1529,6 +1598,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1668,7 +1743,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1730,7 +1804,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1739,8 +1812,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1793,7 +1865,6 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -1812,7 +1883,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1821,8 +1891,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -1838,7 +1920,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1871,6 +1952,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2002,7 +2092,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2049,6 +2138,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-promise": {
@@ -2345,6 +2443,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
@@ -2375,7 +2485,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2385,7 +2494,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -2404,7 +2512,6 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -2417,7 +2524,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2427,7 +2533,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2498,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2580,6 +2684,42 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2587,6 +2727,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -2602,8 +2751,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2625,6 +2773,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2639,6 +2788,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -2719,12 +2877,21 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
-      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
       "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qs": {
@@ -2807,6 +2974,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -2815,6 +2991,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
@@ -2904,7 +3086,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2929,7 +3110,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -2938,15 +3118,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2955,15 +3133,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -2973,6 +3149,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3167,6 +3349,32 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -3282,7 +3490,6 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -3330,6 +3537,7 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3499,6 +3707,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3516,17 +3730,73 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "@kfastov/tgcli",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kfastov/tgcli",
-      "version": "2.0.8",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@mtcute/core": "^0.27.8",
         "@mtcute/node": "^0.27.8",
         "better-sqlite3": "^12.6.0",
-        "commander": "^12.1.0"
+        "commander": "^12.1.0",
+        "qrcode-terminal": "^0.12.0"
       },
       "bin": {
         "tgcli": "cli.js"
@@ -1061,6 +1062,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -1106,7 +1108,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1177,6 +1180,7 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -1201,6 +1205,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1209,13 +1214,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/body-parser/node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -1318,6 +1325,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1354,7 +1362,8 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1659,6 +1668,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1720,6 +1730,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1728,7 +1739,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1781,6 +1793,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -1799,6 +1812,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -1807,7 +1821,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -1823,6 +1838,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1986,6 +2002,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2358,6 +2375,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2367,6 +2385,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -2385,6 +2404,7 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -2397,6 +2417,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2406,6 +2427,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2476,6 +2498,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2579,7 +2602,8 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2601,7 +2625,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2694,6 +2717,14 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
     "node_modules/qs": {
@@ -2873,6 +2904,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2897,6 +2929,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -2905,13 +2938,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/send/node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2920,13 +2955,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -3245,6 +3282,7 @@
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -3292,7 +3330,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3490,7 +3527,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "@mtcute/core": "^0.27.8",
     "@mtcute/node": "^0.27.8",
     "better-sqlite3": "^12.6.0",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {
     "vitest": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mtcute/node": "^0.27.8",
     "better-sqlite3": "^12.6.0",
     "commander": "^12.1.0",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "vitest": "^4.1.2"

--- a/store-lock.js
+++ b/store-lock.js
@@ -43,6 +43,18 @@ function parseLockPid(raw) {
   }
 }
 
+function removeStaleLockFile(lockPath, pid, label) {
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return;
+    }
+    const details = error?.message ? `: ${error.message}` : '';
+    throw new Error(`Found stale ${label} for dead pid ${pid}, but could not remove ${lockPath}${details}`);
+  }
+}
+
 function getAliveReadLocks(storeDir) {
   let entries;
   try {
@@ -61,7 +73,7 @@ function getAliveReadLocks(storeDir) {
     if (isPidAlive(pid)) {
       alive.push({ name, pid });
     } else {
-      try { fs.unlinkSync(filePath); } catch {}
+      removeStaleLockFile(filePath, pid, 'read lock');
     }
   }
   return alive;
@@ -87,7 +99,7 @@ export function acquireStoreLock(storeDir, _retried = false) {
       const info = readStoreLock(storeDir);
       const pid = parseLockPid(info.info);
       if (pid && !isPidAlive(pid) && !_retried) {
-        try { fs.unlinkSync(lockPath); } catch {}
+        removeStaleLockFile(lockPath, pid, 'store lock');
         return acquireStoreLock(storeDir, true);
       }
       const details = info.info ? ` (${info.info})` : '';
@@ -120,7 +132,7 @@ export function acquireReadLock(storeDir) {
   if (writeLock.exists) {
     const pid = parseLockPid(writeLock.info);
     if (pid && !isPidAlive(pid)) {
-      try { fs.unlinkSync(writeLock.path); } catch {}
+      removeStaleLockFile(writeLock.path, pid, 'store lock');
     } else {
       const details = writeLock.info ? ` (${writeLock.info})` : '';
       throw new Error(`Store is locked by a writer${details}`);

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -3,6 +3,7 @@ import { InputMedia } from '@mtcute/core';
 import { randomLong } from '@mtcute/core/utils.js';
 import { html } from '@mtcute/html-parser';
 import { md } from '@mtcute/markdown-parser';
+import QRCode from 'qrcode';
 import EventEmitter from 'events';
 import fs from 'fs';
 import { stat } from 'fs/promises';
@@ -78,22 +79,6 @@ const LOG_HANDLER = IS_TTY
         ...args,
       );
     };
-let qrCodeRendererPromise = null;
-
-async function loadQrCodeRenderer() {
-  if (!qrCodeRendererPromise) {
-    qrCodeRendererPromise = import('qrcode-terminal')
-      .then((module) => module.default ?? module)
-      .catch(() => ({
-        generate(value, _options, callback) {
-          if (typeof callback === 'function') {
-            callback(`QR rendering unavailable locally.\n${value}`);
-          }
-        },
-      }));
-  }
-  return qrCodeRendererPromise;
-}
 
 async function normalizeUploadFile(file) {
   if (typeof file === 'string') {
@@ -719,13 +704,31 @@ class TelegramClient {
         const expiresLabel = expiresAt instanceof Date && !Number.isNaN(expiresAt.getTime())
           ? expiresAt.toISOString()
           : 'unknown';
+        let qrFile = null;
+
+        if (this.options.qrFilePath) {
+          qrFile = this.options.qrFilePath;
+          await QRCode.toFile(qrFile, url, { type: 'png', width: 300 });
+        }
+
+        if (this.options.json) {
+          process.stderr.write(`${JSON.stringify({
+            event: 'qr',
+            url,
+            expiresAt: expiresLabel,
+            qrFile,
+          })}\n`);
+          return;
+        }
+
         console.log('\nScan this QR code in Telegram: Settings -> Devices -> Link Desktop Device');
-        const qrCode = await loadQrCodeRenderer();
-        qrCode.generate(url, { small: true }, (rendered) => {
-          console.log(rendered);
-        });
+        const terminalQr = await QRCode.toString(url, { type: 'terminal', small: true });
+        console.log(terminalQr);
         console.log(`QR login URL: ${url}`);
         console.log(`QR expires at: ${expiresLabel}`);
+        if (qrFile) {
+          console.log(`QR saved to: ${qrFile}`);
+        }
       };
     } else {
       startParams.phone = this.phoneNumber;

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -78,6 +78,22 @@ const LOG_HANDLER = IS_TTY
         ...args,
       );
     };
+let qrCodeRendererPromise = null;
+
+async function loadQrCodeRenderer() {
+  if (!qrCodeRendererPromise) {
+    qrCodeRendererPromise = import('qrcode-terminal')
+      .then((module) => module.default ?? module)
+      .catch(() => ({
+        generate(value, _options, callback) {
+          if (typeof callback === 'function') {
+            callback(`QR rendering unavailable locally.\n${value}`);
+          }
+        },
+      }));
+  }
+  return qrCodeRendererPromise;
+}
 
 async function normalizeUploadFile(file) {
   if (typeof file === 'string') {
@@ -519,6 +535,7 @@ class TelegramClient {
     this.apiHash = sanitizeString(apiHash);
     this.phoneNumber = sanitizeString(phoneNumber);
     this.sessionPath = path.resolve(sessionPath);
+    this.options = options;
 
     const dataDir = path.dirname(this.sessionPath);
     if (!fs.existsSync(dataDir)) {
@@ -539,14 +556,61 @@ class TelegramClient {
         this.updateEmitter.emit('channelTooLong', { channelId, diff });
       },
     };
+    this.updatesConfig = updatesConfig;
+    this.client = this._createClient();
+  }
 
-    this.client = new MtCuteClient({
+  _createClient() {
+    const clientOptions = {
       apiId: this.apiId,
       apiHash: this.apiHash,
       storage: this.sessionPath,
       platform: createPlatform(),
-      updates: updatesConfig,
-    });
+    };
+    if (this.options.disableUpdates) {
+      clientOptions.disableUpdates = true;
+    } else {
+      clientOptions.updates = this.updatesConfig;
+    }
+    return new MtCuteClient(clientOptions);
+  }
+
+  _isAuthKeyUnregisteredError(error) {
+    if (!error) return false;
+    const code = error.code || error.status || error.errorCode;
+    const message = (error.errorMessage || error.text || error.message || '').toUpperCase();
+    return code === 401 && message.includes('AUTH_KEY_UNREGISTERED');
+  }
+
+  _isSessionResetError(error) {
+    if (!error) return false;
+    const message = (error.errorMessage || error.text || error.message || '').toUpperCase();
+    return message.includes('SESSION IS RESET');
+  }
+
+  async _recreateClient() {
+    try {
+      await this.client.destroy();
+    } catch (error) {
+      console.warn('[warning] failed to destroy MTProto client during reset:', error?.message || error);
+    }
+    this.client = this._createClient();
+    this.updatesRunning = false;
+    this.rawUpdateHandler = null;
+  }
+
+  async _resetSessionAndClient() {
+    const sessionFiles = [this.sessionPath, `${this.sessionPath}-wal`, `${this.sessionPath}-shm`];
+    for (const filePath of sessionFiles) {
+      try {
+        fs.unlinkSync(filePath);
+      } catch (error) {
+        if (error?.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+    await this._recreateClient();
   }
 
   _isUnauthorizedError(error) {
@@ -587,17 +651,28 @@ class TelegramClient {
   }
 
   async _askQuestion(prompt) {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-
-    return new Promise(resolve => {
-      rl.question(prompt, answer => {
-        rl.close();
-        resolve(answer.trim());
+    const ask = () => {
+      if (process.stdin.isPaused()) {
+        process.stdin.resume();
+      }
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
       });
-    });
+
+      return new Promise(resolve => {
+        rl.question(prompt, answer => {
+          rl.close();
+          resolve(answer.trim());
+        });
+      });
+    };
+
+    let answer = await ask();
+    if (!answer) {
+      answer = await ask();
+    }
+    return answer;
   }
 
   async _askHiddenQuestion(prompt) {
@@ -605,6 +680,9 @@ class TelegramClient {
       return this._askQuestion(prompt);
     }
 
+    if (process.stdin.isPaused()) {
+      process.stdin.resume();
+    }
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
@@ -628,29 +706,85 @@ class TelegramClient {
     });
   }
 
-  async login() {
-    try {
-      if (await this._isAuthorized()) {
-        console.log('Existing session is valid.');
-        return true;
-      }
+  _buildStartParams() {
+    const startParams = {
+      password: async () => {
+        const value = await this._askHiddenQuestion('Enter your 2FA password (leave empty if not enabled): ');
+        return value.length ? value : undefined;
+      },
+    };
 
-      if (!this.phoneNumber) {
+    if (this.options.useQr) {
+      startParams.qrCodeHandler = async (url, expiresAt) => {
+        const expiresLabel = expiresAt instanceof Date && !Number.isNaN(expiresAt.getTime())
+          ? expiresAt.toISOString()
+          : 'unknown';
+        console.log('\nScan this QR code in Telegram: Settings -> Devices -> Link Desktop Device');
+        const qrCode = await loadQrCodeRenderer();
+        qrCode.generate(url, { small: true }, (rendered) => {
+          console.log(rendered);
+        });
+        console.log(`QR login URL: ${url}`);
+        console.log(`QR expires at: ${expiresLabel}`);
+      };
+    } else {
+      startParams.phone = this.phoneNumber;
+      startParams.code = async () => await this._askQuestion('Enter the code you received: ');
+      startParams.codeSentCallback = async (sentCode) => {
+        if (this.options.forceSms && (sentCode.type === 'app' || sentCode.type === 'email')) {
+          try {
+            await this.client.resendCode({ phone: this.phoneNumber, phoneCodeHash: sentCode.phoneCodeHash });
+            console.log('Code re-sent via SMS.');
+          } catch (error) {
+            const message = (error.text || error.message || '').toUpperCase();
+            if (message.includes('SEND_CODE_UNAVAILABLE')) {
+              console.log('SMS unavailable for this number. Please use the code sent via app.');
+            } else {
+              console.log(`Could not request SMS (${error.text || error.message}). Using code sent via ${sentCode.type}.`);
+            }
+          }
+        } else {
+          console.log(`The confirmation code has been sent via ${sentCode.type}.`);
+        }
+      };
+    }
+
+    return startParams;
+  }
+
+  async login(retriedAfterReset = false, retriedAfterSessionReset = false) {
+    try {
+      const hasExistingSession = await this._isAuthorized();
+
+      if (!hasExistingSession && !this.options.useQr && !this.phoneNumber) {
         throw new Error('TELEGRAM_PHONE_NUMBER is not configured.');
       }
 
-      await this.client.start({
-        phone: this.phoneNumber,
-        code: async () => await this._askQuestion('Enter the code you received: '),
-        password: async () => {
-          const value = await this._askHiddenQuestion('Enter your 2FA password (leave empty if not enabled): ');
-          return value.length ? value : undefined;
-        },
-      });
+      await this.client.start(this._buildStartParams());
 
-      console.log('Logged in successfully!');
+      console.log(hasExistingSession ? 'Existing session is valid.' : 'Logged in successfully!');
       return true;
     } catch (error) {
+      if (!retriedAfterReset && this._isAuthKeyUnregisteredError(error)) {
+        console.log('Detected AUTH_KEY_UNREGISTERED. Resetting local session and retrying login once...');
+        try {
+          await this._resetSessionAndClient();
+          return await this.login(true, retriedAfterSessionReset);
+        } catch (resetError) {
+          console.error('Failed to recover from AUTH_KEY_UNREGISTERED:', resetError);
+          return false;
+        }
+      }
+      if (!retriedAfterSessionReset && this._isSessionResetError(error)) {
+        console.log('Detected session reset during login. Recreating MTProto client and retrying once...');
+        try {
+          await this._recreateClient();
+          return await this.login(retriedAfterReset, true);
+        } catch (resetError) {
+          console.error('Failed to recover from session reset:', resetError);
+          return false;
+        }
+      }
       console.error('Error during login:', error);
       return false;
     }
@@ -674,38 +808,49 @@ class TelegramClient {
     return true;
   }
 
-  async listDialogs(limit = 50) {
-    await this.ensureLogin();
-    const effectiveLimit = limit && limit > 0 ? limit : Infinity;
-    const results = [];
+  async listDialogs(limit = 50, retriedAfterSessionReset = false) {
+    try {
+      await this.ensureLogin();
+      const effectiveLimit = limit && limit > 0 ? limit : Infinity;
+      const results = [];
 
-    for await (const dialog of this.client.iterDialogs({})) {
-      const peer = dialog.peer;
-      if (!peer) continue;
+      for await (const dialog of this.client.iterDialogs({})) {
+        const peer = dialog.peer;
+        if (!peer) continue;
 
-      const id = peer.id.toString();
-      const username = 'username' in peer ? peer.username ?? null : null;
-      const chatType = typeof peer.chatType === 'string' ? peer.chatType : null;
-      const isForum = typeof peer.isForum === 'boolean' ? peer.isForum : null;
-      const isGroup = typeof peer.isGroup === 'boolean' ? peer.isGroup : null;
-      results.push({
-        id,
-        type: normalizePeerType(peer),
-        title: peer.displayName || 'Unknown',
-        username,
-        chatType,
-        isForum,
-        isGroup,
-        unreadCount: typeof dialog.unreadCount === 'number' ? dialog.unreadCount : 0,
-        unreadMentionsCount: typeof dialog.unreadMentionsCount === 'number' ? dialog.unreadMentionsCount : 0,
-      });
+        const id = peer.id.toString();
+        const username = 'username' in peer ? peer.username ?? null : null;
+        const chatType = typeof peer.chatType === 'string' ? peer.chatType : null;
+        const isForum = typeof peer.isForum === 'boolean' ? peer.isForum : null;
+        const isGroup = typeof peer.isGroup === 'boolean' ? peer.isGroup : null;
+        results.push({
+          id,
+          type: normalizePeerType(peer),
+          title: peer.displayName || 'Unknown',
+          username,
+          chatType,
+          isForum,
+          isGroup,
+        });
 
-      if (results.length >= effectiveLimit) {
-        break;
+        if (results.length >= effectiveLimit) {
+          break;
+        }
       }
-    }
 
-    return results;
+      return results;
+    } catch (error) {
+      if (!retriedAfterSessionReset && this._isSessionResetError(error)) {
+        console.log('Detected session reset while listing dialogs. Recreating MTProto client and retrying once...');
+        await this._recreateClient();
+        const loginSuccess = await this.login();
+        if (!loginSuccess) {
+          throw new Error('Failed to restore session after dialog fetch reset.');
+        }
+        return this.listDialogs(limit, true);
+      }
+      throw error;
+    }
   }
 
   async searchPeers(query, limit = 50) {

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -834,6 +834,8 @@ class TelegramClient {
           chatType,
           isForum,
           isGroup,
+          unreadCount: typeof dialog.unreadCount === 'number' ? dialog.unreadCount : 0,
+          unreadMentionsCount: typeof dialog.unreadMentionsCount === 'number' ? dialog.unreadMentionsCount : 0,
         });
 
         if (results.length >= effectiveLimit) {

--- a/tests/auth-recovery.test.js
+++ b/tests/auth-recovery.test.js
@@ -1,0 +1,132 @@
+vi.mock('@mtcute/node', () => ({
+  TelegramClient: vi.fn(),
+}));
+vi.mock('@mtcute/core', () => ({
+  InputMedia: {
+    auto: vi.fn(),
+  },
+}));
+vi.mock('@mtcute/markdown-parser', () => ({
+  md: vi.fn((text) => text),
+}));
+vi.mock('@mtcute/html-parser', () => ({
+  html: vi.fn((text) => text),
+}));
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TelegramClient from '../telegram-client.js';
+
+function makeDialog(peer) {
+  return { peer };
+}
+
+describe('telegram auth recovery', () => {
+  let logSpy;
+  let errorSpy;
+  let warnSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('login routes existing sessions through client.start to complete mtcute login bootstrap', async () => {
+    const tc = Object.create(TelegramClient.prototype);
+    tc.options = { useQr: false, forceSms: false };
+    tc.phoneNumber = '';
+    tc.client = {
+      start: vi.fn().mockResolvedValue({}),
+    };
+    tc._isAuthorized = vi.fn().mockResolvedValue(true);
+    tc._buildStartParams = vi.fn().mockReturnValue({ bootstrap: true });
+
+    const result = await tc.login();
+
+    expect(result).toBe(true);
+    expect(tc.client.start).toHaveBeenCalledWith({ bootstrap: true });
+    expect(logSpy).toHaveBeenCalledWith('Existing session is valid.');
+  });
+
+  it('login retries once after session reset by recreating the MTProto client', async () => {
+    const firstClient = {
+      start: vi.fn().mockRejectedValue(new Error('Session is reset')),
+    };
+    const secondClient = {
+      start: vi.fn().mockResolvedValue({}),
+    };
+    const tc = Object.create(TelegramClient.prototype);
+    tc.options = { useQr: false, forceSms: false };
+    tc.phoneNumber = '+1234567890';
+    tc.client = firstClient;
+    tc._isAuthorized = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    tc._buildStartParams = vi.fn().mockReturnValue({ phone: '+1234567890' });
+    tc._isAuthKeyUnregisteredError = TelegramClient.prototype._isAuthKeyUnregisteredError;
+    tc._isSessionResetError = TelegramClient.prototype._isSessionResetError;
+    tc._recreateClient = vi.fn(async () => {
+      tc.client = secondClient;
+    });
+
+    const result = await tc.login();
+
+    expect(result).toBe(true);
+    expect(tc._recreateClient).toHaveBeenCalledTimes(1);
+    expect(firstClient.start).toHaveBeenCalledTimes(1);
+    expect(secondClient.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('listDialogs retries once after session reset and returns the recovered dialog list', async () => {
+    const firstClient = {
+      iterDialogs: async function* () {
+        throw new Error('Session is reset');
+      },
+    };
+    const secondClient = {
+      iterDialogs: async function* () {
+        yield makeDialog({
+          id: 42,
+          type: 'channel',
+          username: 'tgcli',
+          displayName: 'tgcli',
+          chatType: 'channel',
+          isForum: false,
+          isGroup: false,
+        });
+      },
+    };
+    const tc = Object.create(TelegramClient.prototype);
+    tc.client = firstClient;
+    tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
+    tc.login = vi.fn().mockResolvedValue(true);
+    tc._isSessionResetError = TelegramClient.prototype._isSessionResetError;
+    tc._recreateClient = vi.fn(async () => {
+      tc.client = secondClient;
+    });
+
+    const dialogs = await tc.listDialogs(10);
+
+    expect(tc._recreateClient).toHaveBeenCalledTimes(1);
+    expect(tc.login).toHaveBeenCalledTimes(1);
+    expect(tc.ensureLogin).toHaveBeenCalledTimes(2);
+    expect(dialogs).toEqual([
+      {
+        id: '42',
+        type: 'channel',
+        title: 'tgcli',
+        username: 'tgcli',
+        chatType: 'channel',
+        isForum: false,
+        isGroup: false,
+      },
+    ]);
+  });
+});

--- a/tests/auth-recovery.test.js
+++ b/tests/auth-recovery.test.js
@@ -17,8 +17,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TelegramClient from '../telegram-client.js';
 
-function makeDialog(peer) {
-  return { peer };
+function makeDialog(peer, extra = {}) {
+  return { peer, unreadCount: extra.unreadCount ?? 0, unreadMentionsCount: extra.unreadMentionsCount ?? 0 };
 }
 
 describe('telegram auth recovery', () => {
@@ -126,6 +126,8 @@ describe('telegram auth recovery', () => {
         chatType: 'channel',
         isForum: false,
         isGroup: false,
+        unreadCount: 0,
+        unreadMentionsCount: 0,
       },
     ]);
   });

--- a/tests/cli-auth.test.js
+++ b/tests/cli-auth.test.js
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  acquireStoreLockMock,
+  createTelegramClientMock,
+  createMessageSyncServiceMock,
+  loadConfigMock,
+  normalizeConfigMock,
+  resolveStoreDirMock,
+  validateConfigMock,
+} = vi.hoisted(() => ({
+  acquireStoreLockMock: vi.fn(),
+  createTelegramClientMock: vi.fn(),
+  createMessageSyncServiceMock: vi.fn(),
+  loadConfigMock: vi.fn(),
+  normalizeConfigMock: vi.fn(),
+  resolveStoreDirMock: vi.fn(),
+  validateConfigMock: vi.fn(),
+}));
+
+vi.mock('../store-lock.js', () => ({
+  acquireStoreLock: acquireStoreLockMock,
+  acquireReadLock: vi.fn(),
+  readStoreLock: vi.fn(),
+}));
+
+vi.mock('../core/config.js', () => ({
+  loadConfig: loadConfigMock,
+  normalizeConfig: normalizeConfigMock,
+  saveConfig: vi.fn(),
+  validateConfig: validateConfigMock,
+}));
+
+vi.mock('../core/services.js', () => ({
+  createMessageSyncService: createMessageSyncServiceMock,
+  createServices: vi.fn(),
+  createTelegramClient: createTelegramClientMock,
+}));
+
+vi.mock('../core/store.js', () => ({
+  resolveStoreDir: resolveStoreDirMock,
+}));
+
+import { isCliEntrypoint, runAuthLogin } from '../cli.js';
+
+describe('cli auth command', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    resolveStoreDirMock.mockReturnValue('/tmp/tgcli-store');
+    loadConfigMock.mockReturnValue({
+      config: {
+        apiId: '12345',
+        apiHash: 'hash',
+        phoneNumber: '+1234567890',
+      },
+    });
+    normalizeConfigMock.mockImplementation((config) => config);
+    validateConfigMock.mockReturnValue([]);
+    acquireStoreLockMock.mockReturnValue(vi.fn());
+    createMessageSyncServiceMock.mockReset();
+    createTelegramClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('completes auth without bootstrapping archive sync by default', async () => {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const login = vi.fn().mockResolvedValue(true);
+    createTelegramClientMock.mockReturnValue({
+      telegramClient: {
+        destroy,
+        login,
+      },
+    });
+
+    await runAuthLogin({ json: false, timeoutMs: null }, {});
+
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(createMessageSyncServiceMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      'Authenticated. Run `tgcli sync --once` or `tgcli sync --follow` when you need archive data.',
+    );
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats symlinked tgcli binaries as the cli entrypoint', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-cli-entrypoint-'));
+    const symlinkPath = path.join(tmpDir, 'tgcli');
+
+    try {
+      fs.symlinkSync(path.join(process.cwd(), 'cli.js'), symlinkPath);
+      expect(isCliEntrypoint(symlinkPath)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli-auth.test.js
+++ b/tests/cli-auth.test.js
@@ -90,6 +90,37 @@ describe('cli auth command', () => {
     expect(destroy).toHaveBeenCalledTimes(1);
   });
 
+  it('passes qr file and json flags through to the telegram client', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const login = vi.fn().mockResolvedValue(true);
+    createTelegramClientMock.mockReturnValue({
+      telegramClient: {
+        destroy,
+        login,
+      },
+    });
+
+    try {
+      await runAuthLogin(
+        { json: true, timeoutMs: null },
+        { qr: true, qrFile: '/tmp/tgcli-auth.png', forceSms: false, follow: false },
+      );
+    } finally {
+      stdoutWriteSpy.mockRestore();
+    }
+
+    expect(createTelegramClientMock).toHaveBeenCalledWith(expect.objectContaining({
+      forceSms: false,
+      useQr: true,
+      qrFilePath: '/tmp/tgcli-auth.png',
+      json: true,
+      disableUpdates: true,
+    }));
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('treats symlinked tgcli binaries as the cli entrypoint', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-cli-entrypoint-'));
     const symlinkPath = path.join(tmpDir, 'tgcli');

--- a/tests/services.test.js
+++ b/tests/services.test.js
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { telegramClientCtor, messageSyncServiceCtor } = vi.hoisted(() => ({
+  telegramClientCtor: vi.fn(function (...args) {
+    return { kind: 'telegram', args };
+  }),
+  messageSyncServiceCtor: vi.fn(function (...args) {
+    return { kind: 'sync', args };
+  }),
+}));
+
+vi.mock('../telegram-client.js', () => ({
+  default: telegramClientCtor,
+}));
+
+vi.mock('../message-sync-service.js', () => ({
+  default: messageSyncServiceCtor,
+}));
+
+import {
+  createMessageSyncService,
+  createServices,
+  createTelegramClient,
+} from '../core/services.js';
+
+describe('core services helpers', () => {
+  let storeDir;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-services-test-'));
+    fs.writeFileSync(path.join(storeDir, 'config.json'), JSON.stringify({
+      apiId: '12345',
+      apiHash: 'hash-value',
+      phoneNumber: '+1234567890',
+    }));
+    telegramClientCtor.mockClear();
+    messageSyncServiceCtor.mockClear();
+  });
+
+  afterEach(() => {
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('creates a telegram client without bootstrapping the archive service', () => {
+    const result = createTelegramClient({
+      storeDir,
+      forceSms: true,
+      useQr: true,
+      disableUpdates: true,
+    });
+
+    expect(telegramClientCtor).toHaveBeenCalledWith(
+      '12345',
+      'hash-value',
+      '+1234567890',
+      path.join(storeDir, 'session.json'),
+      { forceSms: true, useQr: true, disableUpdates: true },
+    );
+    expect(messageSyncServiceCtor).not.toHaveBeenCalled();
+    expect(result.sessionPath).toBe(path.join(storeDir, 'session.json'));
+  });
+
+  it('creates a message sync service on demand for an existing telegram client', () => {
+    const fakeClient = { kind: 'telegram' };
+    const result = createMessageSyncService(fakeClient, {
+      storeDir,
+      batchSize: 7,
+      interJobDelayMs: 11,
+      interBatchDelayMs: 13,
+    });
+
+    expect(messageSyncServiceCtor).toHaveBeenCalledWith(fakeClient, {
+      dbPath: path.join(storeDir, 'messages.db'),
+      batchSize: 7,
+      interJobDelayMs: 11,
+      interBatchDelayMs: 13,
+    });
+    expect(result.dbPath).toBe(path.join(storeDir, 'messages.db'));
+  });
+
+  it('keeps the legacy createServices composition intact', () => {
+    const result = createServices({ storeDir });
+
+    expect(telegramClientCtor).toHaveBeenCalledTimes(1);
+    expect(messageSyncServiceCtor).toHaveBeenCalledTimes(1);
+    expect(result.sessionPath).toBe(path.join(storeDir, 'session.json'));
+    expect(result.dbPath).toBe(path.join(storeDir, 'messages.db'));
+  });
+});

--- a/tests/services.test.js
+++ b/tests/services.test.js
@@ -57,7 +57,13 @@ describe('core services helpers', () => {
       'hash-value',
       '+1234567890',
       path.join(storeDir, 'session.json'),
-      { forceSms: true, useQr: true, disableUpdates: true },
+      expect.objectContaining({
+        forceSms: true,
+        useQr: true,
+        qrFilePath: null,
+        json: false,
+        disableUpdates: true,
+      }),
     );
     expect(messageSyncServiceCtor).not.toHaveBeenCalled();
     expect(result.sessionPath).toBe(path.join(storeDir, 'session.json'));

--- a/tests/store-lock.test.js
+++ b/tests/store-lock.test.js
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { acquireStoreLock } from '../store-lock.js';
+
+const originalUnlinkSync = fs.unlinkSync;
+
+describe('store lock recovery', () => {
+  let storeDir;
+  let lockPath;
+  let unlinkSpy;
+  let killSpy;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-lock-test-'));
+    lockPath = path.join(storeDir, 'LOCK');
+    fs.writeFileSync(lockPath, JSON.stringify({ pid: 424242, startedAt: '2026-03-12T00:00:00.000Z' }));
+  });
+
+  afterEach(() => {
+    unlinkSpy?.mockRestore();
+    killSpy?.mockRestore();
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('surfaces stale lock cleanup failures instead of reporting a live locker', () => {
+    killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('no such process');
+      error.code = 'ESRCH';
+      throw error;
+    });
+    unlinkSpy = vi.spyOn(fs, 'unlinkSync').mockImplementation((target) => {
+      if (target === lockPath) {
+        const error = new Error('operation not permitted');
+        error.code = 'EPERM';
+        throw error;
+      }
+      return originalUnlinkSync(target);
+    });
+
+    expect(() => acquireStoreLock(storeDir)).toThrow(
+      `Found stale store lock for dead pid 424242, but could not remove ${lockPath}: operation not permitted`,
+    );
+  });
+});

--- a/tests/telegram-client-auth.test.js
+++ b/tests/telegram-client-auth.test.js
@@ -1,0 +1,58 @@
+const mtcuteClientCtor = vi.hoisted(() => vi.fn(function () {
+  return {
+    destroy: vi.fn().mockResolvedValue(undefined),
+    stopUpdatesLoop: vi.fn().mockResolvedValue(undefined),
+    onRawUpdate: { remove: vi.fn() },
+  };
+}));
+
+vi.mock('@mtcute/node', () => ({
+  TelegramClient: mtcuteClientCtor,
+}));
+
+vi.mock('@mtcute/core', () => ({
+  InputMedia: {},
+}));
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TelegramClient from '../telegram-client.js';
+
+describe('telegram client auth bootstrap options', () => {
+  beforeEach(() => {
+    mtcuteClientCtor.mockReset();
+    mtcuteClientCtor.mockImplementation(function () {
+      return {
+        destroy: vi.fn().mockResolvedValue(undefined),
+        stopUpdatesLoop: vi.fn().mockResolvedValue(undefined),
+        onRawUpdate: { remove: vi.fn() },
+      };
+    });
+  });
+
+  it('disables mtcute updates when requested', () => {
+    new TelegramClient(12345, 'hash', '+1234567890', '/tmp/tgcli-auth-disable-updates.session', {
+      disableUpdates: true,
+    });
+
+    expect(mtcuteClientCtor).toHaveBeenCalledWith(expect.objectContaining({
+      apiId: 12345,
+      apiHash: 'hash',
+      disableUpdates: true,
+    }));
+    expect(mtcuteClientCtor.mock.calls[0][0]).not.toHaveProperty('updates');
+  });
+
+  it('keeps updates configuration enabled by default', () => {
+    new TelegramClient(12345, 'hash', '+1234567890', '/tmp/tgcli-auth-with-updates.session');
+
+    expect(mtcuteClientCtor).toHaveBeenCalledWith(expect.objectContaining({
+      apiId: 12345,
+      apiHash: 'hash',
+      updates: expect.objectContaining({
+        catchUp: true,
+      }),
+    }));
+    expect(mtcuteClientCtor.mock.calls[0][0]).not.toHaveProperty('disableUpdates');
+  });
+});

--- a/tests/telegram-client-qr.test.js
+++ b/tests/telegram-client-qr.test.js
@@ -1,0 +1,117 @@
+const qrcodeMock = vi.hoisted(() => ({
+  toString: vi.fn(),
+  toFile: vi.fn(),
+  toDataURL: vi.fn(),
+}));
+
+const mtcuteClientCtor = vi.hoisted(() => vi.fn(function () {
+  return {
+    destroy: vi.fn().mockResolvedValue(undefined),
+    stopUpdatesLoop: vi.fn().mockResolvedValue(undefined),
+    onRawUpdate: { remove: vi.fn() },
+  };
+}));
+
+vi.mock('qrcode', () => ({
+  default: qrcodeMock,
+  toString: qrcodeMock.toString,
+  toFile: qrcodeMock.toFile,
+  toDataURL: qrcodeMock.toDataURL,
+}));
+
+vi.mock('@mtcute/node', () => ({
+  TelegramClient: mtcuteClientCtor,
+}));
+
+vi.mock('@mtcute/core', () => ({
+  InputMedia: {},
+}));
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TelegramClient from '../telegram-client.js';
+
+describe('telegram client qr auth output', () => {
+  let logSpy;
+  let stderrWriteSpy;
+
+  beforeEach(() => {
+    qrcodeMock.toString.mockReset().mockResolvedValue('terminal-qr');
+    qrcodeMock.toFile.mockReset().mockResolvedValue(undefined);
+    qrcodeMock.toDataURL.mockReset().mockResolvedValue('data:image/png;base64,abc');
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    stderrWriteSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    stderrWriteSpy.mockRestore();
+  });
+
+  it('renders terminal QR output and saves the PNG when requested', async () => {
+    const client = Object.create(TelegramClient.prototype);
+    client.options = {
+      useQr: true,
+      json: false,
+      qrFilePath: '/tmp/tgcli-qr-auth.png',
+    };
+
+    const { qrCodeHandler } = client._buildStartParams();
+    await qrCodeHandler('tg://login?token=abc', new Date('2026-04-02T00:00:00.000Z'));
+
+    expect(qrcodeMock.toString).toHaveBeenCalledWith('tg://login?token=abc', {
+      type: 'terminal',
+      small: true,
+    });
+    expect(qrcodeMock.toFile).toHaveBeenCalledWith('/tmp/tgcli-qr-auth.png', 'tg://login?token=abc', {
+      type: 'png',
+      width: 300,
+    });
+    expect(logSpy).toHaveBeenCalledWith('\nScan this QR code in Telegram: Settings -> Devices -> Link Desktop Device');
+    expect(logSpy).toHaveBeenCalledWith('terminal-qr');
+    expect(logSpy).toHaveBeenCalledWith('QR login URL: tg://login?token=abc');
+    expect(logSpy).toHaveBeenCalledWith('QR expires at: 2026-04-02T00:00:00.000Z');
+    expect(logSpy).toHaveBeenCalledWith('QR saved to: /tmp/tgcli-qr-auth.png');
+    expect(stderrWriteSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits qr events to stderr in json mode and handles refreshed QR codes', async () => {
+    const client = Object.create(TelegramClient.prototype);
+    client.options = {
+      useQr: true,
+      json: true,
+      qrFilePath: '/tmp/tgcli-qr-auth.png',
+    };
+
+    const { qrCodeHandler } = client._buildStartParams();
+    await qrCodeHandler('tg://login?token=first', new Date('2026-04-02T00:00:00.000Z'));
+    await qrCodeHandler('tg://login?token=second', new Date('2026-04-02T00:05:00.000Z'));
+
+    expect(qrcodeMock.toString).not.toHaveBeenCalled();
+    expect(qrcodeMock.toFile).toHaveBeenNthCalledWith(1, '/tmp/tgcli-qr-auth.png', 'tg://login?token=first', {
+      type: 'png',
+      width: 300,
+    });
+    expect(qrcodeMock.toFile).toHaveBeenNthCalledWith(2, '/tmp/tgcli-qr-auth.png', 'tg://login?token=second', {
+      type: 'png',
+      width: 300,
+    });
+    expect(logSpy).not.toHaveBeenCalled();
+
+    const writes = stderrWriteSpy.mock.calls.map(([chunk]) => JSON.parse(String(chunk).trim()));
+    expect(writes).toEqual([
+      {
+        event: 'qr',
+        url: 'tg://login?token=first',
+        expiresAt: '2026-04-02T00:00:00.000Z',
+        qrFile: '/tmp/tgcli-qr-auth.png',
+      },
+      {
+        event: 'qr',
+        url: 'tg://login?token=second',
+        expiresAt: '2026-04-02T00:05:00.000Z',
+        qrFile: '/tmp/tgcli-qr-auth.png',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Backported from dapi/tgcli + agent-friendly QR image

### QR Code Login
```bash
# Terminal QR (human)
tgcli auth --qr

# PNG file (agent-friendly)
tgcli auth --qr --qr-file /tmp/qr.png

# JSON mode emits QR events to stderr
tgcli auth --qr --qr-file /tmp/qr.png --json
# stderr: {"event":"qr","url":"tg://login?token=...","qrFile":"/tmp/qr.png"}
```

QR refreshes automatically — new PNG is written each time.

### Force SMS
```bash
tgcli auth --force-sms
```

### Auth Recovery
- Auto-retry on AUTH_KEY_UNREGISTERED / SESSION_REVOKED
- Resets session files and recreates MTProto client
- Retry on login() and listDialogs()

### Tests
- 203 tests (was 189), 12 test files
- New: telegram-client-qr, cli-auth, telegram-client-auth, store-lock, services

### Dependencies
- Replaced `qrcode-terminal` with `qrcode` (supports terminal + PNG + base64)