### PR TITLE
feat: warm-backend thin client — channels-list & group-invite via shared op handlers (#45, B1)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,7 +11,7 @@ import { Command, Option } from 'commander';
 import { acquireStoreLock, acquireReadLock, readStoreLock } from './store-lock.js';
 import { loadConfig, normalizeConfig, saveConfig, validateConfig } from './core/config.js';
 import { createMessageSyncService, createServices, createTelegramClient } from './core/services.js';
-import { withCommand, runWithTimeout } from './core/command-context.js';
+import { withCommand, runWithTimeout, runOperation } from './core/command-context.js';
 import {
   buildSendErrorPayload,
   buildSendSuccessPayload,
@@ -2551,24 +2551,23 @@ async function runDoctor(globalFlags, options = {}) {
 }
 
 async function runChannelsList(globalFlags, options = {}) {
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    const limit = parsePositiveInt(options.limit, '--limit') ?? 50;
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const dialogs = options.query
-      ? await telegramClient.searchDialogs(options.query, limit)
-      : await telegramClient.listDialogs(limit);
-
-    if (globalFlags.json) {
-      writeJson(dialogs);
-    } else {
-      for (const dialog of dialogs) {
-        const label = dialog.title || dialog.username || dialog.id;
-        console.log(`${label} (${dialog.id})`);
-      }
-    }
+  const limit = parsePositiveInt(options.limit, '--limit') ?? 50;
+  const dialogs = await runOperation(globalFlags, {
+    op: 'listChannels',
+    args: { query: options.query, limit },
+    need: 'full',
+    lock: 'read',
+    requireAuth: true,
   });
+
+  if (globalFlags.json) {
+    writeJson(dialogs);
+  } else {
+    for (const dialog of dialogs) {
+      const label = dialog.title || dialog.username || dialog.id;
+      console.log(`${label} (${dialog.id})`);
+    }
+  }
 }
 
 async function runChannelsShow(globalFlags, options = {}) {
@@ -3879,17 +3878,18 @@ async function runGroupInviteLinkGet(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'read' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const link = await telegramClient.getGroupInviteLink(options.chat);
-    if (globalFlags.json) {
-      writeJson({ link: link.link });
-    } else {
-      console.log(link.link);
-    }
+  const link = await runOperation(globalFlags, {
+    op: 'getGroupInviteLink',
+    args: { chat: options.chat },
+    need: 'telegram',
+    lock: 'read',
+    requireAuth: true,
   });
+  if (globalFlags.json) {
+    writeJson({ link: link.link });
+  } else {
+    console.log(link.link);
+  }
 }
 
 async function runGroupInviteLinkRevoke(globalFlags, options = {}) {

--- a/core/command-context.js
+++ b/core/command-context.js
@@ -1,6 +1,8 @@
 import { resolveStoreDir } from './store.js';
 import { acquireReadLock, acquireStoreLock } from '../store-lock.js';
 import { createMessageSyncService, createTelegramClient, resolveValidatedConfig } from './services.js';
+import { invoke, pingServer } from './control-client.js';
+import { OPERATIONS } from './operations.js';
 
 // Runs fn(ctx) with exactly the services a command needs, owning the surrounding
 // lifecycle: timeout, store dir, store lock, scoped service creation, and teardown.
@@ -75,6 +77,36 @@ export async function withCommand(globalFlags, opts, fn) {
       }
     }
   }, timeoutMs, onTimeout, timeoutMessage);
+}
+
+// Runs a shared operation server-first with a local fallback, returning its
+// structured result. Both paths execute the SAME OPERATIONS[op], so the result —
+// and therefore whatever the caller renders from it — is identical regardless of
+// who served it.
+//
+//   - If a control server is already running, ask it to run the op against its
+//     warm (already-authed) services via POST /control/invoke.
+//   - Otherwise run the op locally inside withCommand with the requested
+//     services/lock. requireAuth enforces the local auth check; the warm path
+//     needs none because the server's client is already logged in.
+//
+// Opportunistic only: this never starts a server, so an offline run keeps the
+// current local behavior.
+export async function runOperation(globalFlags, { op, args, need, lock, requireAuth = false }) {
+  const handler = OPERATIONS[op];
+  if (!handler) {
+    throw new Error(`runOperation: unknown operation "${op}"`);
+  }
+  const storeDir = resolveStoreDir();
+  if (await pingServer(storeDir)) {
+    return invoke(storeDir, { op, args });
+  }
+  return withCommand(globalFlags, { need, lock }, async (ctx) => {
+    if (requireAuth && !(await ctx.telegramClient.isAuthorized().catch(() => false))) {
+      throw new Error('Not authenticated. Run `node cli.js auth` first.');
+    }
+    return handler(ctx, args);
+  });
 }
 
 const VALID_NEEDS = new Set(['telegram', 'archive', 'full', 'worker']);

