### PR TITLE
fix(send): default 30s timeout + --quiet for send commands (#23)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -84,3 +84,4 @@ tgcli channels list --limit 10 --json
 
 - Use `--source live|archive|both` when listing or searching messages.
 - `--json` is best for AI/tooling pipelines.
+- `send` commands time out after `30s` by default so they never hang on a stuck connection. Override with `--timeout 5m` or disable with `--timeout 0`. Long-running commands (`sync`, `--follow`, `server`) are unbounded by default.

--- a/cli.js
+++ b/cli.js
@@ -57,6 +57,7 @@ function buildProgram() {
     .usage('[options] <command>')
     .option('--json', 'Machine-readable output')
     .option('--timeout <duration>', 'Wall-clock timeout (e.g. 30s, 5m)')
+    .option('--quiet', 'Suppress progress/status output on stderr')
     .version(readVersion(), '--version', 'Print version and exit')
     .showHelpAfterError(true);
 
@@ -590,6 +591,7 @@ function getGlobalFlags(command) {
   const timeoutMs = options.timeout ? parseDuration(options.timeout) : null;
   return {
     json: Boolean(options.json),
+    quiet: Boolean(options.quiet),
     timeout: options.timeout ?? null,
     timeoutMs,
   };
@@ -3030,7 +3032,11 @@ function normalizeSendCommandError(error, { method, retries, attempt = 1 } = {})
 
 // Brief progress note on stderr so users/agents see the command is alive while
 // the MTProto connection is established. stderr keeps stdout --json output clean.
-function printSendStatus(message) {
+// Suppressed by the global --quiet flag.
+function printSendStatus(message, globalFlags) {
+  if (globalFlags?.quiet) {
+    return;
+  }
   process.stderr.write(`${message}\n`);
 }
 
@@ -3073,7 +3079,7 @@ async function runSendText(globalFlags, options = {}) {
       const retryBackoff = parseRetryBackoff(options.retryBackoff);
       const storeDir = resolveStoreDir();
       const release = acquireStoreLock(storeDir);
-      printSendStatus('Connecting to Telegram…');
+      printSendStatus('Connecting to Telegram…', globalFlags);
       const { telegramClient, messageSyncService } = createServices({ storeDir });
       try {
         if (!(await telegramClient.isAuthorized().catch(() => false))) {
@@ -3138,7 +3144,7 @@ async function runSendPhoto(globalFlags, options = {}) {
       const retryBackoff = parseRetryBackoff(options.retryBackoff);
       const storeDir = resolveStoreDir();
       const release = acquireStoreLock(storeDir);
-      printSendStatus('Connecting to Telegram…');
+      printSendStatus('Connecting to Telegram…', globalFlags);
       const { telegramClient, messageSyncService } = createServices({ storeDir });
       try {
         if (!(await telegramClient.isAuthorized().catch(() => false))) {
@@ -3204,7 +3210,7 @@ async function runSendFile(globalFlags, options = {}) {
       const retryBackoff = parseRetryBackoff(options.retryBackoff);
       const storeDir = resolveStoreDir();
       const release = acquireStoreLock(storeDir);
-      printSendStatus('Connecting to Telegram…');
+      printSendStatus('Connecting to Telegram…', globalFlags);
       const { telegramClient, messageSyncService } = createServices({ storeDir });
       try {
         if (!(await telegramClient.isAuthorized().catch(() => false))) {

--- a/cli.js
+++ b/cli.js
@@ -38,6 +38,11 @@ const CONFIG_SPECS = [
 
 const SEND_PARSE_MODES = ['markdown', 'html', 'none'];
 const DEFAULT_SEND_RETRIES = 2;
+// Send commands target AI agents and scripts that must not block forever on a
+// hung MTProto connection, so they get a bounded default timeout. Other commands
+// (sync, --follow, server, ...) legitimately run for minutes/hours and stay
+// unbounded unless an explicit --timeout is passed.
+const DEFAULT_SEND_TIMEOUT_MS = 30000;
 const FEEDBACK_LAST_FILE = 'feedback-last.json';
 const FEEDBACK_COOLDOWN_MS = 60 * 1000;
 const FEEDBACK_DEFAULT_CHAT_ID = '@kfastov';
@@ -677,6 +682,28 @@ function parseDuration(value) {
   return amount * 1000;
 }
 
+// Resolve the effective timeout for a send command.
+//   null/undefined (no --timeout)  -> default 30s
+//   0 (--timeout 0)                -> 0, meaning disabled/unbounded
+//   any positive value             -> honored as given
+function resolveSendTimeoutMs(timeoutMs) {
+  return timeoutMs ?? DEFAULT_SEND_TIMEOUT_MS;
+}
+
+function formatTimeoutDuration(timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return `${timeoutMs}ms`;
+  }
+  return timeoutMs % 1000 === 0 ? `${timeoutMs / 1000}s` : `${timeoutMs}ms`;
+}
+
+// Clear, actionable message used when a send exceeds its timeout budget, so the
+// failure reads as a real timeout rather than a generic empty error.
+function formatSendTimeoutMessage(timeoutMs) {
+  return `Send timed out after ${formatTimeoutDuration(timeoutMs)} (no response from Telegram). `
+    + 'Pass --timeout <duration> to extend, or --timeout 0 to disable.';
+}
+
 function resolveConfigSpec(key) {
   if (typeof key !== 'string' || !key.trim()) {
     throw new Error('Config key is required.');
@@ -1017,7 +1044,7 @@ function resolveServiceManager() {
   return { manager: 'unsupported', brewInfo };
 }
 
-function runWithTimeout(task, timeoutMs, onTimeout) {
+function runWithTimeout(task, timeoutMs, onTimeout, timeoutMessage = 'Timeout') {
   if (!timeoutMs) {
     return task();
   }
@@ -1029,7 +1056,7 @@ function runWithTimeout(task, timeoutMs, onTimeout) {
           await onTimeout();
         }
       } finally {
-        reject(new Error('Timeout'));
+        reject(new Error(timeoutMessage));
       }
     }, timeoutMs);
   });
@@ -3001,6 +3028,12 @@ function normalizeSendCommandError(error, { method, retries, attempt = 1 } = {})
   return new SendCommandError(classifySendError(error, { method, retries, attempt }));
 }
 
+// Brief progress note on stderr so users/agents see the command is alive while
+// the MTProto connection is established. stderr keeps stdout --json output clean.
+function printSendStatus(message) {
+  process.stderr.write(`${message}\n`);
+}
+
 function logSendRetry(details, globalFlags) {
   if (globalFlags.json) {
     process.stderr.write(`${JSON.stringify({ event: 'retry', type: details.type, method: details.method, message: details.message, attempt: details.attempt, retries: details.retries })}\n`);
@@ -3027,7 +3060,7 @@ function buildSendPhotoSuccessPayload({ method, inputChatId, result, attempts })
 
 async function runSendText(globalFlags, options = {}) {
   resolveSendAliases(options);
-  const timeoutMs = globalFlags.timeoutMs;
+  const timeoutMs = resolveSendTimeoutMs(globalFlags.timeoutMs);
   const method = 'sendText';
   let retries = DEFAULT_SEND_RETRIES;
 
@@ -3040,6 +3073,7 @@ async function runSendText(globalFlags, options = {}) {
       const retryBackoff = parseRetryBackoff(options.retryBackoff);
       const storeDir = resolveStoreDir();
       const release = acquireStoreLock(storeDir);
+      printSendStatus('Connecting to Telegram…');
       const { telegramClient, messageSyncService } = createServices({ storeDir });
       try {
         if (!(await telegramClient.isAuthorized().catch(() => false))) {
@@ -3062,6 +3096,7 @@ async function runSendText(globalFlags, options = {}) {
             method,
             retries,
             retryBackoff,
+            timeoutMs,
             sleep: (ms) => delay(ms),
           },
         );
@@ -3079,7 +3114,7 @@ async function runSendText(globalFlags, options = {}) {
         await telegramClient.destroy();
         release();
       }
-    }, timeoutMs);
+    }, timeoutMs, undefined, formatSendTimeoutMessage(timeoutMs));
   } catch (error) {
     throw normalizeSendCommandError(error, { method, retries });
   }
@@ -3087,7 +3122,7 @@ async function runSendText(globalFlags, options = {}) {
 
 async function runSendPhoto(globalFlags, options = {}) {
   resolveSendAliases(options);
-  const timeoutMs = globalFlags.timeoutMs;
+  const timeoutMs = resolveSendTimeoutMs(globalFlags.timeoutMs);
   const method = 'sendPhoto';
   let retries = DEFAULT_SEND_RETRIES;
 
@@ -3103,6 +3138,7 @@ async function runSendPhoto(globalFlags, options = {}) {
       const retryBackoff = parseRetryBackoff(options.retryBackoff);
       const storeDir = resolveStoreDir();
       const release = acquireStoreLock(storeDir);
+      printSendStatus('Connecting to Telegram…');
       const { telegramClient, messageSyncService } = createServices({ storeDir });
       try {
         if (!(await telegramClient.isAuthorized().catch(() => false))) {
@@ -3144,7 +3180,7 @@ async function runSendPhoto(globalFlags, options = {}) {
         await telegramClient.destroy();
         release();
       }
-    }, timeoutMs);
+    }, timeoutMs, undefined, formatSendTimeoutMessage(timeoutMs));
   } catch (error) {
     throw normalizeSendCommandError(error, { method, retries });
   }
@@ -3152,7 +3188,7 @@ async function runSendPhoto(globalFlags, options = {}) {
 
 async function runSendFile(globalFlags, options = {}) {
   resolveSendAliases(options);
-  const timeoutMs = globalFlags.timeoutMs;
+  const timeoutMs = resolveSendTimeoutMs(globalFlags.timeoutMs);
   const method = 'sendFile';
   let retries = DEFAULT_SEND_RETRIES;
 
@@ -3168,6 +3204,7 @@ async function runSendFile(globalFlags, options = {}) {
       const retryBackoff = parseRetryBackoff(options.retryBackoff);
       const storeDir = resolveStoreDir();
       const release = acquireStoreLock(storeDir);
+      printSendStatus('Connecting to Telegram…');
       const { telegramClient, messageSyncService } = createServices({ storeDir });
       try {
         if (!(await telegramClient.isAuthorized().catch(() => false))) {
@@ -3194,6 +3231,7 @@ async function runSendFile(globalFlags, options = {}) {
             method,
             retries,
             retryBackoff,
+            timeoutMs,
             sleep: (ms) => delay(ms),
           },
         );
@@ -3211,7 +3249,7 @@ async function runSendFile(globalFlags, options = {}) {
         await telegramClient.destroy();
         release();
       }
-    }, timeoutMs);
+    }, timeoutMs, undefined, formatSendTimeoutMessage(timeoutMs));
   } catch (error) {
     throw normalizeSendCommandError(error, { method, retries });
   }
@@ -4329,13 +4367,16 @@ async function main() {
 export {
   buildProgram,
   buildSendPhotoSuccessPayload,
+  DEFAULT_SEND_TIMEOUT_MS,
   formatFeedbackMessage,
+  formatSendTimeoutMessage,
   getFeedbackCooldownRemainingSeconds,
   isCliEntrypoint,
   logSendRetry,
   main,
   normalizeSendCommandError,
   parseNonNegativeInt,
+  resolveSendTimeoutMs,
   runFeedback,
   shouldRunMain,
   writeError,

--- a/core/send-utils.js
+++ b/core/send-utils.js
@@ -102,6 +102,19 @@ export function parseRequiredWaitSeconds(error) {
   return null;
 }
 
+/**
+ * Build a clear message for a FLOOD_WAIT that exceeds the send timeout budget,
+ * so the failure reads as a rate limit rather than a generic timeout/hang.
+ */
+export function formatRateLimitTimeoutMessage(waitSeconds, timeoutMs) {
+  const timeoutSeconds = Number.isFinite(timeoutMs) && timeoutMs > 0
+    ? Math.round(timeoutMs / 1000)
+    : null;
+  const budget = timeoutSeconds !== null ? `the ${timeoutSeconds}s timeout` : 'the timeout';
+  return `Telegram rate-limited this send (FLOOD_WAIT ${waitSeconds}s), which exceeds ${budget}. `
+    + 'Retry later or pass --timeout 0.';
+}
+
 function looksLikeTelegramError(message, code, error) {
   if (typeof code === 'number') {
     return true;
@@ -299,6 +312,16 @@ export async function executeSendWithRetries(sendFn, options = {}) {
         const left = remainingMs();
         if (left <= 0) {
           throw new SendCommandError(timeoutDetails(attempt));
+        }
+        // A Telegram-imposed FLOOD_WAIT that exceeds the remaining timeout budget
+        // is a deliberate rate limit, not a hung connection. Abort early with the
+        // rate-limit reason instead of sleeping into a generic timeout.
+        if (details.type === 'rate_limit' && waitSeconds !== null && retryDelayMs > left) {
+          throw new SendCommandError({
+            ...details,
+            retryable: false,
+            message: formatRateLimitTimeoutMessage(waitSeconds, options.timeoutMs),
+          });
         }
         if (retryDelayMs > 0) {
           await sleep(Math.min(retryDelayMs, left));

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,6 +7,8 @@ CLI goal: human-readable output by default with --json for scripting.
 - --timeout DURATION
   - No default for most commands (long-running ones like `sync`, `--follow`, and `server` stay unbounded).
   - `send` commands default to `30s` so agents/scripts never hang on a stuck connection. Override with `--timeout 5m`, or `--timeout 0` to disable.
+- --quiet
+  - Suppress informational progress/status output on stderr (e.g. the `Connecting to Telegram…` note from `send`). Errors and primary stdout/`--json` output are unaffected.
 - --version
 
 Store location: OS app data dir (override with TGCLI_STORE).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,6 +5,8 @@ CLI goal: human-readable output by default with --json for scripting.
 ## Global flags
 - --json
 - --timeout DURATION
+  - No default for most commands (long-running ones like `sync`, `--follow`, and `server` stay unbounded).
+  - `send` commands default to `30s` so agents/scripts never hang on a stuck connection. Override with `--timeout 5m`, or `--timeout 0` to disable.
 - --version
 
 Store location: OS app data dir (override with TGCLI_STORE).
@@ -103,6 +105,8 @@ Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 - send photo --to <id|username> --photo PATH [--caption "..."] [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-forwards] [--spoiler] [--caption-above] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]
 - send file --to <id|username> --file PATH [--caption "..."] [--filename NAME] [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-forwards] [--spoiler] [--caption-above] [--force-document] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]
   - `--retries` defaults to `2` for all send commands.
+  - Send commands default to a `30s` wall-clock timeout so a stuck Telegram connection fails fast instead of hanging. Override with `--timeout <duration>` (e.g. `--timeout 5m`) or disable with `--timeout 0`. On timeout the command exits non-zero with: `Send timed out after 30s (no response from Telegram).`
+  - If Telegram returns a `FLOOD_WAIT` whose required wait exceeds the remaining timeout budget, the command aborts early reporting the rate limit (e.g. `Telegram rate-limited this send (FLOOD_WAIT 120s), which exceeds the 30s timeout.`) rather than silently timing out. Retry later or pass `--timeout 0`.
 
 ## media
 - media download --chat <id|username> --id <msgId> [--output PATH]

--- a/tests/send-timeout.test.js
+++ b/tests/send-timeout.test.js
@@ -257,4 +257,27 @@ describe('send command default timeout (CLI integration)', () => {
     // Detach the dangling promise so the test runner can exit cleanly.
     void done;
   });
+
+  it('prints the Connecting status on stderr by default (no --quiet)', async () => {
+    services.current = makeFakeServices({ sendImpl: async () => ({ messageId: 11 }) });
+
+    await runProgram(['send', 'text', '--to', '@x', '--message', 'hi']);
+
+    expect(process.exitCode).toBeUndefined();
+    const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).toContain('Connecting to Telegram');
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Message sent (11).');
+  });
+
+  it('suppresses the Connecting status with --quiet', async () => {
+    services.current = makeFakeServices({ sendImpl: async () => ({ messageId: 12 }) });
+
+    await runProgram(['send', 'text', '--to', '@x', '--message', 'hi', '--quiet']);
+
+    expect(process.exitCode).toBeUndefined();
+    const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).not.toContain('Connecting to Telegram');
+    // Primary stdout/--json output is unaffected.
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Message sent (12).');
+  });
 });

--- a/tests/send-timeout.test.js
+++ b/tests/send-timeout.test.js
@@ -1,0 +1,260 @@
+// Tests for issue #23: send commands get a bounded default timeout, while
+// long-running commands (sync, --follow, server, ...) stay unbounded.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks for the CLI integration tests ---------------------------------
+// The send / sync handlers build real Telegram + sync services and acquire a
+// store lock. Stub those seams so we can drive the command surface without any
+// network, filesystem, or auth side effects.
+
+const services = vi.hoisted(() => ({ current: null }));
+
+vi.mock('../core/services.js', () => ({
+  createServices: vi.fn(() => services.current),
+}));
+
+vi.mock('../store-lock.js', () => ({
+  acquireStoreLock: vi.fn(() => () => {}),
+  acquireReadLock: vi.fn(() => () => {}),
+  readStoreLock: vi.fn(() => ({ exists: false })),
+}));
+
+vi.mock('../core/store.js', () => ({
+  resolveStoreDir: vi.fn(() => '/tmp/tgcli-test-store'),
+}));
+
+const {
+  DEFAULT_SEND_TIMEOUT_MS,
+  formatSendTimeoutMessage,
+  resolveSendTimeoutMs,
+  buildProgram,
+} = await import('../cli.js');
+
+const {
+  executeSendWithRetries,
+  parseRetryBackoff,
+  formatRateLimitTimeoutMessage,
+} = await import('../core/send-utils.js');
+
+// --- Pure helper unit tests ----------------------------------------------
+
+describe('resolveSendTimeoutMs', () => {
+  it('(a) applies the default when no --timeout is given (null)', () => {
+    expect(resolveSendTimeoutMs(null)).toBe(DEFAULT_SEND_TIMEOUT_MS);
+    expect(resolveSendTimeoutMs(undefined)).toBe(DEFAULT_SEND_TIMEOUT_MS);
+    expect(DEFAULT_SEND_TIMEOUT_MS).toBe(30000);
+  });
+
+  it('(c) treats --timeout 0 as disabled/unbounded (stays 0)', () => {
+    expect(resolveSendTimeoutMs(0)).toBe(0);
+  });
+
+  it('(d) honors an explicit --timeout value', () => {
+    expect(resolveSendTimeoutMs(5000)).toBe(5000);
+    expect(resolveSendTimeoutMs(300000)).toBe(300000);
+  });
+});
+
+describe('formatSendTimeoutMessage', () => {
+  it('(e) produces a clear, actionable timeout message', () => {
+    const msg = formatSendTimeoutMessage(30000);
+    expect(msg).toBe(
+      'Send timed out after 30s (no response from Telegram). '
+      + 'Pass --timeout <duration> to extend, or --timeout 0 to disable.',
+    );
+  });
+
+  it('renders sub-second timeouts in ms', () => {
+    expect(formatSendTimeoutMessage(500)).toContain('Send timed out after 500ms');
+  });
+});
+
+describe('formatRateLimitTimeoutMessage', () => {
+  it('names the FLOOD_WAIT and the timeout budget', () => {
+    expect(formatRateLimitTimeoutMessage(120, 30000)).toBe(
+      'Telegram rate-limited this send (FLOOD_WAIT 120s), which exceeds the 30s timeout. '
+      + 'Retry later or pass --timeout 0.',
+    );
+  });
+});
+
+// --- FLOOD_WAIT vs timeout budget ----------------------------------------
+
+describe('executeSendWithRetries FLOOD_WAIT budget handling', () => {
+  it('reports a rate limit (not a generic timeout) when FLOOD_WAIT exceeds the budget', async () => {
+    let currentTime = 0;
+    const now = vi.fn(() => currentTime);
+    const sleep = vi.fn(async (ms) => { currentTime += ms; });
+    const sendFn = vi.fn().mockRejectedValue(new Error('FLOOD_WAIT_120'));
+
+    await expect(
+      executeSendWithRetries(sendFn, {
+        method: 'sendText',
+        retries: 2,
+        retryBackoff: parseRetryBackoff('constant'),
+        timeoutMs: 30000,
+        maxWaitSeconds: 300,
+        sleep,
+        now,
+      }),
+    ).rejects.toMatchObject({
+      name: 'SendCommandError',
+      details: expect.objectContaining({
+        type: 'rate_limit',
+        method: 'sendText',
+        waitSeconds: 120,
+      }),
+    });
+
+    // It must abort early rather than sleep into a generic timeout.
+    expect(sleep).not.toHaveBeenCalled();
+    const error = await executeSendWithRetries(sendFn, {
+      method: 'sendText',
+      retries: 1,
+      timeoutMs: 30000,
+      sleep,
+      now: () => 0,
+    }).catch((e) => e);
+    expect(error.details.message).toContain('FLOOD_WAIT 120s');
+    expect(error.details.message).toContain('30s timeout');
+  });
+
+  it('still retries a FLOOD_WAIT that fits inside the budget', async () => {
+    let currentTime = 0;
+    const now = vi.fn(() => currentTime);
+    const sleep = vi.fn(async (ms) => { currentTime += ms; });
+    const sendFn = vi.fn()
+      .mockRejectedValueOnce(new Error('A wait of 3 seconds is required'))
+      .mockResolvedValueOnce({ messageId: 42 });
+
+    const result = await executeSendWithRetries(sendFn, {
+      method: 'sendText',
+      retries: 2,
+      timeoutMs: 30000,
+      sleep,
+      now,
+    });
+
+    expect(result).toEqual({ result: { messageId: 42 }, attempts: 2 });
+    expect(sleep).toHaveBeenCalledWith(3000);
+  });
+});
+
+// --- CLI integration: scoped default timeout -----------------------------
+
+function makeFakeServices({ sendImpl, refreshImpl } = {}) {
+  const telegramClient = {
+    isAuthorized: vi.fn().mockResolvedValue(true),
+    sendTextMessage: vi.fn(sendImpl ?? (async () => ({ messageId: 1 }))),
+    startUpdates: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+  const messageSyncService = {
+    refreshChannelsFromDialogs: vi.fn(refreshImpl ?? (async () => {})),
+    resumePendingJobs: vi.fn(),
+    getQueueStats: vi.fn(() => ({ pending: 0, in_progress: 0, processing: false })),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+  return { telegramClient, messageSyncService };
+}
+
+describe('send command default timeout (CLI integration)', () => {
+  let logSpy;
+  let errSpy;
+  let exitCode;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    exitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    services.current = null;
+    process.exitCode = exitCode;
+  });
+
+  async function runProgram(argv) {
+    const program = buildProgram();
+    program.exitOverride();
+    return program.parseAsync(['node', 'cli.js', ...argv]);
+  }
+
+  it('(a) times out a hanging send after the 30s default when no --timeout is given', async () => {
+    // sendTextMessage never resolves -> the only thing that can end the command
+    // is the default timeout.
+    services.current = makeFakeServices({ sendImpl: () => new Promise(() => {}) });
+
+    const done = runProgram(['send', 'text', '--to', '@x', '--message', 'hi']);
+
+    // Let the async work reach the hanging send, then cross the 30s boundary.
+    await vi.advanceTimersByTimeAsync(29000);
+    expect(process.exitCode).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(2000);
+    await done;
+
+    expect(process.exitCode).toBe(1);
+    const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).toContain('Send timed out after 30s');
+    expect(stderrText).toContain('Connecting to Telegram');
+  });
+
+  it('(d) honors an explicit --timeout value', async () => {
+    services.current = makeFakeServices({ sendImpl: () => new Promise(() => {}) });
+
+    const done = runProgram(['send', 'text', '--to', '@x', '--message', 'hi', '--timeout', '1s']);
+
+    await vi.advanceTimersByTimeAsync(1500);
+    await done;
+
+    expect(process.exitCode).toBe(1);
+    const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
+    expect(stderrText).toContain('Send timed out after 1s');
+  });
+
+  it('(c) --timeout 0 disables the timeout (send is unbounded)', async () => {
+    let resolveSend;
+    services.current = makeFakeServices({
+      sendImpl: () => new Promise((resolve) => { resolveSend = resolve; }),
+    });
+
+    const done = runProgram(['send', 'text', '--to', '@x', '--message', 'hi', '--timeout', '0']);
+
+    // Cross well past the default budget: nothing should time out.
+    await vi.advanceTimersByTimeAsync(120000);
+    expect(process.exitCode).toBeUndefined();
+
+    // Now let the send finish and confirm success, not a timeout.
+    resolveSend({ messageId: 7 });
+    await done;
+
+    expect(process.exitCode).toBeUndefined();
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Message sent (7).');
+  });
+
+  it('(b) a long-running command (sync) is NOT bounded by the send default', async () => {
+    // refreshChannelsFromDialogs hangs forever; if the send default leaked into
+    // sync it would reject at 30s. It must not.
+    services.current = makeFakeServices({ refreshImpl: () => new Promise(() => {}) });
+
+    let settled = false;
+    const done = runProgram(['sync', '--once']).then(
+      () => { settled = true; },
+      () => { settled = true; },
+    );
+
+    // Advance to 2x the send default; sync must still be running.
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(settled).toBe(false);
+    expect(process.exitCode).toBeUndefined();
+
+    // Detach the dangling promise so the test runner can exit cleanly.
+    void done;
+  });
+});


### PR DESCRIPTION
## Problem

`tgcli send text|photo|file` without `--timeout` could hang forever on a stuck MTProto connection — the global `--timeout` had no default. Since tgcli's primary users are AI agents and scripts that block on the process, an unbounded send is a silent failure mode (you can retry a failure, not a hang).

Closes #23.

## Changes

- **Scoped default 30s timeout for send commands only** (`send text/photo/file`). Long-running commands (`sync`, `--follow`, `server`, `service`, `auth`, large reads) stay unbounded by default.
  - no `--timeout` → 30s · `--timeout 5m` → honored · `--timeout 0` → disabled (unbounded), preserving existing semantics.
- **Clear timeout error** instead of a generic one: `Send timed out after 30s (no response from Telegram). Pass --timeout <duration> to extend, or --timeout 0 to disable.`
- **`Connecting to Telegram…` status on stderr** so humans and agents see progress while connecting; stdout / `--json` output stays clean.
- **`--quiet` global flag** to suppress that status (errors and primary output are unaffected).
- **FLOOD_WAIT is not misreported as a hang**: in `executeSendWithRetries`, when a Telegram-imposed FLOOD_WAIT exceeds the remaining timeout budget, abort early with a rate-limit message (`Telegram rate-limited this send (FLOOD_WAIT Ns), which exceeds the 30s timeout. Retry later or pass --timeout 0.`) instead of sleeping into a generic timeout. Only triggers when a deadline exists; `--timeout 0` keeps prior behavior.

## Files

- `cli.js` — default-timeout resolution (`resolveSendTimeoutMs`), `Connecting…` status helper, `--quiet` flag, clear timeout message.
- `core/send-utils.js` — budget-aware FLOOD_WAIT early-abort.
- `docs/cli.md`, `SKILL.md` — document the send default, `--timeout 0`, and `--quiet`.
- `tests/send-timeout.test.js` — new coverage.

## Testing

`npm test` → **203 passed / 0 failed** (7 files; 14 new tests). Covers: default applied to send, NOT applied to `sync`, `--timeout 0` disables, explicit value honored, clear timeout message, FLOOD_WAIT over/under budget, and status printed without `--quiet` / suppressed with it. No real network — mocked services + fake timers.

## Out of scope

No default timeout applied to non-send commands or the MCP server; no retry-system refactor.
