### PR TITLE
feat(server): loopback control API + per-batch progress + idle-exit (#30, PR-2a)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,6 +21,7 @@ import {
   SendCommandError,
 } from './core/send-utils.js';
 import { resolveStoreDir } from './core/store.js';
+import { parseDuration } from './core/duration.js';
 
 const CLI_PATH = fileURLToPath(import.meta.url);
 const SERVICE_STATE_FILE = 'service-state.json';
@@ -698,24 +699,6 @@ function printArchiveFallbackNote(channelIds) {
     'Showing live results. To archive: tgcli channels watch --chat <id>; ' +
     'tgcli backfill --once (or --follow).';
   console.log(colorizeNote(message));
-}
-
-function parseDuration(value) {
-  if (typeof value !== 'string' || !value.trim()) {
-    return null;
-  }
-  const raw = value.trim();
-  const match = raw.match(/^(\d+)(ms|s|m|h)?$/i);
-  if (!match) {
-    throw new Error(`Invalid duration: ${value}`);
-  }
-  const amount = Number(match[1]);
-  const unit = (match[2] || 's').toLowerCase();
-  if (unit === 'ms') return amount;
-  if (unit === 's') return amount * 1000;
-  if (unit === 'm') return amount * 60 * 1000;
-  if (unit === 'h') return amount * 60 * 60 * 1000;
-  return amount * 1000;
 }
 
 // Resolve the effective timeout for a send command.

--- a/cli.js
+++ b/cli.js
@@ -35,6 +35,9 @@ const CONFIG_SPECS = [
   { key: 'mcp.enabled', path: ['mcp', 'enabled'], type: 'boolean' },
   { key: 'mcp.host', path: ['mcp', 'host'], type: 'string' },
   { key: 'mcp.port', path: ['mcp', 'port'], type: 'number' },
+  { key: 'control.enabled', path: ['control', 'enabled'], type: 'boolean' },
+  { key: 'control.host', path: ['control', 'host'], type: 'string' },
+  { key: 'control.port', path: ['control', 'port'], type: 'number' },
 ];
 
 const SEND_PARSE_MODES = ['markdown', 'html', 'none'];
@@ -161,7 +164,8 @@ function buildProgram() {
   program
     .command('server')
     .description('Run background sync service (MCP optional)')
-    .action(withGlobalOptions((globalFlags) => runServer(globalFlags)));
+    .option('--idle-exit <duration>', 'Exit after this idle period with no jobs or watched channels')
+    .action(withGlobalOptions((globalFlags, options) => runServer(globalFlags, options)));
 
   const service = program.command('service').description('Manage background service');
   service
@@ -1762,8 +1766,11 @@ async function runSync(globalFlags, options = {}) {
   }, timeoutMs);
 }
 