--- a/core/control-client.js
+++ b/core/control-client.js
@@ -123,6 +123,25 @@ export async function cancelBackfill(storeDir, { chatId, jobId } = {}) {
   return json;
 }
 
+// POST /control/invoke { op, args } → the operation's result. Runs the shared
+// operation handler against the server's warm services and returns `result`.
+// Throws on a non-2xx response so the caller surfaces the server's error.
+export async function invoke(storeDir, { op, args } = {}) {
+  const control = readControlFile(storeDir);
+  if (!control) {
+    throw new Error('No control server is running.');
+  }
+  const { status, json } = await controlFetch(control, '/control/invoke', {
+    method: 'POST',
+    body: { op, args },
+    timeoutMs: ENQUEUE_TIMEOUT_MS,
+  });
+  if (status !== 200) {
+    throw new Error(json?.error ?? `Operation failed (HTTP ${status})`);
+  }
+  return json?.result;
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -3,6 +3,7 @@ import path from 'path';
 import crypto from 'crypto';
 
 import { readJsonBody, sendJson } from './http-util.js';
+import { OPERATIONS } from './operations.js';
 
 export const CONTROL_FILE = 'control.json';
 export const CONTROL_TOKEN_HEADER = 'x-tgcli-control-token';
@@ -61,6 +62,9 @@ export function isIdle({ jobCounts, watchedCount, lastActivityAt, now, idleExitM
  *
  * @param {object} deps
  * @param {object} deps.service       MessageSyncService (or compatible stub).
+ * @param {object} [deps.warmServices] Warm { telegramClient, messageSyncService }
+ *                                     the shared operation handlers run against
+ *                                     for /control/invoke.
  * @param {string} deps.token         Secret required in the control token header.
  * @param {number} deps.pid           Server process id.
  * @param {string} deps.version       Server version string.
@@ -70,6 +74,7 @@ export function isIdle({ jobCounts, watchedCount, lastActivityAt, now, idleExitM
  */
 export function createControlRequestHandler({
   service,
+  warmServices,
   token,
   pid,
   version,
@@ -132,6 +137,24 @@ export function createControlRequestHandler({
           channelId: job?.channel_id ?? null,
           status: job?.status ?? null,
         });
+        return;
+      }
+
+      if (req.method === 'POST' && url.pathname === '/control/invoke') {
+        const body = await readJsonBody(req);
+        const op = body?.op;
+        const handler = typeof op === 'string' ? OPERATIONS[op] : undefined;
+        if (!handler) {
+          sendJson(res, 400, { error: `Unknown operation: ${op ?? ''}` });
+          return;
+        }
+        // The warm client serves these reads, so make sure it is logged in
+        // before the handler touches MTProto.
+        if (typeof ensureLogin === 'function') {
+          await ensureLogin();
+        }
+        const result = await handler(warmServices, body?.args ?? {});
+        sendJson(res, 200, { result });
         return;
       }
 

--- a/core/operations.js
+++ b/core/operations.js
@@ -1,0 +1,32 @@
+// Shared operation handlers: the single source of truth for read operations that
+// both the CLI and the MCP tools expose. Each handler is a pure function of the
+// services it needs plus its args, returning the structured data a caller renders.
+//
+// ctx is the warm-or-local service bundle: { telegramClient, messageSyncService }.
+// The same handler runs whether a warm server serves the call (via
+// /control/invoke) or the one-shot CLI runs it locally, so the result shape — and
+// therefore the rendered output — is identical across both paths.
+//
+// OPERATIONS is a fixed allowlist: the control server dispatches only the keys
+// present here.
+
+// args: { query?: string, limit?: number }. With a query, search dialogs by title
+// or username; otherwise list dialogs. Returns the dialog array as-is.
+async function listChannels(ctx, args = {}) {
+  const limit = args.limit ?? 50;
+  if (args.query) {
+    return ctx.telegramClient.searchDialogs(args.query, limit);
+  }
+  return ctx.telegramClient.listDialogs(limit);
+}
+
+// args: { chat: string|number }. Returns the primary invite-link descriptor for
+// the group as the Telegram client reports it.
+async function getGroupInviteLink(ctx, args = {}) {
+  return ctx.telegramClient.getGroupInviteLink(args.chat);
+}
+
+export const OPERATIONS = {
+  listChannels,
+  getGroupInviteLink,
+};

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -19,6 +19,7 @@ import {
 } from "./core/control-server.js";
 import { readJsonBody } from "./core/http-util.js";
 import { parseDuration } from "./core/duration.js";
+import { OPERATIONS } from "./core/operations.js";
 
 const SERVICE_STATE_FILE = "service-state.json";
 
@@ -700,7 +701,7 @@ function createServerInstance() {
     listChannelsSchema,
     async ({ limit }) => {
       await telegramClient.ensureLogin();
-      const dialogs = await telegramClient.listDialogs(limit ?? 50);
+      const dialogs = await OPERATIONS.listChannels({ telegramClient, messageSyncService }, { limit });
 
       return {
         content: [
@@ -1624,7 +1625,10 @@ function createServerInstance() {
     groupsInviteLinkGetSchema,
     async ({ channelId }) => {
       await telegramClient.ensureLogin();
-      const link = await telegramClient.getGroupInviteLink(channelId);
+      const link = await OPERATIONS.getGroupInviteLink(
+        { telegramClient, messageSyncService },
+        { chat: channelId },
+      );
 
       return {
         content: [
@@ -2046,6 +2050,7 @@ if (controlEnabled) {
   const startedAt = serviceState.startedAt;
   const handleControlRequest = createControlRequestHandler({
     service: messageSyncService,
+    warmServices: { telegramClient, messageSyncService },
     token: controlToken,
     pid: process.pid,
     version: serviceState.version,

--- a/tests/control-client.test.js
+++ b/tests/control-client.test.js
@@ -15,6 +15,7 @@ import {
   cancelBackfill,
   enqueueBackfill,
   ensureServer,
+  invoke,
   pingServer,
   readControlFile,
 } from '../core/control-client.js';
@@ -118,6 +119,28 @@ describe('enqueueBackfill / cancelBackfill', () => {
     const [url, init] = global.fetch.mock.calls[0];
     expect(url).toBe('http://127.0.0.1:8765/control/cancel');
     expect(JSON.parse(init.body)).toEqual({ chatId: '@c', jobId: undefined });
+  });
+});
+
+describe('invoke', () => {
+  beforeEach(() => {
+    writeControl({ pid: 9, port: 8765, token: 'secret', startedAt: 's', version: '2' });
+  });
+
+  it('POSTs { op, args } to /control/invoke and returns result', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, { result: [{ id: '1' }] }));
+    const result = await invoke(storeDir, { op: 'listChannels', args: { limit: 5 } });
+    expect(result).toEqual([{ id: '1' }]);
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8765/control/invoke');
+    expect(init.method).toBe('POST');
+    expect(init.headers[CONTROL_TOKEN_HEADER]).toBe('secret');
+    expect(JSON.parse(init.body)).toEqual({ op: 'listChannels', args: { limit: 5 } });
+  });
+
+  it('throws the server error message on a non-200 response', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(400, { error: 'Unknown operation: nope' }));
+    await expect(invoke(storeDir, { op: 'nope', args: {} })).rejects.toThrow('Unknown operation: nope');
   });
 });
 

--- a/tests/control-server.test.js
+++ b/tests/control-server.test.js
@@ -5,6 +5,7 @@ import {
   createControlRequestHandler,
   CONTROL_TOKEN_HEADER,
 } from '../core/control-server.js';
+import { OPERATIONS } from '../core/operations.js';
 
 const TOKEN = 'test-token-abc123';
 
@@ -165,5 +166,70 @@ describe('control API request handler', () => {
   it('returns 404 for non-control paths', async () => {
     const { status } = await request(port, 'GET', '/something-else', { token: TOKEN });
     expect(status).toBe(404);
+  });
+});
+
+describe('POST /control/invoke', () => {
+  let warmServices;
+  let ensureLogin;
+  let server;
+  let port;
+
+  beforeEach(async () => {
+    warmServices = {
+      telegramClient: {
+        listDialogs: vi.fn(() => Promise.resolve([{ id: '1', title: 'Warm' }])),
+        searchDialogs: vi.fn(() => Promise.resolve([])),
+        getGroupInviteLink: vi.fn(() => Promise.resolve({ link: 'https://t.me/+warm' })),
+      },
+      messageSyncService: {},
+    };
+    ensureLogin = vi.fn(() => Promise.resolve());
+    const handler = createControlRequestHandler({
+      service: makeService(),
+      warmServices,
+      token: TOKEN,
+      pid: 1,
+      version: '1',
+      startedAt: 's',
+      ensureLogin,
+    });
+    ({ server, port } = await startServer(handler));
+  });
+
+  afterEach(() => {
+    server.close();
+    vi.restoreAllMocks();
+  });
+
+  it('runs a known op against the warm services and returns its result', async () => {
+    const spy = vi.spyOn(OPERATIONS, 'listChannels');
+    const { status, json } = await request(port, 'POST', '/control/invoke', {
+      token: TOKEN,
+      body: { op: 'listChannels', args: { limit: 10 } },
+    });
+    expect(status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(warmServices, { limit: 10 });
+    expect(warmServices.telegramClient.listDialogs).toHaveBeenCalledWith(10);
+    expect(json).toEqual({ result: [{ id: '1', title: 'Warm' }] });
+    expect(ensureLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 for an unknown op (no handler invoked)', async () => {
+    const { status, json } = await request(port, 'POST', '/control/invoke', {
+      token: TOKEN,
+      body: { op: 'doesNotExist', args: {} },
+    });
+    expect(status).toBe(400);
+    expect(json.error).toMatch(/Unknown operation/);
+    expect(ensureLogin).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invoke without a token', async () => {
+    const { status } = await request(port, 'POST', '/control/invoke', {
+      body: { op: 'listChannels', args: {} },
+    });
+    expect(status).toBe(401);
+    expect(warmServices.telegramClient.listDialogs).not.toHaveBeenCalled();
   });
 });

--- a/tests/operations-seam.test.js
+++ b/tests/operations-seam.test.js
@@ -1,0 +1,148 @@
+// Tests for the shared operation registry and the server-first / local-fallback
+// seam. The same OPERATIONS[op] runs on both paths, so the result a caller renders
+// is identical whether a warm server served it or the local fallback did.
+//
+// pingServer/invoke (server path) and the withCommand service factories / lock
+// helpers (local path) are all stubbed — no network, filesystem, or real DB.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hooks = vi.hoisted(() => ({
+  telegramClient: null,
+  messageSyncService: null,
+  pingServer: null,
+  invoke: null,
+}));
+
+vi.mock('../core/control-client.js', () => ({
+  pingServer: (...args) => hooks.pingServer(...args),
+  invoke: (...args) => hooks.invoke(...args),
+}));
+
+vi.mock('../core/services.js', () => ({
+  createTelegramClient: () => ({ telegramClient: hooks.telegramClient }),
+  createMessageSyncService: () => ({ messageSyncService: hooks.messageSyncService }),
+  resolveValidatedConfig: () => ({}),
+}));
+
+vi.mock('../store-lock.js', () => ({
+  acquireReadLock: vi.fn(() => vi.fn()),
+  acquireStoreLock: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../core/store.js', () => ({
+  resolveStoreDir: vi.fn(() => '/tmp/tgcli-seam-store'),
+}));
+
+const { OPERATIONS } = await import('../core/operations.js');
+const { runOperation } = await import('../core/command-context.js');
+
+beforeEach(() => {
+  hooks.telegramClient = {
+    destroy: vi.fn().mockResolvedValue(undefined),
+    isAuthorized: vi.fn().mockResolvedValue(true),
+    listDialogs: vi.fn().mockResolvedValue([{ id: '1', title: 'Local' }]),
+    searchDialogs: vi.fn().mockResolvedValue([{ id: '2', title: 'LocalSearch' }]),
+    getGroupInviteLink: vi.fn().mockResolvedValue({ link: 'https://t.me/+local' }),
+  };
+  hooks.messageSyncService = {
+    close: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+  hooks.pingServer = vi.fn();
+  hooks.invoke = vi.fn();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('OPERATIONS registry', () => {
+  it('listChannels lists dialogs and applies the default limit', async () => {
+    const ctx = { telegramClient: hooks.telegramClient };
+    const result = await OPERATIONS.listChannels(ctx, {});
+    expect(hooks.telegramClient.listDialogs).toHaveBeenCalledWith(50);
+    expect(result).toEqual([{ id: '1', title: 'Local' }]);
+  });
+
+  it('listChannels searches when a query is given', async () => {
+    const ctx = { telegramClient: hooks.telegramClient };
+    const result = await OPERATIONS.listChannels(ctx, { query: 'foo', limit: 7 });
+    expect(hooks.telegramClient.searchDialogs).toHaveBeenCalledWith('foo', 7);
+    expect(result).toEqual([{ id: '2', title: 'LocalSearch' }]);
+  });
+
+  it('getGroupInviteLink returns the link descriptor', async () => {
+    const ctx = { telegramClient: hooks.telegramClient };
+    const result = await OPERATIONS.getGroupInviteLink(ctx, { chat: '@g' });
+    expect(hooks.telegramClient.getGroupInviteLink).toHaveBeenCalledWith('@g');
+    expect(result).toEqual({ link: 'https://t.me/+local' });
+  });
+});
+
+describe('runOperation seam', () => {
+  it('routes to the server via invoke when a server is reachable', async () => {
+    hooks.pingServer.mockResolvedValue({ ok: true });
+    hooks.invoke.mockResolvedValue([{ id: 'warm' }]);
+
+    const result = await runOperation(
+      {},
+      { op: 'listChannels', args: { limit: 3 }, need: 'full', lock: 'read', requireAuth: true },
+    );
+
+    expect(hooks.invoke).toHaveBeenCalledWith('/tmp/tgcli-seam-store', {
+      op: 'listChannels',
+      args: { limit: 3 },
+    });
+    expect(result).toEqual([{ id: 'warm' }]);
+    // Server path runs nothing locally.
+    expect(hooks.telegramClient.listDialogs).not.toHaveBeenCalled();
+  });
+
+  it('falls back to local withCommand + OPERATIONS[op] when no server is reachable', async () => {
+    hooks.pingServer.mockResolvedValue(null);
+
+    const result = await runOperation(
+      {},
+      { op: 'listChannels', args: { limit: 3 }, need: 'full', lock: 'read', requireAuth: true },
+    );
+
+    expect(hooks.invoke).not.toHaveBeenCalled();
+    expect(hooks.telegramClient.isAuthorized).toHaveBeenCalled();
+    expect(hooks.telegramClient.listDialogs).toHaveBeenCalledWith(3);
+    expect(result).toEqual([{ id: '1', title: 'Local' }]);
+  });
+
+  it('enforces the local auth check before running the op', async () => {
+    hooks.pingServer.mockResolvedValue(null);
+    hooks.telegramClient.isAuthorized.mockResolvedValue(false);
+
+    await expect(
+      runOperation(
+        {},
+        { op: 'listChannels', args: {}, need: 'full', lock: 'read', requireAuth: true },
+      ),
+    ).rejects.toThrow('Not authenticated');
+    expect(hooks.telegramClient.listDialogs).not.toHaveBeenCalled();
+  });
+
+  it('produces identical results via the server path and the local path', async () => {
+    // Local result.
+    hooks.pingServer.mockResolvedValue(null);
+    const local = await runOperation(
+      {},
+      { op: 'getGroupInviteLink', args: { chat: '@g' }, need: 'telegram', lock: 'read', requireAuth: true },
+    );
+
+    // Server path returns whatever the warm OPERATIONS[op] produced — model that
+    // with the same shape the local client returns.
+    hooks.pingServer.mockResolvedValue({ ok: true });
+    hooks.invoke.mockResolvedValue({ link: 'https://t.me/+local' });
+    const served = await runOperation(
+      {},
+      { op: 'getGroupInviteLink', args: { chat: '@g' }, need: 'telegram', lock: 'read', requireAuth: true },
+    );
+
+    expect(served).toEqual(local);
+  });
+});


### PR DESCRIPTION
**Variant B, slice B1 of #45** — the vertical proof that CLI commands can run as thin clients over the **warm server** (which holds a live MTProto connection + open DB), via **operation handlers shared with the MCP tools**.

## What
- **`core/operations.js` — shared `OPERATIONS` registry** (single source of truth): `listChannels`, `getGroupInviteLink`. Each is `async (ctx, args) => result`, `ctx = { telegramClient, messageSyncService }`. The same handler runs whether served warm or locally, so the result shape is identical.
- **`POST /control/invoke { op, args }`** (control server): token-authed like the other `/control/*` endpoints, fixed allowlist (unknown op → 400), runs `ensureLogin` then `OPERATIONS[op]` against the server's **warm** services. `mcp-server.js` now wires `{ telegramClient, messageSyncService }` into the control handler.
- **MCP tools rewired:** `listChannels` and `groupsInviteLinkGet` call the same `OPERATIONS` functions → one handler serves both the MCP tool and `/control/invoke` (`groupsInviteLinkGet` keeps its presentation wrapper around the shared op's raw result).
- **`core/control-client.js` `invoke()`** → `POST /control/invoke` (reuses `controlFetch` + token).
- **Seam `runOperation`** (`command-context.js`): if a server is reachable (`pingServer`) → `invoke`; else `withCommand({ need, lock })` + the same `OPERATIONS[op]`. Both paths run the identical op, so output — including `--json` — is byte-identical whether served warm or by the local fallback. **Opportunistic only — no auto-start for reads**, and no store-lock contention when served warm.
- **Converted 2 commands:** `runChannelsList`, `runGroupInviteLinkGet` (arg validation + formatting unchanged; local path keeps the auth check).

## Scope
Proof slice only — **part of #45, not a close.** Later B slices migrate more operations + the rest of the MCP tool surface into `OPERATIONS`, and decide auto-start/write-op policy.

## Tests
`npm test` → **312 passing** (300 + 12 new): `/control/invoke` (known op runs the registry fn with warm services; unknown → 400; no token → 401); `invoke` client; the seam routes to the server when ping succeeds and to local `withCommand`+op when it fails, enforces the local auth check, and produces identical results both ways; per-op registry behavior; MCP tools reference the shared `OPERATIONS`. No `node_modules` in the commit; no autobiographical comments.
