### PR TITLE
fix: scope job requeue to the worker — reads no longer mutate jobs (#42, PR-3a)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1505,7 +1505,7 @@ async function runAuthStatus(globalFlags) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
     }
   }, timeoutMs);
@@ -1536,7 +1536,7 @@ async function runAuthLogout(globalFlags) {
         console.log('Logged out.');
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -1728,7 +1728,7 @@ async function runFeedback(globalFlags, messageParts, options = {}) {
       }
     } finally {
       if (messageSyncService) {
-        await messageSyncService.shutdown();
+        await messageSyncService.close();
       }
       if (telegramClient) {
         await telegramClient.destroy();
@@ -1937,7 +1937,7 @@ async function runBackfillCancel(globalFlags, options = {}) {
       try {
         result = messageSyncService.cancelJobs({ channelId: options.chat });
       } finally {
-        await messageSyncService.shutdown();
+        await messageSyncService.close();
         await telegramClient.destroy();
         release();
       }
@@ -2459,7 +2459,7 @@ async function runSyncJobsList(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
     }
   }, timeoutMs);
@@ -2560,7 +2560,7 @@ async function runSyncJobsCancel(globalFlags, options = {}) {
         console.log(`Canceled ${result.canceled} job(s).`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -2612,7 +2612,7 @@ async function runDoctor(globalFlags, options = {}) {
       console.log(`FTS: ${payload.ftsEnabled}${payload.ftsVersion ? ` (v${payload.ftsVersion})` : ''}`);
       console.log(`QUEUE: pending=${queue.pending} in_progress=${queue.in_progress} idle=${queue.idle} error=${queue.error}`);
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
     }
   }, timeoutMs);
@@ -2642,7 +2642,7 @@ async function runChannelsList(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -2691,7 +2691,7 @@ async function runChannelsShow(globalFlags, options = {}) {
         console.log(JSON.stringify(channel, null, 2));
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -2750,7 +2750,7 @@ async function runChannelsSync(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -2784,7 +2784,7 @@ async function runChannelsMarkRead(globalFlags, options = {}) {
         console.log(`Marked channel ${result.channelId} as read up to message ${result.messageId}.`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -2933,7 +2933,7 @@ async function runMessagesList(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3124,7 +3124,7 @@ async function runMessagesSearch(globalFlags, queryParts, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3207,7 +3207,7 @@ async function runMessagesShow(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3324,7 +3324,7 @@ async function runMessagesContext(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3447,7 +3447,7 @@ async function runSendText(globalFlags, options = {}) {
           console.log(`Message sent (${result.messageId}).`);
         }
       } finally {
-        await messageSyncService.shutdown();
+        await messageSyncService.close();
         await telegramClient.destroy();
         release();
       }
@@ -3513,7 +3513,7 @@ async function runSendPhoto(globalFlags, options = {}) {
           console.log(`Photo sent (${result.messageId}).`);
         }
       } finally {
-        await messageSyncService.shutdown();
+        await messageSyncService.close();
         await telegramClient.destroy();
         release();
       }
@@ -3582,7 +3582,7 @@ async function runSendFile(globalFlags, options = {}) {
           console.log(`File sent (${result.messageId}).`);
         }
       } finally {
-        await messageSyncService.shutdown();
+        await messageSyncService.close();
         await telegramClient.destroy();
         release();
       }
@@ -3621,7 +3621,7 @@ async function runMediaDownload(globalFlags, options = {}) {
         console.log(`Downloaded to ${result.path} (${result.bytes} bytes).`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3654,7 +3654,7 @@ async function runTopicsList(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3693,7 +3693,7 @@ async function runTopicsSearch(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3727,7 +3727,7 @@ async function runTagsSet(globalFlags, options = {}) {
         console.log(`Tags set for ${options.chat}: ${finalTags.join(', ')}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3751,7 +3751,7 @@ async function runTagsList(globalFlags, options = {}) {
         console.log(tags.map((tag) => tag.tag).join(', '));
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3782,7 +3782,7 @@ async function runTagsSearch(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3815,7 +3815,7 @@ async function runTagsAuto(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3857,7 +3857,7 @@ async function runMetadataGet(globalFlags, options = {}) {
         console.log(JSON.stringify(metadata, null, 2));
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3889,7 +3889,7 @@ async function runMetadataRefresh(globalFlags, options = {}) {
         console.log(JSON.stringify(results, null, 2));
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3925,7 +3925,7 @@ async function runContactsSearch(globalFlags, queryParts, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3961,7 +3961,7 @@ async function runContactsShow(globalFlags, options = {}) {
         console.log(JSON.stringify(contact, null, 2));
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -3989,7 +3989,7 @@ async function runContactsAliasSet(globalFlags, options = {}) {
         console.log(`Alias set for ${options.user}: ${alias}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4014,7 +4014,7 @@ async function runContactsAliasRm(globalFlags, options = {}) {
         console.log(`Alias removed for ${options.user}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4043,7 +4043,7 @@ async function runContactsTagsAdd(globalFlags, options = {}) {
         console.log(`Tags updated for ${options.user}: ${updated.join(', ')}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4072,7 +4072,7 @@ async function runContactsTagsRm(globalFlags, options = {}) {
         console.log(`Tags updated for ${options.user}: ${updated.join(', ')}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4100,7 +4100,7 @@ async function runContactsNotesSet(globalFlags, options = {}) {
         console.log(`Notes updated for ${options.user}.`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4131,7 +4131,7 @@ async function runGroupsList(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4159,7 +4159,7 @@ async function runGroupsInfo(globalFlags, options = {}) {
         console.log(JSON.stringify(info, null, 2));
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4190,7 +4190,7 @@ async function runGroupsRename(globalFlags, options = {}) {
         console.log(`Group renamed: ${options.name}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4224,7 +4224,7 @@ async function runGroupMembersAdd(globalFlags, options = {}) {
         console.log('Members added.');
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4259,7 +4259,7 @@ async function runGroupMembersRemove(globalFlags, options = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4287,7 +4287,7 @@ async function runGroupInviteLinkGet(globalFlags, options = {}) {
         console.log(link.link);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4316,7 +4316,7 @@ async function runGroupInviteLinkRevoke(globalFlags, options = {}) {
         console.log(link.link);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4352,7 +4352,7 @@ async function runGroupsJoin(globalFlags, options = {}) {
         console.log(`Joined: ${chat.displayName || chat.title || 'Unknown'}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4380,7 +4380,7 @@ async function runGroupsLeave(globalFlags, options = {}) {
         console.log(`Left ${options.chat}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4408,7 +4408,7 @@ async function runFoldersList(globalFlags) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4471,7 +4471,7 @@ async function runFoldersShow(globalFlags, folder, opts = {}) {
         }
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4510,7 +4510,7 @@ async function runFoldersCreate(globalFlags, options) {
         console.log(`Created folder: ${result.title} (id=${result.id})`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4549,7 +4549,7 @@ async function runFoldersEdit(globalFlags, folder, options) {
         console.log(`Updated folder: ${result.title} (id=${result.id})`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4573,7 +4573,7 @@ async function runFoldersDelete(globalFlags, folder) {
         console.log(`Deleted folder id=${result.id}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4598,7 +4598,7 @@ async function runFoldersReorder(globalFlags, options) {
         console.log('Folders reordered');
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4623,7 +4623,7 @@ async function runFoldersChatsAdd(globalFlags, folder, options) {
         console.log(`Chat added to folder id=${result.folderId}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4648,7 +4648,7 @@ async function runFoldersChatsRemove(globalFlags, folder, options) {
         console.log(`Chat removed from folder id=${result.folderId}`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }
@@ -4672,7 +4672,7 @@ async function runFoldersJoin(globalFlags, link) {
         console.log(`Joined folder: ${result.title} (id=${result.id})`);
       }
     } finally {
-      await messageSyncService.shutdown();
+      await messageSyncService.close();
       await telegramClient.destroy();
       release();
     }

--- a/message-sync-service.js
+++ b/message-sync-service.js
@@ -545,6 +545,10 @@ export default class MessageSyncService {
     this.realtimeActive = false;
     this.realtimeHandlers = null;
     this.unsubscribeChannelTooLong = null;
+    // Id of the job this instance set to `in_progress` while running the queue.
+    // Only the queue worker owns its in-flight job; `shutdown()` requeues just
+    // this one so it resumes next run, without touching jobs other processes own.
+    this.ownedInProgressJobId = null;
 
     this._initDatabase();
   }
@@ -2090,6 +2094,10 @@ export default class MessageSyncService {
     void this.processQueue();
   }
 
+  // Worker-only teardown. Stops the queue loop, requeues *only* the job this
+  // instance left in_progress (so the worker resumes it next run), then releases
+  // resources via close(). Jobs owned by other processes are never touched.
+  // Non-worker commands must call close() instead — see #42.
   async shutdown() {
     this.stopRequested = true;
 
@@ -2097,14 +2105,23 @@ export default class MessageSyncService {
       await delay(100);
     }
 
-    if (this.db && this.db.open) {
+    if (this.ownedInProgressJobId !== null && this.db && this.db.open) {
       this.db.prepare(`
         UPDATE jobs
         SET status = ?, error = NULL, updated_at = CURRENT_TIMESTAMP
-        WHERE status = ?
-      `).run(JOB_STATUS.PENDING, JOB_STATUS.IN_PROGRESS);
+        WHERE id = ? AND status = ?
+      `).run(JOB_STATUS.PENDING, this.ownedInProgressJobId, JOB_STATUS.IN_PROGRESS);
+      this.ownedInProgressJobId = null;
     }
 
+    this.close();
+  }
+
+  // Non-mutating teardown for any process that isn't the queue worker. Removes
+  // realtime handlers (if registered) and closes the DB handle, but never touches
+  // the `jobs` table — so a read-only command run against a live server's store
+  // cannot corrupt the server's in-progress job (#42).
+  close() {
     if (this.realtimeActive && this.realtimeHandlers) {
       this.telegramClient.client.onNewMessage.remove(this.realtimeHandlers.newMessageHandler);
       this.telegramClient.client.onEditMessage.remove(this.realtimeHandlers.editMessageHandler);
@@ -2714,6 +2731,9 @@ export default class MessageSyncService {
     }
 
     this._updateJobStatus(job.id, JOB_STATUS.IN_PROGRESS);
+    // Claim ownership so shutdown() requeues this job (and only this one) if the
+    // process exits before _processJob writes its terminal/pending status.
+    this.ownedInProgressJobId = job.id;
 
     try {
       const channelId = normalizeChannelKey(job.channel_id);
@@ -2762,6 +2782,11 @@ export default class MessageSyncService {
       } else {
         this._markJobError(job.id, error);
       }
+    } finally {
+      // _processJob always writes a non-in_progress status above before
+      // returning, so releasing ownership here is safe. If the process is
+      // killed mid-await instead, ownership is still set and shutdown() requeues.
+      this.ownedInProgressJobId = null;
     }
   }
 

--- a/tests/backfill-rename.test.js
+++ b/tests/backfill-rename.test.js
@@ -51,6 +51,7 @@ function makeFakeServices(overrides = {}) {
     })),
     processQueue: vi.fn(),
     shutdown: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
   return { telegramClient, messageSyncService };

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -36,7 +36,7 @@ function createMockServices(messageId = 321) {
     destroy: vi.fn().mockResolvedValue(undefined),
   };
   const messageSyncService = {
-    shutdown: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
   };
   createServices.mockReturnValue({ telegramClient, messageSyncService });
   return { telegramClient, messageSyncService };
@@ -131,7 +131,7 @@ tgcli v2.0.8 | linux | v24.0.0`);
       ok: true,
       messageId: 654,
     });
-    expect(messageSyncService.shutdown).toHaveBeenCalledTimes(1);
+    expect(messageSyncService.close).toHaveBeenCalledTimes(1);
     expect(telegramClient.destroy).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/send-timeout.test.js
+++ b/tests/send-timeout.test.js
@@ -155,6 +155,7 @@ function makeFakeServices({ sendImpl, refreshImpl } = {}) {
     resumePendingJobs: vi.fn(),
     getQueueStats: vi.fn(() => ({ pending: 0, in_progress: 0, processing: false })),
     shutdown: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
   };
   return { telegramClient, messageSyncService };
 }

--- a/tests/shutdown-requeue.test.js
+++ b/tests/shutdown-requeue.test.js
@@ -1,0 +1,174 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import MessageSyncService from '../message-sync-service.js';
+
+// Regression coverage for #42: only the queue worker may requeue in_progress
+// jobs, and only the one it actually owns. Every non-worker teardown goes through
+// close(), which must never touch the `jobs` table — otherwise a read-only
+// command run against a live server's store would reset the server's in-flight
+// job to pending and corrupt its state.
+
+// Minimal fake client: close()/shutdown() only ever touch onNewMessage/etc. when
+// realtime handlers are registered, which these tests never do.
+function makeFakeClient() {
+  return {
+    client: {
+      onNewMessage: { add() {}, remove() {} },
+      onEditMessage: { add() {}, remove() {} },
+      onDeleteMessage: { add() {}, remove() {} },
+    },
+  };
+}
+
+function newService(storeDir) {
+  return new MessageSyncService(makeFakeClient(), {
+    dbPath: path.join(storeDir, 'messages.db'),
+    batchSize: 5,
+    interJobDelayMs: 0,
+    interBatchDelayMs: 0,
+  });
+}
+
+// Insert a job row directly in a chosen status (channel_id is UNIQUE).
+function seedJob(service, channelId, status) {
+  const info = service.db.prepare(`
+    INSERT INTO jobs (channel_id, status, updated_at)
+    VALUES (?, ?, CURRENT_TIMESTAMP)
+  `).run(String(channelId), status);
+  return Number(info.lastInsertRowid);
+}
+
+function statusOf(service, id) {
+  return service.db.prepare('SELECT status FROM jobs WHERE id = ?').get(id)?.status;
+}
+
+describe('teardown responsibility separation (#42)', () => {
+  let storeDir;
+  let service;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-shutdown-test-'));
+  });
+
+  afterEach(() => {
+    if (service?.db?.open) {
+      service.db.close();
+    }
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('close() does not reset an in_progress job (non-worker teardown)', () => {
+    service = newService(storeDir);
+    const jobId = seedJob(service, '100', 'in_progress');
+
+    service.close();
+
+    // Reopen the DB to read what was persisted: close() closed the handle.
+    const reopened = newService(storeDir);
+    expect(statusOf(reopened, jobId)).toBe('in_progress');
+    reopened.db.close();
+    service = null;
+  });
+
+  it('close() closes the DB handle without touching jobs', () => {
+    service = newService(storeDir);
+    seedJob(service, '100', 'in_progress');
+
+    expect(service.db.open).toBe(true);
+    service.close();
+    expect(service.db.open).toBe(false);
+  });
+
+  it('shutdown() requeues only the job this instance owns', async () => {
+    service = newService(storeDir);
+    const ownedId = seedJob(service, '100', 'in_progress');
+    const otherId = seedJob(service, '200', 'in_progress');
+
+    // Simulate the worker having claimed `ownedId` as its in-flight job.
+    service.ownedInProgressJobId = ownedId;
+
+    await service.shutdown();
+
+    const reopened = newService(storeDir);
+    // The owned job is requeued so the worker resumes it next run...
+    expect(statusOf(reopened, ownedId)).toBe('pending');
+    // ...but the in_progress job owned by another process is left untouched.
+    expect(statusOf(reopened, otherId)).toBe('in_progress');
+    reopened.db.close();
+    service = null;
+  });
+
+  it('shutdown() with no owned job leaves every in_progress row untouched', async () => {
+    service = newService(storeDir);
+    const a = seedJob(service, '100', 'in_progress');
+    const b = seedJob(service, '200', 'in_progress');
+
+    // ownedInProgressJobId starts null: this instance never ran the queue.
+    await service.shutdown();
+
+    const reopened = newService(storeDir);
+    expect(statusOf(reopened, a)).toBe('in_progress');
+    expect(statusOf(reopened, b)).toBe('in_progress');
+    reopened.db.close();
+    service = null;
+  });
+
+  it('shutdown() clears ownership after requeuing (idempotent)', async () => {
+    service = newService(storeDir);
+    const ownedId = seedJob(service, '100', 'in_progress');
+    service.ownedInProgressJobId = ownedId;
+
+    await service.shutdown();
+    expect(service.ownedInProgressJobId).toBeNull();
+  });
+});
+
+describe('worker job ownership lifecycle (#42)', () => {
+  let storeDir;
+  let service;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-ownership-test-'));
+    service = newService(storeDir);
+  });
+
+  afterEach(() => {
+    if (service?.db?.open) {
+      service.db.close();
+    }
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  it('_processJob claims ownership while running and releases it on completion', async () => {
+    const jobId = seedJob(service, '100', 'pending');
+    const job = service.db.prepare('SELECT * FROM jobs WHERE id = ?').get(jobId);
+
+    // Stub the heavy sync/backfill steps so the job reaches a terminal status
+    // without any network. We assert ownership is set the moment the job goes
+    // in_progress, then cleared once _processJob writes its terminal status.
+    let ownedDuringSync = null;
+    service._syncNewerMessages = async () => {
+      ownedDuringSync = service.ownedInProgressJobId;
+      return { stoppedEarly: false };
+    };
+    service._countMessages = () => 0;
+    service._backfillHistory = async () => ({
+      stoppedEarly: false,
+      hasMoreOlder: false,
+      finalCount: 0,
+      cursorMessageId: null,
+      cursorMessageDate: null,
+    });
+
+    await service._processJob(job);
+
+    // Ownership was held for the duration of the job...
+    expect(ownedDuringSync).toBe(jobId);
+    // ...and released once the job reached its terminal (idle) status.
+    expect(service.ownedInProgressJobId).toBeNull();
+    expect(statusOf(service, jobId)).toBe('idle');
+  });
+});


### PR DESCRIPTION
**PR-3a** of the backfill arc — the root fix for the responsibility leak behind #42.

Closes #42.

## Problem
`MessageSyncService.shutdown()` blanket-requeued **every** in-progress job (`UPDATE jobs SET status='pending' WHERE status='in_progress'`). That's *worker* semantics (a worker resumes its own interrupted job next run). But every command builds the full stack via `createServices()` and calls `shutdown()` in `finally`, so a **read-only** command run while the server is mid-backfill reset the server's running job → corruption.

## Fix — separate the responsibility
- **`close()` (new): non-mutating teardown.** Removes realtime handlers (if any) and closes the DB handle; **never touches the `jobs` table**. This is the teardown for any process that isn't the queue worker.
- **`shutdown()` (now worker-only + ownership-scoped):** requeues **only the job this instance owns** (`ownedInProgressJobId`, set in `_processJob` right after claiming a job, cleared on every terminal path — `_processJob` is the only writer that sets `in_progress`, so it's the single source of truth), then delegates to `close()`. Another process's `in_progress` row is never touched.
- **Call sites:** 52 non-worker `shutdown()` sites → `close()` (reads, send, channels, messages, topics, tags, metadata, contacts, groups, folders, media, doctor, feedback, auth status/logout, backfill cancel/status/count, `jobs list/cancel`). **5 worker sites keep `shutdown()`:** the background server (`mcp-server.js`), legacy `runSync` once/follow, `jobs add`/`jobs retry` (they kick `processQueue`), and `auth --follow`'s cleanup.

This makes the requeue the **worker's** responsibility, not part of generic teardown — so reads can no longer mutate server-owned jobs.

## Scope
Part of the PR-3 "first-class backend" arc. **Deferred to later slices:** lazily skipping the Telegram client for archive-only reads (an orthogonal optimization), routing realtime + auth-bootstrap through the single writer, and shrinking the legacy `sync` direct-write path to a thin shim.

## Tests
`npm test` → **285 passing** (279 + 6 new in `tests/shutdown-requeue.test.js`): `close()` leaves an `in_progress` job untouched (the #42 regression); `close()` closes the DB; `shutdown()` requeues only the owned job and leaves another process's `in_progress` row alone; no-owned-job shutdown touches nothing; ownership cleared after requeue; `_processJob` claims/releases ownership. No user-visible behavior changed (teardown is internal) — no docs change.