-async function runServer(globalFlags) {
+async function runServer(globalFlags, options = {}) {
   const timeoutMs = globalFlags.timeoutMs;
+  // When no --idle-exit is passed the server stays up forever (manual server is
+  // always-on). Validate the duration here so a bad value fails fast in the CLI.
+  const idleExitMs = options.idleExit ? parseDuration(options.idleExit) : null;
   let child = null;
 
   const runChild = () => new Promise((resolve, reject) => {
@@ -1781,7 +1788,12 @@ async function runServer(globalFlags) {
     process.on('SIGINT', handleSignal);
     process.on('SIGTERM', handleSignal);
 
-    child = spawn(process.execPath, [serverPath], {
+    const childArgs = [serverPath];
+    if (Number.isFinite(idleExitMs) && idleExitMs > 0) {
+      childArgs.push('--idle-exit', String(idleExitMs));
+    }
+
+    child = spawn(process.execPath, childArgs, {
       stdio: 'inherit',
       env: process.env,
     });

--- a/core/config.js
+++ b/core/config.js
@@ -42,6 +42,7 @@ export function normalizeConfig(raw = {}) {
   const apiHash = normalizeValue(raw.apiHash ?? raw.api_hash);
   const phoneNumber = normalizeValue(raw.phoneNumber ?? raw.phone ?? raw.phone_number);
   const mcpRaw = raw.mcp && typeof raw.mcp === 'object' ? raw.mcp : {};
+  const controlRaw = raw.control && typeof raw.control === 'object' ? raw.control : {};
   const feedbackRaw = raw.feedback && typeof raw.feedback === 'object' ? raw.feedback : {};
   const mcpEnabled = normalizeBoolean(raw.mcpEnabled ?? raw.mcp_enabled ?? mcpRaw.enabled, false);
   const mcp = {
@@ -56,6 +57,19 @@ export function normalizeConfig(raw = {}) {
   if (Number.isFinite(mcpPort) && mcpPort > 0) {
     mcp.port = mcpPort;
   }
+  // Loopback control API: always-on (default enabled) and independent of mcp.*.
+  const controlEnabled = normalizeBoolean(
+    raw.controlEnabled ?? raw.control_enabled ?? controlRaw.enabled,
+    true,
+  );
+  const control = {
+    enabled: controlEnabled,
+  };
+  const controlHost = normalizeValue(controlRaw.host ?? raw.controlHost ?? raw.control_host);
+  control.host = controlHost || '127.0.0.1';
+  const controlPortRaw = controlRaw.port ?? raw.controlPort ?? raw.control_port;
+  const controlPort = Number(controlPortRaw);
+  control.port = Number.isFinite(controlPort) && controlPort > 0 ? controlPort : 8765;
   const feedbackChatId = normalizeValue(
     feedbackRaw.chatId ?? raw.feedbackChatId ?? raw.feedback_chat_id,
   );
@@ -64,6 +78,7 @@ export function normalizeConfig(raw = {}) {
     apiHash,
     phoneNumber,
     mcp,
+    control,
   };
   if (feedbackChatId) {
     normalized.feedback = { chatId: feedbackChatId };

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -1,0 +1,184 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+export const CONTROL_FILE = 'control.json';
+export const CONTROL_TOKEN_HEADER = 'x-tgcli-control-token';
+
+// Generate a fresh control secret. Loopback binding plus this token are the two
+// layers guarding the always-on control API.
+export function generateControlToken() {
+  return crypto.randomBytes(24).toString('hex');
+}
+
+// Write <store>/control.json with mode 0600 so only the owner can read the token.
+// Returns the descriptor written so callers can hold onto it.
+export function writeControlFile(storeDir, descriptor) {
+  fs.mkdirSync(storeDir, { recursive: true });
+  const filePath = path.join(storeDir, CONTROL_FILE);
+  fs.writeFileSync(filePath, `${JSON.stringify(descriptor, null, 2)}\n`, { mode: 0o600 });
+  // writeFileSync only applies mode on create; chmod guards the overwrite case.
+  fs.chmodSync(filePath, 0o600);
+  return descriptor;
+}
+
+export function removeControlFile(storeDir) {
+  const filePath = path.join(storeDir, CONTROL_FILE);
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+// Pure idle predicate, shared by the server idle monitor and its unit tests.
+// Idle = no queued/in-flight jobs AND no watched channels AND control API has
+// been quiet longer than the configured window.
+export function isIdle({ jobCounts, watchedCount, lastActivityAt, now, idleExitMs }) {
+  if (!Number.isFinite(idleExitMs) || idleExitMs <= 0) {
+    return false;
+  }
+  const pending = jobCounts?.pending ?? 0;
+  const inProgress = jobCounts?.inProgress ?? 0;
+  if (pending > 0 || inProgress > 0) {
+    return false;
+  }
+  if ((watchedCount ?? 0) > 0) {
+    return false;
+  }
+  return now - lastActivityAt > idleExitMs;
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req
+      .on('data', (chunk) => chunks.push(chunk))
+      .on('end', () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve(raw.length ? JSON.parse(raw) : {});
+        } catch (error) {
+          reject(error);
+        }
+      })
+      .on('error', (error) => reject(error));
+  });
+}
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json' }).end(JSON.stringify(payload));
+}
+
+/**
+ * Builds the request handler for the loopback control API. Every endpoint
+ * delegates to the same MessageSyncService methods the MCP tools use, so there
+ * is no duplicated job logic. The returned handler is meant to back a dedicated
+ * http.Server bound to loopback.
+ *
+ * @param {object} deps
+ * @param {object} deps.service       MessageSyncService (or compatible stub).
+ * @param {string} deps.token         Secret required in the control token header.
+ * @param {number} deps.pid           Server process id.
+ * @param {string} deps.version       Server version string.
+ * @param {string} deps.startedAt     ISO timestamp the server started.
+ * @param {Function} [deps.onActivity] Called on every authed request (idle reset).
+ * @param {Function} [deps.ensureLogin] Optional async hook run before enqueue.
+ */
+export function createControlRequestHandler({
+  service,
+  token,
+  pid,
+  version,
+  startedAt,
+  onActivity,
+  ensureLogin,
+}) {
+  return async function handleControlRequest(req, res) {
+    let url;
+    try {
+      url = new URL(req.url ?? '', 'http://127.0.0.1');
+    } catch (error) {
+      sendJson(res, 400, { error: 'Bad request' });
+      return;
+    }
+
+    if (!url.pathname.startsWith('/control/')) {
+      sendJson(res, 404, { error: 'Not found' });
+      return;
+    }
+
+    const provided = req.headers[CONTROL_TOKEN_HEADER];
+    if (!provided || provided !== token) {
+      sendJson(res, 401, { error: 'Unauthorized' });
+      return;
+    }
+
+    if (typeof onActivity === 'function') {
+      onActivity();
+    }
+
+    try {
+      if (req.method === 'GET' && url.pathname === '/control/ping') {
+        sendJson(res, 200, {
+          ok: true,
+          pid,
+          version,
+          startedAt,
+          jobs: service.getJobCounts(),
+        });
+        return;
+      }
+
+      if (req.method === 'POST' && url.pathname === '/control/backfill') {
+        const body = await readJsonBody(req);
+        const chatId = body?.chatId;
+        if (chatId === undefined || chatId === null || String(chatId).trim() === '') {
+          sendJson(res, 400, { error: 'chatId is required' });
+          return;
+        }
+        if (typeof ensureLogin === 'function') {
+          await ensureLogin();
+        }
+        // Same path as the scheduleMessageSync MCP tool: enqueue then kick the
+        // queue so processing starts without waiting for the next trigger.
+        const job = service.addJob(chatId, { depth: body?.depth, minDate: body?.minDate });
+        void service.processQueue();
+        sendJson(res, 200, {
+          jobId: job?.id ?? null,
+          channelId: job?.channel_id ?? null,
+          status: job?.status ?? null,
+        });
+        return;
+      }
+
+      if (req.method === 'POST' && url.pathname === '/control/cancel') {
+        const body = await readJsonBody(req);
+        const chatId = body?.chatId;
+        const jobId = body?.jobId;
+        if (
+          (chatId === undefined || chatId === null || String(chatId).trim() === '') &&
+          (jobId === undefined || jobId === null)
+        ) {
+          sendJson(res, 400, { error: 'Provide chatId or jobId' });
+          return;
+        }
+        // Same logic as `sync jobs cancel`.
+        const result = service.cancelJobs({ channelId: chatId, jobId });
+        sendJson(res, 200, {
+          canceled: result.canceled,
+          jobIds: result.jobIds,
+        });
+        return;
+      }
+
+      sendJson(res, 404, { error: 'Not found' });
+    } catch (error) {
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: error?.message ?? 'Internal error' });
+      }
+    }
+  };
+}

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 
+import { readJsonBody, sendJson } from './http-util.js';
+
 export const CONTROL_FILE = 'control.json';
 export const CONTROL_TOKEN_HEADER = 'x-tgcli-control-token';
 
@@ -49,27 +51,6 @@ export function isIdle({ jobCounts, watchedCount, lastActivityAt, now, idleExitM
     return false;
   }
   return now - lastActivityAt > idleExitMs;
-}
-
-function readJsonBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    req
-      .on('data', (chunk) => chunks.push(chunk))
-      .on('end', () => {
-        try {
-          const raw = Buffer.concat(chunks).toString('utf8');
-          resolve(raw.length ? JSON.parse(raw) : {});
-        } catch (error) {
-          reject(error);
-        }
-      })
-      .on('error', (error) => reject(error));
-  });
-}
-
-function sendJson(res, status, payload) {
-  res.writeHead(status, { 'Content-Type': 'application/json' }).end(JSON.stringify(payload));
 }
 
 /**

--- a/core/duration.js
+++ b/core/duration.js
@@ -1,0 +1,24 @@
+// Shared duration parser used by the CLI (cli.js) and the background server
+// (mcp-server.js). Returns the duration in milliseconds.
+//
+// Accepts a string with an optional unit suffix: ms | s | m | h. A bare number
+// is interpreted as SECONDS (e.g. "30" -> 30000), matching long-standing CLI
+// behavior. Returns null for empty/non-string input; throws on an unparseable
+// value.
+export function parseDuration(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return null;
+  }
+  const raw = value.trim();
+  const match = raw.match(/^(\d+)(ms|s|m|h)?$/i);
+  if (!match) {
+    throw new Error(`Invalid duration: ${value}`);
+  }
+  const amount = Number(match[1]);
+  const unit = (match[2] || 's').toLowerCase();
+  if (unit === 'ms') return amount;
+  if (unit === 's') return amount * 1000;
+  if (unit === 'm') return amount * 60 * 1000;
+  if (unit === 'h') return amount * 60 * 60 * 1000;
+  return amount * 1000;
+}

--- a/core/http-util.js
+++ b/core/http-util.js
@@ -1,0 +1,27 @@
+// Small shared helpers for the loopback control listener (core/control-server.js)
+// and the MCP HTTP listener (mcp-server.js). Both read a JSON request body the
+// same way; keep one implementation so they cannot drift.
+
+// Reads the full request body and parses it as JSON. Resolves to {} for an
+// empty body; rejects on invalid JSON.
+export function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req
+      .on('data', (chunk) => chunks.push(chunk))
+      .on('end', () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf8');
+          resolve(raw.length ? JSON.parse(raw) : {});
+        } catch (error) {
+          reject(error);
+        }
+      })
+      .on('error', (error) => reject(error));
+  });
+}
+
+// Writes a JSON response with the given status code.
+export function sendJson(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json' }).end(JSON.stringify(payload));
+}

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -17,6 +17,8 @@ import {
   removeControlFile,
   isIdle,
 } from "./core/control-server.js";
+import { readJsonBody } from "./core/http-util.js";
+import { parseDuration } from "./core/duration.js";
 
 const SERVICE_STATE_FILE = "service-state.json";
 
@@ -43,9 +45,9 @@ const controlPortRaw = Number(controlConfig.port ?? 8765);
 const CONTROL_PORT = Number.isFinite(controlPortRaw) && controlPortRaw > 0 ? controlPortRaw : 8765;
 
 // Idle-exit window (ms). Plumbed from the CLI `server --idle-exit <duration>`
-// via argv (`--idle-exit <ms|duration>`) or the TGCLI_IDLE_EXIT env var. When
-// unset/zero the server stays up forever.
-const IDLE_EXIT_MS = parseIdleExitMs(readIdleExitArg());
+// via argv or the TGCLI_IDLE_EXIT env var. When unset/zero the server stays up
+// forever. See resolveIdleExitMs for the ms-vs-duration-string handling.
+const IDLE_EXIT_MS = resolveIdleExitMs(readIdleExitArg());
 const IDLE_CHECK_INTERVAL_MS = 5000;
 
 const { telegramClient, messageSyncService } = createServices({ storeDir, config });
@@ -70,24 +72,27 @@ function readIdleExitArg() {
   return process.env.TGCLI_IDLE_EXIT ?? null;
 }
 
-// Accepts a plain millisecond number or a duration string (e.g. "60s", "5m").
-// Mirrors the CLI parseDuration units so either form works over argv/env.
-function parseIdleExitMs(value) {
+// Resolve the idle-exit window to milliseconds. The CLI forwards `--idle-exit`
+// as a plain integer of milliseconds (it has already parsed the user's duration
+// via parseDuration), so a bare integer here is treated AS-IS as ms. A value
+// carrying a unit suffix (e.g. "60s", "5m" from TGCLI_IDLE_EXIT) is parsed with
+// the shared parseDuration (where a bare number would mean seconds, but that
+// branch never applies here because bare integers are short-circuited above).
+// This explicit split avoids the previous accidental divergence where the same
+// bare number meant seconds in the CLI but milliseconds in the server.
+function resolveIdleExitMs(value) {
   if (value === null || value === undefined || value === "") {
     return 0;
   }
   const raw = String(value).trim();
-  const match = raw.match(/^(\d+)(ms|s|m|h)?$/i);
-  if (!match) {
+  if (/^\d+$/.test(raw)) {
+    return Number(raw);
+  }
+  try {
+    return parseDuration(raw) ?? 0;
+  } catch (error) {
     return 0;
   }
-  const amount = Number(match[1]);
-  const unit = (match[2] || "ms").toLowerCase();
-  if (unit === "ms") return amount;
-  if (unit === "s") return amount * 1000;
-  if (unit === "m") return amount * 60 * 1000;
-  if (unit === "h") return amount * 60 * 60 * 1000;
-  return amount;
 }
 
 function readVersion() {
@@ -1871,25 +1876,8 @@ async function ensureSession(req, res, body) {
   return record;
 }
 
-function readBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    req
-      .on("data", (chunk) => chunks.push(chunk))
-      .on("end", () => {
-        try {
-          const raw = Buffer.concat(chunks).toString("utf8");
-          resolve(raw.length ? JSON.parse(raw) : {});
-        } catch (error) {
-          reject(error);
-        }
-      })
-      .on("error", (error) => reject(error));
-  });
-}
-
 async function handlePost(req, res) {
-  const body = await readBody(req);
+  const body = await readJsonBody(req);
   const sessionRecord = await ensureSession(req, res, body);
   if (!sessionRecord) {
     return;

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -10,6 +10,13 @@ import { z } from "zod";
 import { loadConfig, validateConfig } from "./core/config.js";
 import { createServices } from "./core/services.js";
 import { resolveStoreDir } from "./core/store.js";
+import {
+  createControlRequestHandler,
+  generateControlToken,
+  writeControlFile,
+  removeControlFile,
+  isIdle,
+} from "./core/control-server.js";
 
 const SERVICE_STATE_FILE = "service-state.json";
 
@@ -26,10 +33,62 @@ const resolvedHost = mcpConfig.host ?? process.env.MCP_HOST ?? process.env.FASTM
 const resolvedPort = Number(mcpConfig.port ?? process.env.MCP_PORT ?? process.env.FASTMCP_PORT ?? "8080");
 const HOST = resolvedHost;
 const PORT = Number.isFinite(resolvedPort) && resolvedPort > 0 ? resolvedPort : 8080;
+
+// Always-on loopback control API. Separate listener from MCP and not gated by
+// mcp.enabled; bound to loopback only.
+const controlConfig = config?.control ?? {};
+const controlEnabled = controlConfig.enabled !== false;
+const CONTROL_HOST = controlConfig.host ?? "127.0.0.1";
+const controlPortRaw = Number(controlConfig.port ?? 8765);
+const CONTROL_PORT = Number.isFinite(controlPortRaw) && controlPortRaw > 0 ? controlPortRaw : 8765;
+
+// Idle-exit window (ms). Plumbed from the CLI `server --idle-exit <duration>`
+// via argv (`--idle-exit <ms|duration>`) or the TGCLI_IDLE_EXIT env var. When
+// unset/zero the server stays up forever.
+const IDLE_EXIT_MS = parseIdleExitMs(readIdleExitArg());
+const IDLE_CHECK_INTERVAL_MS = 5000;
+
 const { telegramClient, messageSyncService } = createServices({ storeDir, config });
 
 let telegramReady = false;
 let serviceState = null;
+let controlToken = null;
+let controlServer = null;
+let idleTimer = null;
+let lastControlActivityAt = Date.now();
+
+function readIdleExitArg() {
+  const args = process.argv.slice(2);
+  const flagIndex = args.indexOf("--idle-exit");
+  if (flagIndex !== -1 && args[flagIndex + 1]) {
+    return args[flagIndex + 1];
+  }
+  const inline = args.find((arg) => arg.startsWith("--idle-exit="));
+  if (inline) {
+    return inline.slice("--idle-exit=".length);
+  }
+  return process.env.TGCLI_IDLE_EXIT ?? null;
+}
+
+// Accepts a plain millisecond number or a duration string (e.g. "60s", "5m").
+// Mirrors the CLI parseDuration units so either form works over argv/env.
+function parseIdleExitMs(value) {
+  if (value === null || value === undefined || value === "") {
+    return 0;
+  }
+  const raw = String(value).trim();
+  const match = raw.match(/^(\d+)(ms|s|m|h)?$/i);
+  if (!match) {
+    return 0;
+  }
+  const amount = Number(match[1]);
+  const unit = (match[2] || "ms").toLowerCase();
+  if (unit === "ms") return amount;
+  if (unit === "s") return amount * 1000;
+  if (unit === "m") return amount * 60 * 1000;
+  if (unit === "h") return amount * 60 * 60 * 1000;
+  return amount;
+}
 
 function readVersion() {
   try {
@@ -1993,6 +2052,81 @@ if (mcpEnabled) {
   console.log("[startup] MCP disabled; running sync-only service.");
 }
 
+// --- Always-on loopback control API (independent of mcp.enabled) ---
+if (controlEnabled) {
+  controlToken = generateControlToken();
+  const startedAt = serviceState.startedAt;
+  const handleControlRequest = createControlRequestHandler({
+    service: messageSyncService,
+    token: controlToken,
+    pid: process.pid,
+    version: serviceState.version,
+    startedAt,
+    onActivity: () => {
+      lastControlActivityAt = Date.now();
+    },
+    ensureLogin: () => telegramClient.ensureLogin(),
+  });
+
+  controlServer = http.createServer((req, res) => {
+    if (req.method === "OPTIONS") {
+      res.writeHead(204).end();
+      return;
+    }
+    void handleControlRequest(req, res);
+  });
+
+  controlServer.on("error", (error) => {
+    console.error(`[control] server error: ${error.message}`);
+  });
+
+  controlServer.listen(CONTROL_PORT, CONTROL_HOST, () => {
+    const address = controlServer.address();
+    const boundPort = typeof address === "object" && address ? address.port : CONTROL_PORT;
+    try {
+      writeControlFile(storeDir, {
+        pid: process.pid,
+        port: boundPort,
+        token: controlToken,
+        startedAt,
+        version: serviceState.version,
+      });
+    } catch (error) {
+      console.error(`[control] failed to write control.json: ${error?.message ?? error}`);
+    }
+    console.log(`[startup] control API listening on http://${CONTROL_HOST}:${boundPort}/control`);
+  });
+
+  updateServiceState({
+    controlEnabled: true,
+    controlHost: CONTROL_HOST,
+    controlPort: CONTROL_PORT,
+  });
+}
+
+// --- Idle-exit monitor (active only when --idle-exit is configured) ---
+if (IDLE_EXIT_MS > 0) {
+  idleTimer = setInterval(() => {
+    if (shuttingDown) {
+      return;
+    }
+    const idle = isIdle({
+      jobCounts: messageSyncService.getJobCounts(),
+      watchedCount: messageSyncService.getWatchedChannelCount(),
+      lastActivityAt: lastControlActivityAt,
+      now: Date.now(),
+      idleExitMs: IDLE_EXIT_MS,
+    });
+    if (idle) {
+      console.log("[shutdown] idle window elapsed with no work; exiting.");
+      void shutdown().finally(() => process.exit(0));
+    }
+  }, IDLE_CHECK_INTERVAL_MS);
+  if (typeof idleTimer.unref === "function") {
+    idleTimer.unref();
+  }
+}
+
 async function shutdown() {
   if (shuttingDown) {
     return;
@@ -2014,6 +2148,27 @@ async function shutdown() {
     httpServer.close(() => {
       console.log("[shutdown] HTTP server closed");
     });
+  }
+
+  if (idleTimer) {
+    clearInterval(idleTimer);
+    idleTimer = null;
+  }
+
+  if (controlServer) {
+    controlServer.closeAllConnections?.();
+    controlServer.close(() => {
+      console.log("[shutdown] control server closed");
+    });
+    controlServer = null;
+  }
+
+  if (controlEnabled) {
+    try {
+      removeControlFile(storeDir);
+    } catch (error) {
+      console.error(`[shutdown] failed to remove control.json: ${error?.message ?? error}`);
+    }
   }
 
   try {

--- a/message-sync-service.js
+++ b/message-sync-service.js
@@ -630,6 +630,7 @@ export default class MessageSyncService {
     this._ensureJobColumn('cursor_message_id', 'INTEGER');
     this._ensureJobColumn('cursor_message_date', 'TEXT');
     this._ensureJobColumn('backfill_min_date', 'TEXT');
+    this._ensureJobColumn('started_at', 'TEXT');
 
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS users (
@@ -1971,6 +1972,28 @@ export default class MessageSyncService {
     return { canceled: ids.length, jobIds: ids };
   }
 
+  // Compact job-count snapshot for the control API (`/control/ping`) and the
+  // server idle monitor. `inProgress` includes pending+in_progress because a
+  // pending job still represents queued work the server must stay up for.
+  getJobCounts() {
+    const stats = this.getQueueStats();
+    return {
+      pending: stats.pending,
+      inProgress: stats.in_progress,
+    };
+  }
+
+  // Number of channels with realtime watch enabled. Used by the idle monitor:
+  // a server watching any channel must stay up to receive realtime updates.
+  getWatchedChannelCount() {
+    const row = this.db.prepare(`
+      SELECT COUNT(*) AS cnt
+      FROM channels
+      WHERE sync_enabled = 1
+    `).get();
+    return row?.cnt ?? 0;
+  }
+
   getQueueStats() {
     const rows = this.db.prepare(`
       SELECT status, COUNT(*) AS count
@@ -2773,6 +2796,27 @@ export default class MessageSyncService {
     );
   }
 
+  // Lightweight per-batch progress write used while a backfill run is mid-flight.
+  // Keeps `message_count`/cursor/`updated_at` live (and stamps `started_at` on the
+  // first batch) without touching status, so the control API and idle monitor can
+  // observe progress between terminal updates.
+  _updateJobProgress(id, { messageCount, cursorMessageId, cursorMessageDate }) {
+    this.db.prepare(`
+      UPDATE jobs
+      SET message_count = ?,
+          cursor_message_id = ?,
+          cursor_message_date = ?,
+          started_at = COALESCE(started_at, CURRENT_TIMESTAMP),
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `).run(
+      messageCount ?? 0,
+      cursorMessageId ?? null,
+      cursorMessageDate ?? null,
+      id,
+    );
+  }
+
   _markJobError(id, error) {
     this.db.prepare(`
       UPDATE jobs
@@ -3507,6 +3551,17 @@ export default class MessageSyncService {
         currentOldestId = lowestIdInChunk;
         currentOldestDate = lowestDateInChunk || currentOldestDate;
       }
+
+      // Persist live progress after every batch so the control API and idle
+      // monitor see the archived count and resume cursor advance mid-run, not
+      // just on terminal completion. `started_at` is stamped on the first batch.
+      this._updateJobProgress(job.id, {
+        messageCount: this._countMessages(channelId),
+        cursorMessageId: nextOffsetId ?? null,
+        cursorMessageDate: Number.isFinite(nextOffsetDate) && nextOffsetDate > 0
+          ? toIsoString(nextOffsetDate)
+          : null,
+      });
 
       if (nextOffsetId === previousOffsetId && (nextOffsetDate ?? 0) === previousOffsetDate) {
         break;

--- a/message-sync-service.js
+++ b/message-sync-service.js
@@ -1972,15 +1972,12 @@ export default class MessageSyncService {
     return { canceled: ids.length, jobIds: ids };
   }
 
-  // Compact job-count snapshot for the control API (`/control/ping`) and the
-  // server idle monitor. `inProgress` includes pending+in_progress because a
-  // pending job still represents queued work the server must stay up for.
+  // Compact `{ pending, inProgress }` snapshot for the control API
+  // (`/control/ping`) and the idle monitor. A trivial re-key of getQueueStats()
+  // that keeps callers (and their service stubs) off the snake_case queue shape.
   getJobCounts() {
-    const stats = this.getQueueStats();
-    return {
-      pending: stats.pending,
-      inProgress: stats.in_progress,
-    };
+    const { pending, in_progress: inProgress } = this.getQueueStats();
+    return { pending, inProgress };
   }
 
   // Number of channels with realtime watch enabled. Used by the idle monitor:

--- a/tests/backfill-progress.test.js
+++ b/tests/backfill-progress.test.js
@@ -1,0 +1,175 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import MessageSyncService from '../message-sync-service.js';
+
+const CHANNEL_ID = '1001';
+
+// Build a fake telegram client whose iterHistory yields a fresh batch of
+// messages each call (older message IDs each time), so _backfillHistory makes
+// several passes and we can observe per-batch progress.
+function makeFakeClient(batches) {
+  let call = 0;
+  return {
+    client: {
+      resolvePeer: async () => ({ id: Number(CHANNEL_ID) }),
+      iterHistory() {
+        const batch = batches[call] ?? [];
+        call += 1;
+        return (async function* () {
+          for (const message of batch) {
+            yield message;
+          }
+        })();
+      },
+    },
+    // _backfillHistory serializes each yielded message through the client.
+    _serializeMessage(message) {
+      return {
+        id: message.id,
+        date: message.date,
+        from_id: message.from_id ?? null,
+        text: message.text ?? `msg ${message.id}`,
+      };
+    },
+  };
+}
+
+function buildBatch(startId, count, baseDate) {
+  const batch = [];
+  for (let i = 0; i < count; i += 1) {
+    const id = startId - i;
+    batch.push({ id, date: baseDate - id, text: `message ${id}` });
+  }
+  return batch;
+}
+
+describe('per-batch backfill progress persistence', () => {
+  let storeDir;
+  let service;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-progress-test-'));
+  });
+
+  afterEach(async () => {
+    if (service?.db?.open) {
+      service.db.close();
+    }
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('adds a started_at column to the jobs table', () => {
+    service = new MessageSyncService(makeFakeClient([]), {
+      dbPath: path.join(storeDir, 'messages.db'),
+      batchSize: 5,
+      interJobDelayMs: 0,
+      interBatchDelayMs: 0,
+    });
+    const columns = service.db.prepare('PRAGMA table_info(jobs)').all().map((c) => c.name);
+    expect(columns).toContain('started_at');
+  });
+
+  it('advances message_count, updated_at, and started_at every batch', async () => {
+    const baseDate = 2_000_000;
+    // 3 batches of 5 messages each, descending IDs.
+    const batches = [
+      buildBatch(100, 5, baseDate),
+      buildBatch(95, 5, baseDate),
+      buildBatch(90, 5, baseDate),
+    ];
+
+    service = new MessageSyncService(makeFakeClient(batches), {
+      dbPath: path.join(storeDir, 'messages.db'),
+      batchSize: 5,
+      interJobDelayMs: 0,
+      interBatchDelayMs: 0,
+    });
+
+    // Seed the channel row so _getChannel / cursor updates work.
+    service.db.prepare(`
+      INSERT INTO channels (channel_id, sync_enabled, last_message_id, updated_at)
+      VALUES (?, 1, 200, CURRENT_TIMESTAMP)
+    `).run(CHANNEL_ID);
+
+    const job = service.addJob(CHANNEL_ID, { depth: 15 });
+    expect(job.message_count).toBe(0);
+
+    const snapshots = [];
+    const original = service._updateJobProgress.bind(service);
+    // Capture the persisted job row right after each per-batch progress write.
+    service._updateJobProgress = (id, payload) => {
+      original(id, payload);
+      const row = service.db.prepare('SELECT message_count, updated_at, started_at FROM jobs WHERE id = ?').get(id);
+      snapshots.push(row);
+    };
+
+    const result = await service._backfillHistory(job, 0, 15);
+
+    // Three batches => three progress writes.
+    expect(snapshots.length).toBe(3);
+
+    // message_count is live and strictly increases across batches.
+    expect(snapshots[0].message_count).toBe(5);
+    expect(snapshots[1].message_count).toBe(10);
+    expect(snapshots[2].message_count).toBe(15);
+
+    // started_at is stamped on the first batch and stays set thereafter.
+    expect(snapshots[0].started_at).toBeTruthy();
+    expect(snapshots[1].started_at).toBe(snapshots[0].started_at);
+
+    // The final terminal count matches.
+    expect(result.finalCount).toBe(15);
+
+    // The persisted job row reflects the last live progress write.
+    const finalRow = service.db.prepare('SELECT message_count, started_at FROM jobs WHERE id = ?').get(job.id);
+    expect(finalRow.message_count).toBe(15);
+    expect(finalRow.started_at).toBeTruthy();
+  });
+});
+
+describe('job-count and watched-channel helpers', () => {
+  let storeDir;
+  let service;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-counts-test-'));
+    service = new MessageSyncService(makeFakeClient([]), {
+      dbPath: path.join(storeDir, 'messages.db'),
+      batchSize: 5,
+      interJobDelayMs: 0,
+      interBatchDelayMs: 0,
+    });
+  });
+
+  afterEach(() => {
+    if (service?.db?.open) {
+      service.db.close();
+    }
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('getJobCounts reports pending and inProgress', () => {
+    expect(service.getJobCounts()).toEqual({ pending: 0, inProgress: 0 });
+
+    service.db.prepare(`
+      INSERT INTO channels (channel_id, sync_enabled, updated_at) VALUES ('5', 1, CURRENT_TIMESTAMP)
+    `).run();
+    service.addJob('5');
+    expect(service.getJobCounts()).toEqual({ pending: 1, inProgress: 0 });
+  });
+
+  it('getWatchedChannelCount counts channels with sync_enabled = 1', () => {
+    expect(service.getWatchedChannelCount()).toBe(0);
+
+    service.db.prepare(`
+      INSERT INTO channels (channel_id, sync_enabled, updated_at) VALUES ('5', 1, CURRENT_TIMESTAMP)
+    `).run();
+    service.db.prepare(`
+      INSERT INTO channels (channel_id, sync_enabled, updated_at) VALUES ('6', 0, CURRENT_TIMESTAMP)
+    `).run();
+    expect(service.getWatchedChannelCount()).toBe(1);
+  });
+});

--- a/tests/config-control.test.js
+++ b/tests/config-control.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeConfig } from '../core/config.js';
+
+describe('control config normalization', () => {
+  it('defaults control to enabled on loopback:8765', () => {
+    const { control } = normalizeConfig({});
+    expect(control).toEqual({ enabled: true, host: '127.0.0.1', port: 8765 });
+  });
+
+  it('honors explicit control overrides', () => {
+    const { control } = normalizeConfig({
+      control: { enabled: false, host: '127.0.0.1', port: 9000 },
+    });
+    expect(control).toEqual({ enabled: false, host: '127.0.0.1', port: 9000 });
+  });
+
+  it('accepts flat controlEnabled/controlHost/controlPort keys', () => {
+    const { control } = normalizeConfig({
+      controlEnabled: 'false',
+      controlHost: '127.0.0.1',
+      controlPort: '7000',
+    });
+    expect(control).toEqual({ enabled: false, host: '127.0.0.1', port: 7000 });
+  });
+
+  it('falls back to defaults for invalid port and missing host', () => {
+    const { control } = normalizeConfig({ control: { port: 'not-a-number' } });
+    expect(control.host).toBe('127.0.0.1');
+    expect(control.port).toBe(8765);
+    expect(control.enabled).toBe(true);
+  });
+
+  it('leaves the existing mcp config untouched', () => {
+    const config = normalizeConfig({ mcp: { enabled: true, port: 8080 } });
+    expect(config.mcp).toMatchObject({ enabled: true, port: 8080 });
+    expect(config.control.enabled).toBe(true);
+  });
+});

--- a/tests/control-server.test.js
+++ b/tests/control-server.test.js
@@ -1,0 +1,169 @@
+import http from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createControlRequestHandler,
+  CONTROL_TOKEN_HEADER,
+} from '../core/control-server.js';
+
+const TOKEN = 'test-token-abc123';
+
+function makeService(overrides = {}) {
+  return {
+    getJobCounts: vi.fn(() => ({ pending: 1, inProgress: 2 })),
+    addJob: vi.fn((chatId, opts) => ({
+      id: 42,
+      channel_id: String(chatId),
+      status: 'pending',
+      ...opts,
+    })),
+    processQueue: vi.fn(() => Promise.resolve()),
+    cancelJobs: vi.fn(() => ({ canceled: 1, jobIds: [42] })),
+    ...overrides,
+  };
+}
+
+function startServer(handler) {
+  const server = http.createServer((req, res) => {
+    void handler(req, res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, port });
+    });
+  });
+}
+
+async function request(port, method, pathname, { token, body } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token !== undefined) {
+    headers[CONTROL_TOKEN_HEADER] = token;
+  }
+  const res = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try {
+    json = await res.json();
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json };
+}
+
+describe('control API request handler', () => {
+  let service;
+  let onActivity;
+  let server;
+  let port;
+
+  beforeEach(async () => {
+    service = makeService();
+    onActivity = vi.fn();
+    const handler = createControlRequestHandler({
+      service,
+      token: TOKEN,
+      pid: 12345,
+      version: '9.9.9',
+      startedAt: '2026-06-02T00:00:00.000Z',
+      onActivity,
+      ensureLogin: vi.fn(() => Promise.resolve()),
+    });
+    ({ server, port } = await startServer(handler));
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  it('GET /control/ping returns ok with job counts', async () => {
+    const { status, json } = await request(port, 'GET', '/control/ping', { token: TOKEN });
+    expect(status).toBe(200);
+    expect(json).toMatchObject({
+      ok: true,
+      pid: 12345,
+      version: '9.9.9',
+      startedAt: '2026-06-02T00:00:00.000Z',
+      jobs: { pending: 1, inProgress: 2 },
+    });
+    expect(onActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /control/backfill enqueues via addJob and kicks the queue', async () => {
+    const { status, json } = await request(port, 'POST', '/control/backfill', {
+      token: TOKEN,
+      body: { chatId: '777', depth: 500, minDate: '2026-01-01T00:00:00.000Z' },
+    });
+    expect(status).toBe(200);
+    expect(service.addJob).toHaveBeenCalledWith('777', {
+      depth: 500,
+      minDate: '2026-01-01T00:00:00.000Z',
+    });
+    expect(service.processQueue).toHaveBeenCalledTimes(1);
+    expect(json).toEqual({ jobId: 42, channelId: '777', status: 'pending' });
+  });
+
+  it('POST /control/backfill requires chatId', async () => {
+    const { status } = await request(port, 'POST', '/control/backfill', {
+      token: TOKEN,
+      body: {},
+    });
+    expect(status).toBe(400);
+    expect(service.addJob).not.toHaveBeenCalled();
+  });
+
+  it('POST /control/cancel cancels via cancelJobs', async () => {
+    const { status, json } = await request(port, 'POST', '/control/cancel', {
+      token: TOKEN,
+      body: { chatId: '777' },
+    });
+    expect(status).toBe(200);
+    expect(service.cancelJobs).toHaveBeenCalledWith({ channelId: '777', jobId: undefined });
+    expect(json).toEqual({ canceled: 1, jobIds: [42] });
+  });
+
+  it('POST /control/cancel accepts jobId', async () => {
+    const { status } = await request(port, 'POST', '/control/cancel', {
+      token: TOKEN,
+      body: { jobId: 42 },
+    });
+    expect(status).toBe(200);
+    expect(service.cancelJobs).toHaveBeenCalledWith({ channelId: undefined, jobId: 42 });
+  });
+
+  it('POST /control/cancel requires chatId or jobId', async () => {
+    const { status } = await request(port, 'POST', '/control/cancel', {
+      token: TOKEN,
+      body: {},
+    });
+    expect(status).toBe(400);
+    expect(service.cancelJobs).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with a missing token', async () => {
+    const { status, json } = await request(port, 'GET', '/control/ping');
+    expect(status).toBe(401);
+    expect(json).toEqual({ error: 'Unauthorized' });
+    expect(service.getJobCounts).not.toHaveBeenCalled();
+    expect(onActivity).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests with a wrong token', async () => {
+    const { status } = await request(port, 'GET', '/control/ping', { token: 'nope' });
+    expect(status).toBe(401);
+    expect(service.getJobCounts).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for unknown control paths', async () => {
+    const { status } = await request(port, 'GET', '/control/unknown', { token: TOKEN });
+    expect(status).toBe(404);
+  });
+
+  it('returns 404 for non-control paths', async () => {
+    const { status } = await request(port, 'GET', '/something-else', { token: TOKEN });
+    expect(status).toBe(404);
+  });
+});

--- a/tests/duration.test.js
+++ b/tests/duration.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseDuration } from '../core/duration.js';
+
+describe('parseDuration', () => {
+  it('returns null for empty or non-string input', () => {
+    expect(parseDuration('')).toBeNull();
+    expect(parseDuration('   ')).toBeNull();
+    expect(parseDuration(undefined)).toBeNull();
+    expect(parseDuration(null)).toBeNull();
+    expect(parseDuration(30)).toBeNull();
+  });
+
+  it('treats a bare number as seconds', () => {
+    expect(parseDuration('30')).toBe(30_000);
+    expect(parseDuration('0')).toBe(0);
+  });
+
+  it('honors unit suffixes', () => {
+    expect(parseDuration('500ms')).toBe(500);
+    expect(parseDuration('5s')).toBe(5_000);
+    expect(parseDuration('2m')).toBe(120_000);
+    expect(parseDuration('1h')).toBe(3_600_000);
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(parseDuration('  10S ')).toBe(10_000);
+    expect(parseDuration('250MS')).toBe(250);
+  });
+
+  it('throws on an unparseable value', () => {
+    expect(() => parseDuration('bogus')).toThrow(/Invalid duration/);
+    expect(() => parseDuration('10x')).toThrow(/Invalid duration/);
+  });
+});

--- a/tests/idle-exit.test.js
+++ b/tests/idle-exit.test.js
@@ -1,0 +1,159 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isIdle,
+  writeControlFile,
+  removeControlFile,
+  generateControlToken,
+  CONTROL_FILE,
+} from '../core/control-server.js';
+
+describe('isIdle predicate', () => {
+  const base = {
+    jobCounts: { pending: 0, inProgress: 0 },
+    watchedCount: 0,
+    lastActivityAt: 0,
+    now: 60_000,
+    idleExitMs: 30_000,
+  };
+
+  it('is idle with no jobs, no watched channels, and stale activity', () => {
+    expect(isIdle(base)).toBe(true);
+  });
+
+  it('is not idle when there are pending jobs', () => {
+    expect(isIdle({ ...base, jobCounts: { pending: 1, inProgress: 0 } })).toBe(false);
+  });
+
+  it('is not idle when there are in-progress jobs', () => {
+    expect(isIdle({ ...base, jobCounts: { pending: 0, inProgress: 1 } })).toBe(false);
+  });
+
+  it('is not idle when channels are watched', () => {
+    expect(isIdle({ ...base, watchedCount: 3 })).toBe(false);
+  });
+
+  it('is not idle when activity is recent (within the window)', () => {
+    expect(isIdle({ ...base, lastActivityAt: 45_000 })).toBe(false);
+  });
+
+  it('is never idle when idleExitMs is zero or unset', () => {
+    expect(isIdle({ ...base, idleExitMs: 0 })).toBe(false);
+    expect(isIdle({ ...base, idleExitMs: null })).toBe(false);
+  });
+});
+
+describe('idle monitor shutdown timing (fake timers)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires shutdown only after the idle window with no work', () => {
+    const idleExitMs = 30_000;
+    const intervalMs = 5_000;
+    let lastActivityAt = 0;
+    const onShutdown = vi.fn();
+    const service = {
+      getJobCounts: () => ({ pending: 0, inProgress: 0 }),
+      getWatchedChannelCount: () => 0,
+    };
+
+    const timer = setInterval(() => {
+      if (
+        isIdle({
+          jobCounts: service.getJobCounts(),
+          watchedCount: service.getWatchedChannelCount(),
+          lastActivityAt,
+          now: Date.now(),
+          idleExitMs,
+        })
+      ) {
+        onShutdown();
+      }
+    }, intervalMs);
+
+    // Before the window elapses, no shutdown.
+    vi.advanceTimersByTime(30_000);
+    expect(onShutdown).not.toHaveBeenCalled();
+
+    // Crossing the window (now - lastActivityAt > idleExitMs) triggers shutdown.
+    vi.advanceTimersByTime(5_000);
+    expect(onShutdown).toHaveBeenCalled();
+
+    clearInterval(timer);
+  });
+
+  it('does not fire shutdown while a channel is watched', () => {
+    const idleExitMs = 30_000;
+    const onShutdown = vi.fn();
+    const service = {
+      getJobCounts: () => ({ pending: 0, inProgress: 0 }),
+      getWatchedChannelCount: () => 1,
+    };
+
+    const timer = setInterval(() => {
+      if (
+        isIdle({
+          jobCounts: service.getJobCounts(),
+          watchedCount: service.getWatchedChannelCount(),
+          lastActivityAt: 0,
+          now: Date.now(),
+          idleExitMs,
+        })
+      ) {
+        onShutdown();
+      }
+    }, 5_000);
+
+    vi.advanceTimersByTime(120_000);
+    expect(onShutdown).not.toHaveBeenCalled();
+
+    clearInterval(timer);
+  });
+});
+
+describe('control.json lifecycle', () => {
+  let storeDir;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-control-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('writes control.json with mode 0600 and removes it', () => {
+    const token = generateControlToken();
+    expect(token).toMatch(/^[0-9a-f]{48}$/);
+
+    writeControlFile(storeDir, {
+      pid: 999,
+      port: 8765,
+      token,
+      startedAt: '2026-06-02T00:00:00.000Z',
+      version: '9.9.9',
+    });
+
+    const filePath = path.join(storeDir, CONTROL_FILE);
+    const stat = fs.statSync(filePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    expect(parsed).toMatchObject({ pid: 999, port: 8765, token, version: '9.9.9' });
+
+    removeControlFile(storeDir);
+    expect(fs.existsSync(filePath)).toBe(false);
+
+    // Removing a missing file is a no-op (does not throw).
+    expect(() => removeControlFile(storeDir)).not.toThrow();
+  });
+});


### PR DESCRIPTION
**PR-2a of #30** — server-side foundation for server-executed backfill. The CLI client (`backfill --chat X` foreground/background, `backfill status/count/wait/cancel`, auto-start) consumes this in **PR-2b**.

## A. Always-on loopback control API
- New `core/control-server.js` + a listener in `mcp-server.js`, bound to **127.0.0.1** (config `control.{enabled,host,port}`, default `true`/`127.0.0.1`/`8765`), **independent of `mcp.enabled`**. The existing MCP listener is untouched.
- Auth: a per-store **192-bit token** written to `<store>/control.json` (mode `0600`); every `/control/*` request must send header `x-tgcli-control-token`, else `401`.
- Endpoints (delegate to the **same `MessageSyncService` methods the MCP tools use** — no duplicated job logic):
  - `GET /control/ping` → `{ ok, pid, version, startedAt, jobs: { pending, inProgress } }`
  - `POST /control/backfill {chatId, depth?, minDate?}` → `addJob` + `processQueue` → `{ jobId, channelId, status }`
  - `POST /control/cancel {chatId?|jobId?}` → `{ canceled, jobIds }`

## B. Per-batch progress persistence
- New `started_at` jobs column (via the idempotent `_ensureJobColumn`); `_backfillHistory` now updates `message_count`/cursor/`updated_at` (and stamps `started_at` on the first batch) **every batch**, so `backfill status/count` (PR-2b) reflect live progress. New helpers `getJobCounts()` and `getWatchedChannelCount()`.

## C. Idle-exit
- `server --idle-exit <duration>` (forwarded to the worker child). **Idle** = 0 pending + 0 in-progress jobs **AND** 0 watched channels (`sync_enabled=1`) **AND** control API quiet longer than the window → graceful shutdown (removes `control.json`). No flag → always-on. So any active `channels watch` keeps the daemon alive (it needs realtime).

## Why
The server is a lock-free WAL writer and CLI reads coexist with it. Routing backfill through it (PR-2b) means the CLI won't take its own exclusive write lock → single writer, no lock contention.

## Scope — not here
Server-side only: **part of #30, not a close.** PR-2b adds the CLI `backfill` client + auto-start; PR-3 routes realtime/auth through the single writer. The MCP listener is unchanged.

## Tests
`npm test` → **252 passing** (224 baseline + 28 new across 4 files): control endpoints incl. `401` on missing/wrong token; per-batch progress with a temp DB + stub client; idle predicate truth table + fake-timer shutdown + `control.json` 0600 lifecycle; `control.*` config normalization. No real network.

## Noted hardening follow-ups (negligible on a loopback+token API; not blocking)
- Token compare is plain `===` — could use `crypto.timingSafeEqual`.
- No request-body size cap on the control endpoints.
