### PR TITLE
feat(cli): rename sync→backfill + channels watch/unwatch (#30, PR-1)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -57,10 +57,12 @@ tgcli send file --to @channel --file ./report.pdf --caption "FYI"
 tgcli send text --to @username --message "Hello"
 ```
 
-### Sync & Service
+### Backfill & Service
 ```bash
-tgcli sync --follow
-tgcli sync jobs add --chat @channel --min-date 2024-01-01T00:00:00Z
+tgcli channels watch --chat @channel   # subscribe a chat for archiving (queues a backfill)
+tgcli backfill --follow                 # `sync` remains a silent alias of `backfill`
+tgcli backfill jobs add --chat @channel --min-date 2024-01-01T00:00:00Z
+tgcli channels unwatch --chat @channel  # stop archiving a chat
 tgcli service install
 tgcli service start
 ```
@@ -84,4 +86,5 @@ tgcli channels list --limit 10 --json
 
 - Use `--source live|archive|both` when listing or searching messages.
 - `--json` is best for AI/tooling pipelines.
-- `send` commands time out after `30s` by default so they never hang on a stuck connection. Override with `--timeout 5m` or disable with `--timeout 0`. Long-running commands (`sync`, `--follow`, `server`) are unbounded by default.
+- `send` commands time out after `30s` by default so they never hang on a stuck connection. Override with `--timeout 5m` or disable with `--timeout 0`. Long-running commands (`backfill`, `--follow`, `server`) are unbounded by default.
+- `backfill` is the canonical archive command; `sync` (and `channels sync --enable/--disable`) keep working as aliases. Prefer `channels watch`/`channels unwatch` to subscribe/unsubscribe a chat.

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,7 @@ const CLI_PATH = fileURLToPath(import.meta.url);
 const SERVICE_STATE_FILE = 'service-state.json';
 const LAUNCHD_LABEL = 'com.kfastov.tgcli';
 const SYSTEMD_SERVICE_NAME = 'tgcli';
-const AUTH_SYNC_HINT = 'Run `tgcli sync --once` or `tgcli sync --follow` when you need archive data.';
+const AUTH_SYNC_HINT = 'Run `tgcli backfill --once` or `tgcli backfill --follow` when you need archive data.';
 const CONFIG_SPECS = [
   { key: 'apiId', path: ['apiId'], type: 'number' },
   { key: 'apiHash', path: ['apiHash'], type: 'string', secret: true },
@@ -111,7 +111,15 @@ function buildProgram() {
       runFeedback(globalFlags, messageParts, options),
     ));
 
-  const sync = program.command('sync').description('Archive backfill and realtime sync');
+  // `backfill` is the canonical name; `sync` stays as a silent alias so existing
+  // invocations (and the subcommands below) keep working unchanged. Commander's
+  // `.alias()` makes the alias resolve to the same command tree, so every nested
+  // subcommand (`backfill jobs add`, `backfill status`, ...) is reachable under
+  // both `backfill <...>` and `sync <...>`.
+  const sync = program
+    .command('backfill')
+    .alias('sync')
+    .description('Archive backfill and realtime sync');
   sync
     .option('--once', 'Run once and exit')
     .option('--follow', 'Keep syncing realtime updates')
@@ -195,9 +203,28 @@ function buildProgram() {
     .description('Show channel info')
     .option('--chat <id|username>', 'Channel identifier')
     .action(withGlobalOptions((globalFlags, options) => runChannelsShow(globalFlags, options)));
+  // `watch`/`unwatch` are the canonical per-chat archive subscription commands.
+  // They delegate to the same handler as the legacy `channels sync --enable/--disable`
+  // by pre-setting the enable/disable flag, so `watch` also queues a backfill job
+  // when none exists (parity with the old enable behavior).
   channels
-    .command('sync')
-    .description('Enable or disable sync')
+    .command('watch')
+    .description('Subscribe a chat for archiving (enable sync, queue a backfill)')
+    .option('--chat <id|username>', 'Channel identifier')
+    .action(withGlobalOptions((globalFlags, options) =>
+      runChannelsSync(globalFlags, { ...options, enable: true }),
+    ));
+  channels
+    .command('unwatch')
+    .description('Unsubscribe a chat from archiving (disable sync)')
+    .option('--chat <id|username>', 'Channel identifier')
+    .action(withGlobalOptions((globalFlags, options) =>
+      runChannelsSync(globalFlags, { ...options, disable: true }),
+    ));
+  // Hidden back-compat alias of watch/unwatch via explicit --enable/--disable.
+  channels
+    .command('sync', { hidden: true })
+    .description('Enable or disable sync (alias of watch/unwatch)')
     .option('--chat <id|username>', 'Channel identifier')
     .option('--enable', 'Enable sync')
     .option('--disable', 'Disable sync')
@@ -658,15 +685,14 @@ function printArchiveFallbackNote(channelIds) {
   if (channelIds.length === 1) {
     const id = channelIds[0];
     const message = `${prefix} no archived messages for ${id}. Showing live results. ` +
-      `To archive: tgcli channels sync --chat ${id} --enable; ` +
-      `tgcli sync jobs add --chat ${id}; ` +
-      'tgcli sync --once (or --follow).';
+      `To archive: tgcli channels watch --chat ${id}; ` +
+      'tgcli backfill --once (or --follow).';
     console.log(colorizeNote(message));
     return;
   }
   const message = `${prefix} no archived messages for chats: ${channelIds.join(', ')}. ` +
-    'Showing live results. To archive: tgcli channels sync --chat <id> --enable; ' +
-    'tgcli sync jobs add --chat <id>; tgcli sync --once (or --follow).';
+    'Showing live results. To archive: tgcli channels watch --chat <id>; ' +
+    'tgcli backfill --once (or --follow).';
   console.log(colorizeNote(message));
 }
 
@@ -2443,7 +2469,7 @@ async function runChannelsSync(globalFlags, options = {}) {
             : '';
           console.log(
             `Sync enabled for ${result.channel_id}.${jobMessage} ` +
-              'Run `tgcli sync --once` (or `tgcli sync --follow`/`tgcli server`) to process.',
+              'Run `tgcli backfill --once` (or `tgcli backfill --follow`/`tgcli server`) to process.',
           );
         } else {
           console.log(`Sync disabled for ${result.channel_id}`);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ CLI goal: human-readable output by default with --json for scripting.
 ## Global flags
 - --json
 - --timeout DURATION
-  - No default for most commands (long-running ones like `sync`, `--follow`, and `server` stay unbounded).
+  - No default for most commands (long-running ones like `backfill`, `--follow`, and `server` stay unbounded).
   - `send` commands default to `30s` so agents/scripts never hang on a stuck connection. Override with `--timeout 5m`, or `--timeout 0` to disable.
 - --quiet
   - Suppress informational progress/status output on stderr (e.g. the `Connecting to Telegram…` note from `send`). Errors and primary stdout/`--json` output are unaffected.
@@ -22,14 +22,15 @@ MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP)
 - auth status
 - auth logout
 
-## sync
-- sync
+## backfill
+- backfill (alias: `sync`)
   - Flags: --once | --follow, --idle-exit 30s, --download-media, --refresh-contacts, --refresh-groups
-- sync status
-- sync jobs list [--status] [--limit] [--channel]
-- sync jobs add --chat <id|username> [--min-date ISO] [--depth N]
-- sync jobs retry [--job-id] [--channel] [--all-errors]
-- sync jobs cancel --job-id|--channel
+- backfill status
+- backfill jobs list [--status] [--limit] [--channel]
+- backfill jobs add --chat <id|username> [--min-date ISO] [--depth N]
+- backfill jobs retry [--job-id] [--channel] [--all-errors]
+- backfill jobs cancel --job-id|--channel
+- `sync` remains a silent alias of `backfill` (and every subcommand), so existing `sync …` invocations keep working unchanged.
 
 ## server
 - server
@@ -49,8 +50,11 @@ MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP)
 ## channels
 - channels list [--limit] [--query]
 - channels show --chat <id|username>
-- channels sync --chat <id|username> --enable|--disable
-  - Enabling queues a backfill job; run `tgcli sync --once` or `tgcli sync --follow` to process it.
+- channels watch --chat <id|username>
+  - Subscribe a chat for archiving: enables sync and queues a backfill job; run `tgcli backfill --once` or `tgcli backfill --follow` to process it.
+- channels unwatch --chat <id|username>
+  - Unsubscribe a chat from archiving (disables sync).
+  - `channels sync --chat <id|username> --enable|--disable` remains as a hidden alias of watch/unwatch.
 
 ## topics (forum supergroups)
 - topics list --chat <id|username> [--limit]

--- a/tests/backfill-rename.test.js
+++ b/tests/backfill-rename.test.js
@@ -1,0 +1,172 @@
+// Tests for issue #30 (PR-1): naming/aliasing only.
+//
+// `backfill` is the canonical name for the whole `sync` command tree, with
+// `sync` kept as a silent alias. `channels watch`/`channels unwatch` are the
+// canonical per-chat archive subscription commands, delegating to the same
+// handler as the legacy (now hidden) `channels sync --enable/--disable`.
+//
+// These tests drive the real commander surface from buildProgram() with all
+// service/lock/store seams stubbed, so there is no network, filesystem, or auth
+// side effect. They assert that the new names resolve to the SAME handlers and
+// behavior as the old names.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const services = vi.hoisted(() => ({ current: null }));
+
+vi.mock('../core/services.js', () => ({
+  createServices: vi.fn(() => services.current),
+}));
+
+vi.mock('../store-lock.js', () => ({
+  acquireStoreLock: vi.fn(() => () => {}),
+  acquireReadLock: vi.fn(() => () => {}),
+  readStoreLock: vi.fn(() => ({ exists: false })),
+}));
+
+vi.mock('../core/store.js', () => ({
+  resolveStoreDir: vi.fn(() => '/tmp/tgcli-test-store'),
+}));
+
+const { buildProgram } = await import('../cli.js');
+
+function makeFakeServices(overrides = {}) {
+  const telegramClient = {
+    isAuthorized: vi.fn().mockResolvedValue(true),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+  const messageSyncService = {
+    getQueueStats: vi.fn(() => ({
+      pending: 0,
+      in_progress: 0,
+      idle: 0,
+      error: 0,
+      processing: false,
+    })),
+    listJobs: vi.fn(() => []),
+    addJob: vi.fn((chat) => ({ id: 1, channel_id: chat, status: 'pending' })),
+    setChannelSync: vi.fn((chat, enabled) => ({
+      channel_id: chat,
+      sync_enabled: enabled ? 1 : 0,
+    })),
+    processQueue: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return { telegramClient, messageSyncService };
+}
+
+async function runProgram(argv) {
+  const program = buildProgram();
+  program.exitOverride();
+  return program.parseAsync(['node', 'cli.js', ...argv]);
+}
+
+describe('backfill is a canonical alias of sync', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    services.current = null;
+    vi.clearAllMocks();
+  });
+
+  it('`backfill status` invokes the same handler as `sync status`', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill', 'status']);
+    expect(services.current.messageSyncService.getQueueStats).toHaveBeenCalledTimes(1);
+
+    // Same behavior under the `sync` alias.
+    services.current = makeFakeServices();
+    await runProgram(['sync', 'status']);
+    expect(services.current.messageSyncService.getQueueStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('`backfill status` and `sync status` produce identical output', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill', 'status']);
+    const backfillOut = logSpy.mock.calls.map((c) => c.join(' '));
+
+    logSpy.mockClear();
+    services.current = makeFakeServices();
+    await runProgram(['sync', 'status']);
+    const syncOut = logSpy.mock.calls.map((c) => c.join(' '));
+
+    expect(backfillOut).toEqual(syncOut);
+    expect(backfillOut.join('\n')).toContain('QUEUE:');
+  });
+
+  it('`backfill jobs add` resolves the nested subcommand and queues a job (like `sync jobs add`)', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill', 'jobs', 'add', '--chat', '@chan']);
+    expect(services.current.messageSyncService.addJob).toHaveBeenCalledWith('@chan', {
+      depth: null,
+      minDate: null,
+    });
+
+    services.current = makeFakeServices();
+    await runProgram(['sync', 'jobs', 'add', '--chat', '@chan']);
+    expect(services.current.messageSyncService.addJob).toHaveBeenCalledWith('@chan', {
+      depth: null,
+      minDate: null,
+    });
+  });
+});
+
+describe('channels watch / unwatch', () => {
+  let logSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    services.current = null;
+    vi.clearAllMocks();
+  });
+
+  it('`channels watch --chat X` enables sync and queues a backfill job', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['channels', 'watch', '--chat', '@chan']);
+    const svc = services.current.messageSyncService;
+    expect(svc.setChannelSync).toHaveBeenCalledWith('@chan', true);
+    // Queues a job when none exists (parity with `channels sync --enable`).
+    expect(svc.addJob).toHaveBeenCalledWith('@chan');
+  });
+
+  it('`channels unwatch --chat X` disables sync and queues no job', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['channels', 'unwatch', '--chat', '@chan']);
+    const svc = services.current.messageSyncService;
+    expect(svc.setChannelSync).toHaveBeenCalledWith('@chan', false);
+    expect(svc.addJob).not.toHaveBeenCalled();
+  });
+
+  it('`channels watch` matches legacy `channels sync --enable` behavior', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['channels', 'watch', '--chat', '@chan']);
+    const watchSvc = services.current.messageSyncService;
+
+    services.current = makeFakeServices();
+    await runProgram(['channels', 'sync', '--chat', '@chan', '--enable']);
+    const enableSvc = services.current.messageSyncService;
+
+    expect(watchSvc.setChannelSync.mock.calls).toEqual(enableSvc.setChannelSync.mock.calls);
+    expect(watchSvc.addJob.mock.calls).toEqual(enableSvc.addJob.mock.calls);
+  });
+
+  it('legacy hidden `channels sync --enable/--disable` still works', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['channels', 'sync', '--chat', '@chan', '--enable']);
+    expect(services.current.messageSyncService.setChannelSync).toHaveBeenCalledWith('@chan', true);
+
+    services.current = makeFakeServices();
+    await runProgram(['channels', 'sync', '--chat', '@chan', '--disable']);
+    expect(services.current.messageSyncService.setChannelSync).toHaveBeenCalledWith('@chan', false);
+  });
+});

--- a/tests/cli-auth.test.js
+++ b/tests/cli-auth.test.js
@@ -85,7 +85,7 @@ describe('cli auth command', () => {
     expect(login).toHaveBeenCalledTimes(1);
     expect(createMessageSyncServiceMock).not.toHaveBeenCalled();
     expect(logSpy).toHaveBeenCalledWith(
-      'Authenticated. Run `tgcli sync --once` or `tgcli sync --follow` when you need archive data.',
+      'Authenticated. Run `tgcli backfill --once` or `tgcli backfill --follow` when you need archive data.',
     );
     expect(destroy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
PR-1 of #30 — **naming / discoverability only, zero behavior change.**

## What

- **`backfill` is now the canonical command; `sync` is kept as a silent alias** (commander `.alias('sync')`). Every existing `sync …` invocation and all subcommands (`jobs add/list/retry/cancel`, `status`, flags `--once/--follow/--idle-exit/…`) work unchanged under both names, sharing the same handlers. No deprecation warning.
- **`channels watch` / `channels unwatch`** are the canonical per-chat archive subscription (delegate to the same handler as before: `watch` enables sync **and** queues a backfill job; `unwatch` disables). The legacy `channels sync --enable/--disable` is kept as a **hidden** alias.
- **User-facing hints updated** to the canonical names (`tgcli backfill …`, `tgcli channels watch …`).
- Docs (`docs/cli.md`, `SKILL.md`) present the new names as primary, noting the old ones remain as aliases.

## Why

`sync` is ambiguous and collides with `channels sync`. AI agents (the primary users) discover commands via `--help` and need self-documenting names: `backfill` = "download/index history", `watch` = "keep this chat archived".

## Scope — what's NOT here (it's PR-2)

This PR is naming/aliasing only: **no engine, DB, or `--json`-shape changes.** The server-executed backfill model lands next: `backfill --chat X` foreground / `--background`, `backfill status` / `count` / `wait` / `cancel`, live progress, and auto-start-with-idle-exit. So this PR is **part of #30, not a full close.**

## Tests

`npm test` → **224 passing** (217 baseline + 7 new in `tests/backfill-rename.test.js`). Covers: `backfill` resolves identically to `sync` for the action and subcommands; `channels watch/unwatch` call `setChannelSync(true/false)` and `watch` queues a job; legacy `channels sync --enable/--disable` still works. No real network — mocked services.
