### PR TITLE
feat(cli): server-executed backfill client (#30, #26, PR-2b)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,13 +59,24 @@ tgcli send text --to @username --message "Hello"
 
 ### Backfill & Service
 ```bash
-tgcli channels watch --chat @channel   # subscribe a chat for archiving (queues a backfill)
-tgcli backfill --follow                 # `sync` remains a silent alias of `backfill`
-tgcli backfill jobs add --chat @channel --min-date 2024-01-01T00:00:00Z
-tgcli channels unwatch --chat @channel  # stop archiving a chat
+tgcli backfill --chat @channel                 # backfill one chat (auto-starts the server, follows progress)
+tgcli backfill --chat @channel --background    # enqueue and return the job id
+tgcli backfill --chat @channel --depth 5000 --min-date 2024-01-01T00:00:00Z
+tgcli backfill status                          # active backfills + server status
+tgcli backfill count                           # number of in-progress backfills
+tgcli backfill wait                            # block until the queue drains
+tgcli backfill cancel --chat @channel          # stop a chat's backfills
+tgcli channels watch --chat @channel           # subscribe a chat for archiving (queues a backfill)
+tgcli channels unwatch --chat @channel         # stop archiving a chat
+tgcli backfill --follow                         # legacy in-process sync (`sync` is a silent alias)
 tgcli service install
 tgcli service start
 ```
+
+Backfill work runs in the always-on control server, not the CLI. `backfill --chat`
+and `backfill wait` auto-start `tgcli server` in the background if needed; it
+shuts itself down once idle. Foreground `backfill --chat` follows progress on
+stderr; **Ctrl-C detaches** (the job keeps running — check `tgcli backfill status`).
 
 ### Contacts & Groups
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,12 @@ import {
 } from './core/send-utils.js';
 import { resolveStoreDir } from './core/store.js';
 import { parseDuration } from './core/duration.js';
+import {
+  cancelBackfill,
+  enqueueBackfill,
+  ensureServer,
+  pingServer,
+} from './core/control-client.js';
 
 const CLI_PATH = fileURLToPath(import.meta.url);
 const SERVICE_STATE_FILE = 'service-state.json';
@@ -125,14 +131,39 @@ function buildProgram() {
     .alias('sync')
     .description('Archive backfill and realtime sync');
   sync
+    // Server-executed one-shot client (issue #30/#26): `--chat` enqueues a
+    // backfill on the always-on server (auto-starting it) and follows progress.
+    .option('--chat <id|username>', 'Backfill a single chat via the control server')
+    .option('--depth <n>', 'Maximum messages to backfill (with --chat)')
+    .option('--min-date <iso>', 'Earliest date to backfill (with --chat)')
+    .option('--background', 'Enqueue and return immediately (with --chat)')
+    // Legacy in-process sync flags (no --chat).
     .option('--once', 'Run once and exit')
     .option('--follow', 'Keep syncing realtime updates')
     .option('--idle-exit <duration>', 'Exit after idle period')
-    .action(withGlobalOptions((globalFlags, options) => runSync(globalFlags, options)));
+    .action(withGlobalOptions((globalFlags, options) => runBackfill(globalFlags, options)));
   sync
     .command('status')
-    .description('Show sync status')
+    .description('Show backfill progress and server status')
     .action(withGlobalOptions((globalFlags) => runSyncStatus(globalFlags)));
+  sync
+    .command('count')
+    .description('Print the number of in-progress backfills')
+    .action(withGlobalOptions((globalFlags) => runBackfillCount(globalFlags)));
+  sync
+    .command('wait')
+    .description('Start the server if needed and wait for backfills to drain')
+    .action(withGlobalOptions((globalFlags) => runBackfillWait(globalFlags)));
+  sync
+    .command('cancel')
+    .description('Cancel backfills for a chat')
+    .option('--chat <id|username>', 'Channel identifier')
+    // --chat is also declared on the parent `backfill`; commander binds the
+    // duplicated flag to the parent, so merge via optsWithGlobals (and validate
+    // presence inside the handler rather than with requiredOption).
+    .action(withGlobalOptions((globalFlags, options, command) =>
+      runBackfillCancel(globalFlags, command.optsWithGlobals()),
+    ));
   const syncJobs = sync.command('jobs').description('Manage sync jobs');
   syncJobs
     .command('list')
@@ -147,7 +178,13 @@ function buildProgram() {
     .option('--chat <id|username>', 'Channel identifier')
     .option('--depth <n>', 'Maximum messages to backfill')
     .option('--min-date <iso>', 'Earliest date to backfill')
-    .action(withGlobalOptions((globalFlags, options) => runSyncJobsAdd(globalFlags, options)));
+    // optsWithGlobals merges in the parent `backfill` options. The parent now
+    // declares --chat/--depth/--min-date too (for `backfill --chat`), and
+    // commander binds those duplicated flags to the parent scope; merging here
+    // keeps `backfill jobs add --chat X` working.
+    .action(withGlobalOptions((globalFlags, options, command) =>
+      runSyncJobsAdd(globalFlags, command.optsWithGlobals()),
+    ));
   syncJobs
     .command('retry')
     .description('Retry failed jobs')
@@ -1701,6 +1738,218 @@ async function runFeedback(globalFlags, messageParts, options = {}) {
   }, timeoutMs);
 }
 
+// A backfill job is terminal once the worker stops touching it: `idle` means the
+// backfill reached its target/exhausted history; `error` means it failed.
+const TERMINAL_JOB_STATUSES = new Set(['idle', 'error']);
+
+// Briefly take a read lock, read job state, then release — never held across a
+// poll loop. Holding it for the whole wait would block CLI writers like `send`,
+// which need the write lock. Returns whatever the reader produces.
+//
+// We deliberately close the DB handle directly rather than calling
+// service.shutdown(): shutdown() rewrites in_progress jobs back to pending, which
+// would corrupt the job state owned by the running server we are merely observing.
+function withReadSnapshot(storeDir, reader) {
+  const release = acquireReadLock(storeDir);
+  let service;
+  let telegramClient;
+  try {
+    ({ telegramClient, messageSyncService: service } = createServices({ storeDir }));
+    return reader(service);
+  } finally {
+    if (service?.db?.open) {
+      service.db.close();
+    }
+    if (telegramClient) {
+      void telegramClient.destroy?.();
+    }
+    release();
+  }
+}
+
+function jobProgressLine(job) {
+  const label = job.peer_title || job.channel_id;
+  const done = job.message_count ?? 0;
+  const target = job.target_message_count ?? 0;
+  const pct = target > 0 ? Math.min(100, Math.round((done / target) * 100)) : 0;
+  return `Backfilling ${label}: ${done}/${target} (${pct}%)`;
+}
+
+function writeProgress(globalFlags, line) {
+  if (!globalFlags.quiet) {
+    process.stderr.write(`${line}\n`);
+  }
+}
+
+// Server-executed backfill (issue #30/#26). With `--chat`, enqueue on the
+// always-on control server (auto-starting it) and either return the job id
+// (`--background`) or follow progress in the foreground. Without `--chat`, fall
+// through to the unchanged in-process legacy sync (so `sync`/`backfill --once`
+// /`--follow` keep working).
+async function runBackfill(globalFlags, options = {}) {
+  if (!options.chat) {
+    return runSync(globalFlags, options);
+  }
+
+  // Long-running command: do NOT apply the send default timeout. A user-supplied
+  // --timeout is still honored via runWithTimeout below.
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const depth = parsePositiveInt(options.depth, '--depth');
+    const minDate = options.minDate ?? null;
+
+    await ensureServer(storeDir, { idleExit: '60s' });
+    const enqueued = await enqueueBackfill(storeDir, {
+      chatId: options.chat,
+      depth,
+      minDate,
+    });
+    const channelId = enqueued?.channelId ?? null;
+    const jobId = enqueued?.jobId ?? null;
+
+    if (options.background) {
+      if (globalFlags.json) {
+        writeJson({ jobId, channelId, status: enqueued?.status ?? null });
+      } else {
+        console.log(`Queued backfill for ${channelId} (job #${jobId}).`);
+      }
+      return;
+    }
+
+    // Ctrl-C detaches instead of cancelling: the server keeps draining the queue.
+    let detached = false;
+    const onSigint = () => {
+      detached = true;
+      writeProgress(globalFlags, 'Still running in the background — check `tgcli backfill status`');
+      process.exit(0);
+    };
+    process.on('SIGINT', onSigint);
+
+    try {
+      let job = null;
+      while (!detached) {
+        job = withReadSnapshot(storeDir, (service) => {
+          const jobs = service.listJobs({ channelId, limit: 1 });
+          return jobs[0] ?? null;
+        });
+        if (!job) {
+          // Job already gone (cancelled or never persisted) — nothing to follow.
+          break;
+        }
+        writeProgress(globalFlags, jobProgressLine(job));
+        if (TERMINAL_JOB_STATUSES.has(job.status)) {
+          break;
+        }
+        await delay(1000);
+      }
+
+      if (detached) {
+        return;
+      }
+
+      if (job && job.status === 'error') {
+        if (globalFlags.json) {
+          writeJson({ ok: false, jobId: job.id, channelId, status: job.status, error: job.error ?? null });
+        } else {
+          console.error(`Backfill failed for ${channelId}: ${job.error ?? 'unknown error'}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      if (globalFlags.json) {
+        writeJson({
+          ok: true,
+          jobId: job?.id ?? jobId,
+          channelId,
+          status: job?.status ?? null,
+          messageCount: job?.message_count ?? 0,
+          targetMessageCount: job?.target_message_count ?? 0,
+        });
+      } else if (job) {
+        console.log(`Backfill complete for ${channelId}: ${job.message_count ?? 0} message(s) archived.`);
+      } else {
+        console.log(`Backfill for ${channelId} is no longer queued.`);
+      }
+    } finally {
+      process.off('SIGINT', onSigint);
+    }
+  }, globalFlags.timeoutMs);
+}
+
+// Snapshot of in-progress + pending backfills plus whether the server is up.
+async function runBackfillCount(globalFlags) {
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    const count = withReadSnapshot(storeDir, (service) => service.getJobCounts().inProgress);
+    if (globalFlags.json) {
+      writeJson({ inProgress: count });
+    } else {
+      console.log(String(count));
+    }
+  }, globalFlags.timeoutMs);
+}
+
+// Start the server if needed (so the queue actually drains) and wait until no
+// pending/in-progress backfills remain, showing progress to stderr.
+async function runBackfillWait(globalFlags) {
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    await ensureServer(storeDir, { idleExit: '60s' });
+    while (true) {
+      const { active, jobs } = withReadSnapshot(storeDir, (service) => {
+        const counts = service.getJobCounts();
+        const inFlight = service.listJobs({ status: 'in_progress', limit: 50 });
+        return { active: counts.pending + counts.inProgress, jobs: inFlight };
+      });
+      for (const job of jobs) {
+        writeProgress(globalFlags, jobProgressLine(job));
+      }
+      if (active === 0) {
+        break;
+      }
+      await delay(1000);
+    }
+    if (globalFlags.json) {
+      writeJson({ ok: true, drained: true });
+    } else if (!globalFlags.quiet) {
+      console.log('Backfill queue drained.');
+    }
+  }, globalFlags.timeoutMs);
+}
+
+// Cancel backfills for a chat. Prefer the control server (so an in-flight job is
+// stopped by the worker); fall back to a direct DB delete when no server is up.
+async function runBackfillCancel(globalFlags, options = {}) {
+  return runWithTimeout(async () => {
+    if (!options.chat) {
+      throw new Error('--chat is required');
+    }
+    const storeDir = resolveStoreDir();
+    const ping = await pingServer(storeDir);
+    let result;
+    if (ping) {
+      result = await cancelBackfill(storeDir, { chatId: options.chat });
+    } else {
+      // No server running: same direct path as `backfill jobs cancel --channel`.
+      const release = acquireStoreLock(storeDir);
+      const { telegramClient, messageSyncService } = createServices({ storeDir });
+      try {
+        result = messageSyncService.cancelJobs({ channelId: options.chat });
+      } finally {
+        await messageSyncService.shutdown();
+        await telegramClient.destroy();
+        release();
+      }
+    }
+    if (globalFlags.json) {
+      writeJson(result);
+    } else {
+      console.log(`Canceled ${result.canceled} job(s).`);
+    }
+  }, globalFlags.timeoutMs);
+}
+
 async function runSync(globalFlags, options = {}) {
   const timeoutMs = globalFlags.timeoutMs;
   return runWithTimeout(async () => {
@@ -2139,18 +2388,48 @@ async function runSyncStatus(globalFlags) {
   const timeoutMs = globalFlags.timeoutMs;
   return runWithTimeout(async () => {
     const storeDir = resolveStoreDir();
-    const { telegramClient, messageSyncService } = createServices({ storeDir });
-    try {
-      const queue = messageSyncService.getQueueStats();
-      if (globalFlags.json) {
-        writeJson({ queue });
-      } else {
-        console.log(`QUEUE: pending=${queue.pending} in_progress=${queue.in_progress} idle=${queue.idle} error=${queue.error}`);
-        console.log(`PROCESSING: ${queue.processing}`);
+    // Snapshot the queue + active backfills under a brief read lock so a running
+    // server keeps its write lock free.
+    const { queue, jobs } = withReadSnapshot(storeDir, (service) => ({
+      queue: service.getQueueStats(),
+      jobs: service.listJobs({ limit: 100 }),
+    }));
+    // in_progress first, then pending — the chats actively/imminently backfilling.
+    const active = jobs.filter((job) => job.status === 'in_progress' || job.status === 'pending');
+    const ping = await pingServer(storeDir);
+
+    if (globalFlags.json) {
+      writeJson({
+        server: ping ? { up: true, pid: ping.pid, version: ping.version, startedAt: ping.startedAt } : { up: false },
+        queue,
+        backfills: active.map((job) => ({
+          jobId: job.id,
+          channelId: job.channel_id,
+          title: job.peer_title ?? null,
+          status: job.status,
+          messageCount: job.message_count ?? 0,
+          targetMessageCount: job.target_message_count ?? 0,
+          cursorDate: job.cursor_message_date ?? null,
+          updatedAt: job.updated_at ?? null,
+        })),
+      });
+      return;
+    }
+
+    console.log(`QUEUE: pending=${queue.pending} in_progress=${queue.in_progress} idle=${queue.idle} error=${queue.error}`);
+    console.log(`SERVER: ${ping ? `up (pid ${ping.pid})` : 'down'}`);
+    if (active.length === 0) {
+      console.log('No active backfills.');
+    } else {
+      for (const job of active) {
+        const label = job.peer_title || job.channel_id;
+        const done = job.message_count ?? 0;
+        const target = job.target_message_count ?? 0;
+        const pct = target > 0 ? Math.min(100, Math.round((done / target) * 100)) : 0;
+        const cursor = job.cursor_message_date ? ` cursor=${job.cursor_message_date}` : '';
+        const updated = job.updated_at ? ` updated=${job.updated_at}` : '';
+        console.log(`  ${label} [${job.status}] ${done}/${target} (${pct}%)${cursor}${updated}`);
       }
-    } finally {
-      await messageSyncService.shutdown();
-      await telegramClient.destroy();
     }
   }, timeoutMs);
 }

--- a/core/control-client.js
+++ b/core/control-client.js
@@ -1,0 +1,166 @@
+// Thin client over the always-on loopback control API (see core/control-server.js).
+// The CLI is a one-shot process: it asks a long-lived server to execute backfill
+// work rather than doing MTProto/SQLite writes itself. Every call here is a plain
+// HTTP request to 127.0.0.1, authed with the token from <store>/control.json.
+//
+// We deliberately use Node's built-in global `fetch` (Node 18+) — no http.request
+// hand-rolling — and reuse the server's existing control endpoints, so enqueue and
+// cancel logic is never reimplemented client-side.
+
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+
+import { CONTROL_FILE, CONTROL_TOKEN_HEADER } from './control-server.js';
+
+// Path to this package's CLI, used to (re)spawn `tgcli server`.
+const CLI_ENTRYPOINT = fileURLToPath(new URL('../cli.js', import.meta.url));
+
+const PING_TIMEOUT_MS = 1500;
+const ENQUEUE_TIMEOUT_MS = 30000;
+const SERVER_START_TIMEOUT_MS = 10000;
+const SERVER_POLL_INTERVAL_MS = 250;
+
+// Parse <store>/control.json, returning the descriptor or null when absent.
+// Shape: { pid, port, token, startedAt, version }.
+export function readControlFile(storeDir) {
+  const filePath = path.join(storeDir, CONTROL_FILE);
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function controlUrl(control, pathname) {
+  return `http://127.0.0.1:${control.port}${pathname}`;
+}
+
+async function controlFetch(control, pathname, { method = 'GET', body, timeoutMs } = {}) {
+  const headers = { [CONTROL_TOKEN_HEADER]: control.token };
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  const signal = Number.isFinite(timeoutMs) ? AbortSignal.timeout(timeoutMs) : undefined;
+  const res = await fetch(controlUrl(control, pathname), {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    signal,
+  });
+  let json = null;
+  try {
+    json = await res.json();
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json };
+}
+
+// GET /control/ping. Returns the parsed body ({ ok, pid, version, startedAt, jobs })
+// or null when no server is reachable (no control.json, refused connection, timeout,
+// or a non-2xx response).
+export async function pingServer(storeDir) {
+  const control = readControlFile(storeDir);
+  if (!control || !control.port || !control.token) {
+    return null;
+  }
+  try {
+    const { status, json } = await controlFetch(control, '/control/ping', {
+      timeoutMs: PING_TIMEOUT_MS,
+    });
+    if (status === 200 && json?.ok) {
+      return json;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// POST /control/backfill → { jobId, channelId, status }. Throws on a non-2xx
+// response so the caller surfaces the server's error (e.g. unknown chat).
+export async function enqueueBackfill(storeDir, { chatId, depth, minDate } = {}) {
+  const control = readControlFile(storeDir);
+  if (!control) {
+    throw new Error('No control server is running. Start one with `tgcli server`.');
+  }
+  const { status, json } = await controlFetch(control, '/control/backfill', {
+    method: 'POST',
+    body: { chatId, depth, minDate },
+    timeoutMs: ENQUEUE_TIMEOUT_MS,
+  });
+  if (status !== 200) {
+    throw new Error(json?.error ?? `Backfill request failed (HTTP ${status})`);
+  }
+  return json;
+}
+
+// POST /control/cancel → { canceled, jobIds }. Throws on a non-2xx response.
+export async function cancelBackfill(storeDir, { chatId, jobId } = {}) {
+  const control = readControlFile(storeDir);
+  if (!control) {
+    throw new Error('No control server is running.');
+  }
+  const { status, json } = await controlFetch(control, '/control/cancel', {
+    method: 'POST',
+    body: { chatId, jobId },
+    timeoutMs: ENQUEUE_TIMEOUT_MS,
+  });
+  if (status !== 200) {
+    throw new Error(json?.error ?? `Cancel request failed (HTTP ${status})`);
+  }
+  return json;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Spawn `tgcli server --idle-exit <idleExit>` fully detached so it outlives this
+// one-shot CLI process. We ignore its stdio and unref the child; the server writes
+// its own control.json once it is listening.
+function spawnDetachedServer(idleExit) {
+  const child = spawn(process.execPath, [CLI_ENTRYPOINT, 'server', '--idle-exit', idleExit], {
+    detached: true,
+    stdio: 'ignore',
+    env: process.env,
+  });
+  child.unref();
+  return child;
+}
+
+// Ensure a control server is reachable, returning its ping body.
+//   - If one is already up, use it (covers the race where another CLI invocation,
+//     or the user's own `tgcli server`, started it first).
+//   - Otherwise spawn a detached `tgcli server --idle-exit <idleExit>` and poll
+//     pingServer for up to ~10s. The idle-exit window lets the auto-started server
+//     shut itself down once the queue drains and nothing is being watched.
+export async function ensureServer(storeDir, { idleExit = '60s' } = {}) {
+  const existing = await pingServer(storeDir);
+  if (existing) {
+    return existing;
+  }
+
+  spawnDetachedServer(idleExit);
+
+  const deadline = Date.now() + SERVER_START_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(SERVER_POLL_INTERVAL_MS);
+    const ping = await pingServer(storeDir);
+    if (ping) {
+      return ping;
+    }
+  }
+  throw new Error('Timed out waiting for the control server to start.');
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,9 +23,36 @@ MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP)
 - auth logout
 
 ## backfill
-- backfill (alias: `sync`)
+Backfill work is executed by the always-on control server, not in the CLI
+process. Commands that need the server (`backfill --chat`, `backfill wait`)
+auto-start `tgcli server --idle-exit 60s` in the background if one isn't already
+running, talk to it over the loopback control API, and the server shuts itself
+down once the queue drains and nothing is watched. The CLI stays a thin,
+one-shot client.
+
+- backfill --chat <id|username> [--depth N] [--min-date ISO] [--background]
+  - Enqueue a single-chat backfill on the server (auto-starting it).
+  - Foreground (default): follows progress to terminal, printing
+    `Backfilling <title>: <done>/<target> (NN%)` to stderr (suppressed by
+    `--quiet`) and a final summary on stdout. Exits non-zero if the job errors.
+  - **Ctrl-C detaches** instead of cancelling: it prints a note and exits 0; the
+    server keeps draining the job. Use `backfill cancel --chat <id>` to stop it.
+  - `--background`: enqueue and return immediately, printing `{ jobId, channelId,
+    status }` (one human line, or JSON with `--json`).
+  - Long-running: no default timeout (a user-supplied `--timeout` is honored).
+- backfill status [--json]
+  - Snapshot: queue counts, whether the server is up, and each in-progress /
+    pending backfill (title, message_count/target, %, cursor date, updated_at).
+- backfill count [--json]
+  - Print the number of in-progress backfills (cheap; brief read lock).
+- backfill wait [--json]
+  - Auto-start the server if needed, then block until no pending/in-progress
+    backfills remain, showing progress (respects `--quiet`).
+- backfill cancel --chat <id|username>
+  - Cancel a chat's backfills via the server when one is up; falls back to a
+    direct cancel (same as `backfill jobs cancel --channel`) when none is.
+- backfill (no --chat): legacy in-process sync (alias: `sync`)
   - Flags: --once | --follow, --idle-exit 30s, --download-media, --refresh-contacts, --refresh-groups
-- backfill status
 - backfill jobs list [--status] [--limit] [--channel]
 - backfill jobs add --chat <id|username> [--min-date ISO] [--depth N]
 - backfill jobs retry [--job-id] [--channel] [--all-errors]

--- a/tests/backfill-client.test.js
+++ b/tests/backfill-client.test.js
@@ -1,0 +1,224 @@
+// Tests for the server-executed backfill CLI surface (issue #30/#26): the
+// `backfill --chat`, `--background`, `count`, `status`, `wait`, and `cancel`
+// commands that talk to the control server. The control client and all
+// service/lock/store seams are stubbed, so there is no network, filesystem, or
+// auth side effect.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const services = vi.hoisted(() => ({ current: null }));
+const control = vi.hoisted(() => ({
+  ensureServer: vi.fn(() => Promise.resolve({ ok: true, pid: 7, version: '2' })),
+  pingServer: vi.fn(() => Promise.resolve(null)),
+  enqueueBackfill: vi.fn(() => Promise.resolve({ jobId: 11, channelId: '-100', status: 'pending' })),
+  cancelBackfill: vi.fn(() => Promise.resolve({ canceled: 1, jobIds: [11] })),
+}));
+
+vi.mock('../core/services.js', () => ({
+  createServices: vi.fn(() => services.current),
+}));
+
+vi.mock('../store-lock.js', () => ({
+  acquireStoreLock: vi.fn(() => () => {}),
+  acquireReadLock: vi.fn(() => () => {}),
+  readStoreLock: vi.fn(() => ({ exists: false })),
+}));
+
+vi.mock('../core/store.js', () => ({
+  resolveStoreDir: vi.fn(() => '/tmp/tgcli-test-store'),
+}));
+
+vi.mock('../core/control-client.js', () => control);
+
+const { buildProgram } = await import('../cli.js');
+
+function makeFakeServices(overrides = {}) {
+  const telegramClient = {
+    isAuthorized: vi.fn().mockResolvedValue(true),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+  const messageSyncService = {
+    db: { open: false }, // withReadSnapshot only closes when db.open is true
+    getQueueStats: vi.fn(() => ({ pending: 0, in_progress: 0, idle: 0, error: 0, processing: false })),
+    getJobCounts: vi.fn(() => ({ pending: 0, inProgress: 0 })),
+    listJobs: vi.fn(() => []),
+    cancelJobs: vi.fn(() => ({ canceled: 1, jobIds: [11] })),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return { telegramClient, messageSyncService };
+}
+
+async function runProgram(argv) {
+  const program = buildProgram();
+  program.exitOverride();
+  return program.parseAsync(['node', 'cli.js', ...argv]);
+}
+
+let logSpy;
+let errSpy;
+let stdoutSpy;
+let stderrSpy;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  services.current = null;
+  control.ensureServer.mockClear();
+  control.pingServer.mockClear();
+  control.enqueueBackfill.mockClear();
+  control.cancelBackfill.mockClear();
+  control.ensureServer.mockResolvedValue({ ok: true, pid: 7, version: '2' });
+  control.pingServer.mockResolvedValue(null);
+  control.enqueueBackfill.mockResolvedValue({ jobId: 11, channelId: '-100', status: 'pending' });
+  control.cancelBackfill.mockResolvedValue({ canceled: 1, jobIds: [11] });
+  vi.clearAllMocks();
+});
+
+function stdoutText() {
+  return stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+}
+function stderrText() {
+  return stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+}
+
+describe('backfill --chat (server-executed)', () => {
+  it('--background enqueues and prints the job id without polling', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['--json', 'backfill', '--chat', '@chan', '--depth', '50', '--background']);
+
+    expect(control.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-test-store', { idleExit: '60s' });
+    expect(control.enqueueBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      chatId: '@chan',
+      depth: 50,
+      minDate: null,
+    });
+    // No progress polling in background mode.
+    expect(services.current.messageSyncService.listJobs).not.toHaveBeenCalled();
+    expect(stdoutText()).toContain('"jobId": 11');
+  });
+
+  it('foreground polls listJobs until the job reaches a terminal status', async () => {
+    const listJobs = vi
+      .fn()
+      .mockReturnValueOnce([{ id: 11, channel_id: '-100', peer_title: 'Chan', status: 'in_progress', message_count: 10, target_message_count: 100 }])
+      .mockReturnValue([{ id: 11, channel_id: '-100', peer_title: 'Chan', status: 'idle', message_count: 100, target_message_count: 100 }]);
+    services.current = makeFakeServices({ listJobs });
+
+    await runProgram(['backfill', '--chat', '@chan']);
+
+    expect(control.enqueueBackfill).toHaveBeenCalled();
+    expect(listJobs).toHaveBeenCalledWith({ channelId: '-100', limit: 1 });
+    // Progress rendered to stderr; final summary on stdout.
+    expect(stderrText()).toContain('Backfilling Chan');
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Backfill complete');
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('exits non-zero when the job ends in error', async () => {
+    const listJobs = vi.fn(() => [
+      { id: 11, channel_id: '-100', peer_title: 'Chan', status: 'error', error: 'boom', message_count: 0, target_message_count: 100 },
+    ]);
+    services.current = makeFakeServices({ listJobs });
+
+    await runProgram(['backfill', '--chat', '@chan']);
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0; // reset for other tests
+  });
+
+  it('--quiet suppresses progress on stderr', async () => {
+    const listJobs = vi.fn(() => [
+      { id: 11, channel_id: '-100', peer_title: 'Chan', status: 'idle', message_count: 100, target_message_count: 100 },
+    ]);
+    services.current = makeFakeServices({ listJobs });
+
+    await runProgram(['--quiet', 'backfill', '--chat', '@chan']);
+    expect(stderrText()).not.toContain('Backfilling');
+  });
+
+  it('SIGINT detaches without cancelling the job', async () => {
+    // Keep the job non-terminal so the poll loop is running when SIGINT fires.
+    const listJobs = vi.fn(() => [
+      { id: 11, channel_id: '-100', peer_title: 'Chan', status: 'in_progress', message_count: 5, target_message_count: 100 },
+    ]);
+    services.current = makeFakeServices({ listJobs });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('__exit__'); // unwind the poll loop like a real exit would
+    });
+
+    const run = runProgram(['backfill', '--chat', '@chan']).catch((e) => {
+      if (e?.message !== '__exit__') throw e;
+    });
+    // Let the first poll tick start, then deliver SIGINT. The handler calls
+    // process.exit(0), which our stub turns into a synchronous throw — catch it
+    // here since it unwinds through the synchronous emit.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    try {
+      process.emit('SIGINT');
+    } catch (e) {
+      if (e?.message !== '__exit__') throw e;
+    }
+    await run;
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(stderrText()).toContain('Still running in the background');
+    // Detach must NOT cancel: no cancel call of any kind.
+    expect(control.cancelBackfill).not.toHaveBeenCalled();
+    expect(services.current.messageSyncService.cancelJobs).not.toHaveBeenCalled();
+  });
+});
+
+describe('backfill count', () => {
+  it('prints the number of in-progress jobs', async () => {
+    services.current = makeFakeServices({
+      getJobCounts: vi.fn(() => ({ pending: 2, inProgress: 3 })),
+    });
+    await runProgram(['backfill', 'count']);
+    expect(logSpy).toHaveBeenCalledWith('3');
+  });
+});
+
+describe('backfill status', () => {
+  it('reports active backfills and server state', async () => {
+    services.current = makeFakeServices({
+      getQueueStats: vi.fn(() => ({ pending: 1, in_progress: 1, idle: 0, error: 0 })),
+      listJobs: vi.fn(() => [
+        { id: 11, channel_id: '-100', peer_title: 'Chan', status: 'in_progress', message_count: 40, target_message_count: 100, cursor_message_date: '2026-01-01', updated_at: 'u' },
+      ]),
+    });
+    control.pingServer.mockResolvedValue({ ok: true, pid: 7, version: '2' });
+
+    await runProgram(['backfill', 'status']);
+    const out = logSpy.mock.calls.flat().join('\n');
+    expect(out).toContain('QUEUE:');
+    expect(out).toContain('SERVER: up (pid 7)');
+    expect(out).toContain('Chan [in_progress] 40/100 (40%)');
+  });
+});
+
+describe('backfill cancel', () => {
+  it('routes to the control client when a server is up', async () => {
+    services.current = makeFakeServices();
+    control.pingServer.mockResolvedValue({ ok: true, pid: 7 });
+
+    await runProgram(['backfill', 'cancel', '--chat', '@chan']);
+    expect(control.cancelBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', { chatId: '@chan' });
+    expect(services.current.messageSyncService.cancelJobs).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a direct cancel when no server is running', async () => {
+    services.current = makeFakeServices();
+    control.pingServer.mockResolvedValue(null);
+
+    await runProgram(['backfill', 'cancel', '--chat', '@chan']);
+    expect(control.cancelBackfill).not.toHaveBeenCalled();
+    expect(services.current.messageSyncService.cancelJobs).toHaveBeenCalledWith({ channelId: '@chan' });
+  });
+});

--- a/tests/control-client.test.js
+++ b/tests/control-client.test.js
@@ -1,0 +1,170 @@
+// Tests for the control client (issue #30/#26): the thin HTTP layer the one-shot
+// CLI uses to drive the always-on control server. Global `fetch` and
+// child_process.spawn are mocked — no real network, no real process.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+vi.mock('child_process', () => ({ spawn: spawnMock }));
+
+import {
+  cancelBackfill,
+  enqueueBackfill,
+  ensureServer,
+  pingServer,
+  readControlFile,
+} from '../core/control-client.js';
+import { CONTROL_TOKEN_HEADER } from '../core/control-server.js';
+
+let storeDir;
+
+function writeControl(descriptor) {
+  fs.writeFileSync(path.join(storeDir, 'control.json'), JSON.stringify(descriptor));
+}
+
+function jsonResponse(status, body) {
+  return {
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+beforeEach(() => {
+  storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-control-client-'));
+  spawnMock.mockReset();
+  spawnMock.mockReturnValue({ unref: vi.fn() });
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  fs.rmSync(storeDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('readControlFile', () => {
+  it('returns null when control.json is absent', () => {
+    expect(readControlFile(storeDir)).toBeNull();
+  });
+
+  it('parses a present control.json', () => {
+    writeControl({ pid: 1, port: 8765, token: 'tok', startedAt: 'now', version: '1' });
+    expect(readControlFile(storeDir)).toMatchObject({ port: 8765, token: 'tok' });
+  });
+
+  it('returns null on malformed JSON', () => {
+    fs.writeFileSync(path.join(storeDir, 'control.json'), '{not json');
+    expect(readControlFile(storeDir)).toBeNull();
+  });
+});
+
+describe('pingServer', () => {
+  it('returns null with no control file (no fetch attempted)', async () => {
+    const result = await pingServer(storeDir);
+    expect(result).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns the body and sends the token header when reachable', async () => {
+    writeControl({ pid: 9, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+    global.fetch.mockResolvedValue(jsonResponse(200, { ok: true, pid: 9, version: '2' }));
+    const result = await pingServer(storeDir);
+    expect(result).toMatchObject({ ok: true, pid: 9 });
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8765/control/ping');
+    expect(init.headers[CONTROL_TOKEN_HEADER]).toBe('secret');
+  });
+
+  it('returns null when the server is unreachable', async () => {
+    writeControl({ pid: 9, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+    global.fetch.mockRejectedValue(new Error('ECONNREFUSED'));
+    expect(await pingServer(storeDir)).toBeNull();
+  });
+
+  it('returns null on a non-200 response', async () => {
+    writeControl({ pid: 9, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+    global.fetch.mockResolvedValue(jsonResponse(401, { error: 'Unauthorized' }));
+    expect(await pingServer(storeDir)).toBeNull();
+  });
+});
+
+describe('enqueueBackfill / cancelBackfill', () => {
+  beforeEach(() => {
+    writeControl({ pid: 9, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+  });
+
+  it('POSTs to /control/backfill and returns the job descriptor', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, { jobId: 7, channelId: '-100', status: 'pending' }));
+    const result = await enqueueBackfill(storeDir, { chatId: '@c', depth: 50, minDate: '2026-01-01' });
+    expect(result).toEqual({ jobId: 7, channelId: '-100', status: 'pending' });
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8765/control/backfill');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ chatId: '@c', depth: 50, minDate: '2026-01-01' });
+  });
+
+  it('throws the server error message on a non-200 backfill response', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(400, { error: 'chatId is required' }));
+    await expect(enqueueBackfill(storeDir, {})).rejects.toThrow('chatId is required');
+  });
+
+  it('POSTs to /control/cancel', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, { canceled: 2, jobIds: [1, 2] }));
+    const result = await cancelBackfill(storeDir, { chatId: '@c' });
+    expect(result).toEqual({ canceled: 2, jobIds: [1, 2] });
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8765/control/cancel');
+    expect(JSON.parse(init.body)).toEqual({ chatId: '@c', jobId: undefined });
+  });
+});
+
+describe('ensureServer', () => {
+  it('uses an existing server when ping succeeds (no spawn)', async () => {
+    writeControl({ pid: 9, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+    global.fetch.mockResolvedValue(jsonResponse(200, { ok: true, pid: 9 }));
+    const result = await ensureServer(storeDir, { idleExit: '60s' });
+    expect(result).toMatchObject({ ok: true, pid: 9 });
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns a detached server and polls until it becomes reachable', async () => {
+    // First ping (pre-spawn) fails: no control file yet. After "spawn" we write
+    // the control file and make subsequent pings succeed.
+    let started = false;
+    spawnMock.mockImplementation(() => {
+      started = true;
+      writeControl({ pid: 42, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+      return { unref: vi.fn() };
+    });
+    global.fetch.mockImplementation(() => {
+      if (!started) {
+        return Promise.reject(new Error('ECONNREFUSED'));
+      }
+      return Promise.resolve(jsonResponse(200, { ok: true, pid: 42 }));
+    });
+
+    const result = await ensureServer(storeDir, { idleExit: '60s' });
+    expect(result).toMatchObject({ ok: true, pid: 42 });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args, opts] = spawnMock.mock.calls[0];
+    expect(args).toContain('server');
+    expect(args).toContain('--idle-exit');
+    expect(args).toContain('60s');
+    expect(opts).toMatchObject({ detached: true, stdio: 'ignore' });
+  });
+
+  it('handles the race where another process started the server first', async () => {
+    // No control file initially; "spawn" does nothing, but a concurrent process
+    // wrote control.json before our first poll tick.
+    spawnMock.mockImplementation(() => {
+      writeControl({ pid: 99, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+      return { unref: vi.fn() };
+    });
+    global.fetch.mockResolvedValue(jsonResponse(200, { ok: true, pid: 99 }));
+    const result = await ensureServer(storeDir, {});
+    expect(result).toMatchObject({ ok: true, pid: 99 });
+  });
+});


### PR DESCRIPTION
**PR-2b of #30** — the CLI thin client over the PR-2a control API. Backfill is now executed by the long-lived server, not the CLI process, so a `send` (which needs the store write lock) is never blocked by a CLI that's busy backfilling.

Closes #30. Closes #26.

## New surface
- **`backfill --chat <id> [--depth N] [--min-date ISO] [--background]`** — `ensureServer` (auto-starts `tgcli server --idle-exit 60s` if none is up) → enqueue via the control API.
  - foreground (default): follows progress to terminal, polling `listJobs` under a **brief acquire→read→release read lock each ~1s** (never held across the wait, so it can't block other CLI writers), renders progress to **stderr** (respects `--quiet`), final summary to stdout. Long command → **no default timeout** (a user `--timeout` is still honored). **Ctrl-C = detach** (prints a note, exits 0) — it does NOT cancel; the server keeps draining.
  - `--background`: prints `{ jobId, channelId, status }` and exits.
- **`backfill status [--json]`** — enhanced: queue overview + per-chat in_progress/pending progress (done/target, %, cursor) + whether the server is up.
- **`backfill count [--json]`** — number of in_progress backfills (cheap poll).
- **`backfill wait [--json]`** — `ensureServer` then drain the queue.
- **`backfill cancel --chat <id>`** — routes through the control API when a server is up; falls back to a direct `cancelJobs` when not.
- Bare `backfill` (no `--chat`) keeps the unchanged legacy in-process sync; `sync` stays a silent alias.

## Principles honored (from our review)
- **No bicycles:** `core/control-client.js` uses Node's built-in global `fetch` (+ `AbortSignal.timeout`) — no hand-rolled `http.request`. Reuses `CONTROL_FILE`/`CONTROL_TOKEN_HEADER` from `control-server.js` and `core/duration.js`.
- **No functional duplication:** enqueue/cancel go through the existing PR-2a endpoints — never reimplemented client-side. status/count/wait reuse existing service read methods.
- **No premature abstraction:** one small shared `withReadSnapshot` helper for the read paths; nothing parameterized for the sake of it.

## Notable find (flagged separately, not fixed here)
Pre-existing bug: `MessageSyncService.shutdown()` resets **all** `in_progress` jobs to `pending` (message-sync-service.js:2100-2106). Any read command that does `createServices()` + `shutdown()` would, if run while the server is mid-backfill, reset the server's running job. PR-2b's new read paths avoid this (they open the DB read-only and close the handle directly, never calling `shutdown()`); the existing read commands are flagged as a separate cleanup task.

## Tests
`npm test` → **279 passing** (21 files). New: `tests/control-client.test.js` (fetch + spawn mocked: ensureServer reuse vs spawn-and-wait, the start race, ping/enqueue/cancel) and `tests/backfill-client.test.js` (real commander surface, services/locks/store/client stubbed: foreground poll-to-completion, `--background`, error exit, `--quiet`, SIGINT-detach-without-cancel, count/status, cancel routing up/down). No real network/Telegram.

## Size note
~450 lines production (`control-client.js` 166 + `cli.js` client surface) / ~394 lines new tests / ~50 docs — net-new CLI functionality, not churn.
