### PR TITLE
feat: route all commands through the warm server — thin clients on shared ops (#45, Step 1)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -73,10 +73,14 @@ tgcli service install
 tgcli service start
 ```
 
-Backfill work runs in the always-on control server, not the CLI. `backfill --chat`
-and `backfill wait` auto-start `tgcli server` in the background if needed; it
-shuts itself down once idle. Foreground `backfill --chat` follows progress on
-stderr; **Ctrl-C detaches** (the job keeps running — check `tgcli backfill status`).
+Telegram and archive commands (channels, messages, send, media, topics, tags,
+metadata, contacts, groups, folders) run through the always-on control server,
+not the CLI. The CLI is a thin client: it auto-starts `tgcli server` in the
+background when one isn't running, has it execute the operation against its warm
+connection and database, then renders the result; the server shuts itself down
+once idle. `config`, `service`, `doctor`, and `auth` stay local. Foreground
+`backfill --chat` follows progress on stderr; **Ctrl-C detaches** (the job keeps
+running — check `tgcli backfill status`).
 
 ### Contacts & Groups
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,6 @@ import {
   buildSendErrorPayload,
   buildSendSuccessPayload,
   classifySendError,
-  executeSendWithRetries,
   formatSendErrorMessage,
   parseRetryBackoff,
   SendCommandError,
@@ -1215,90 +1214,6 @@ function parseListValues(value) {
     .filter(Boolean);
 }
 
-function resolveSource(source) {
-  const resolved = source ? String(source).toLowerCase() : 'archive';
-  if (!['archive', 'live', 'both'].includes(resolved)) {
-    throw new Error(`Invalid source: ${source}`);
-  }
-  return resolved;
-}
-
-function parseDateMs(value, label) {
-  if (!value) {
-    return null;
-  }
-  const ts = Date.parse(value);
-  if (Number.isNaN(ts)) {
-    throw new Error(`Invalid ${label}: ${value}`);
-  }
-  return ts;
-}
-
-function filterLiveMessagesByDate(messages, fromDate, toDate) {
-  const fromMs = parseDateMs(fromDate, 'after');
-  const toMs = parseDateMs(toDate, 'before');
-  if (!fromMs && !toMs) {
-    return messages;
-  }
-  return messages.filter((message) => {
-    const ts = typeof message.date === 'number' ? message.date * 1000 : null;
-    if (!ts) {
-      return false;
-    }
-    if (fromMs && ts < fromMs) {
-      return false;
-    }
-    if (toMs && ts > toMs) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function getMessageIdValue(message) {
-  const value = message?.messageId ?? message?.id;
-  return Number.isFinite(value) ? value : null;
-}
-
-function filterMessagesById(messages, beforeId, afterId) {
-  if (!beforeId && !afterId) {
-    return messages;
-  }
-  return messages.filter((message) => {
-    const messageId = getMessageIdValue(message);
-    if (!messageId) {
-      return false;
-    }
-    if (beforeId && messageId >= beforeId) {
-      return false;
-    }
-    if (afterId && messageId <= afterId) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function formatLiveMessage(message, context) {
-  const dateIso = message.date ? new Date(message.date * 1000).toISOString() : null;
-  return {
-    channelId: context.channelId ?? message.peer_id ?? null,
-    peerTitle: context.peerTitle ?? null,
-    username: context.username ?? null,
-    messageId: message.id,
-    date: dateIso,
-    fromId: message.from_id ?? null,
-    fromUsername: message.from_username ?? null,
-    fromDisplayName: message.from_display_name ?? null,
-    fromPeerType: message.from_peer_type ?? null,
-    fromIsBot: typeof message.from_is_bot === 'boolean' ? message.from_is_bot : null,
-    text: message.text ?? message.message ?? '',
-    urls: message.urls ?? null,
-    media: message.media ?? null,
-    topicId: message.topic_id ?? null,
-  };
-}
-
 function getMessageSenderLabel(message) {
   return message.fromDisplayName || message.fromUsername || message.fromId || null;
 }
@@ -1347,48 +1262,6 @@ function formatPeerHeaderLabel(group) {
     return `${handle}`;
   }
   return group.channelId || 'unknown';
-}
-
-function messageDateMs(message) {
-  const ts = Date.parse(message.date ?? '');
-  return Number.isNaN(ts) ? 0 : ts;
-}
-
-function mergeMessageSets(sets, limit) {
-  const map = new Map();
-  for (const list of sets) {
-    for (const message of list) {
-      const channelId = message.channelId ?? '';
-      const messageId = message.messageId ?? message.id;
-      const key = `${String(channelId)}:${String(messageId)}`;
-      if (!map.has(key) || message.source === 'live') {
-        map.set(key, message);
-      }
-    }
-  }
-  const merged = Array.from(map.values());
-  merged.sort((a, b) => messageDateMs(b) - messageDateMs(a));
-  return limit && limit > 0 ? merged.slice(0, limit) : merged;
-}
-
-function buildMessageListJsonPayload(source, messages, requestedLimit) {
-  const hasMore = messages.length === requestedLimit;
-  const payload = {
-    source,
-    returned: messages.length,
-    hasMore,
-    messages,
-  };
-
-  if (hasMore) {
-    const lastMessage = messages[messages.length - 1];
-    const nextBeforeId = getMessageIdValue(lastMessage);
-    if (nextBeforeId) {
-      payload.nextBeforeId = nextBeforeId;
-    }
-  }
-
-  return payload;
 }
 
 function normalizeInviteCode(value) {
@@ -2555,9 +2428,6 @@ async function runChannelsList(globalFlags, options = {}) {
   const dialogs = await runOperation(globalFlags, {
     op: 'listChannels',
     args: { query: options.query, limit },
-    need: 'full',
-    lock: 'read',
-    requireAuth: true,
   });
 
   if (globalFlags.json) {
@@ -2574,39 +2444,15 @@ async function runChannelsShow(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    let channel = messageSyncService.getChannel(options.chat);
-    if (!channel) {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      const meta = await telegramClient.getPeerMetadata(options.chat);
-      channel = {
-        channelId: String(options.chat),
-        peerTitle: meta?.peerTitle ?? null,
-        peerType: meta?.peerType ?? null,
-        chatType: meta?.chatType ?? null,
-        isForum: meta?.isForum ?? null,
-        username: meta?.username ?? null,
-        syncEnabled: null,
-        lastMessageId: null,
-        lastMessageDate: null,
-        oldestMessageId: null,
-        oldestMessageDate: null,
-        about: meta?.about ?? null,
-        metadataUpdatedAt: null,
-        createdAt: null,
-        updatedAt: null,
-        source: 'live',
-      };
-    }
-
-    if (globalFlags.json) {
-      writeJson(channel);
-    } else {
-      console.log(JSON.stringify(channel, null, 2));
-    }
+  const channel = await runOperation(globalFlags, {
+    op: 'channelShow',
+    args: { chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson(channel);
+  } else {
+    console.log(JSON.stringify(channel, null, 2));
+  }
 }
 
 async function runChannelsSync(globalFlags, options = {}) {
@@ -2619,43 +2465,25 @@ async function runChannelsSync(globalFlags, options = {}) {
   if (!options.enable && !options.disable) {
     throw new Error('--enable or --disable is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    const result = messageSyncService.setChannelSync(options.chat, Boolean(options.enable));
-    let job = null;
-    let jobQueued = false;
-    if (options.enable) {
-      const existing = messageSyncService.listJobs({ channelId: options.chat, limit: 1 });
-      if (existing.length > 0) {
-        job = existing[0];
-      } else {
-        job = messageSyncService.addJob(options.chat);
-        jobQueued = true;
-      }
-    }
-    if (globalFlags.json) {
-      writeJson({
-        channelId: result.channel_id,
-        syncEnabled: Boolean(result.sync_enabled),
-        jobId: job?.id ?? null,
-        jobStatus: job?.status ?? null,
-        jobQueued,
-      });
-    } else {
-      if (result.sync_enabled) {
-        const jobMessage = job
-          ? jobQueued
-            ? ` Backfill job queued (#${job.id}).`
-            : ` Backfill job exists (#${job.id}, ${job.status}).`
-          : '';
-        console.log(
-          `Sync enabled for ${result.channel_id}.${jobMessage} ` +
-            'Run `tgcli backfill --once` (or `tgcli backfill --follow`/`tgcli server`) to process.',
-        );
-      } else {
-        console.log(`Sync disabled for ${result.channel_id}`);
-      }
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'channelSetSync',
+    args: { chat: options.chat, enable: Boolean(options.enable) },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else if (result.syncEnabled) {
+    const jobMessage = result.jobId
+      ? result.jobQueued
+        ? ` Backfill job queued (#${result.jobId}).`
+        : ` Backfill job exists (#${result.jobId}, ${result.jobStatus}).`
+      : '';
+    console.log(
+      `Sync enabled for ${result.channelId}.${jobMessage} ` +
+        'Run `tgcli backfill --once` (or `tgcli backfill --follow`/`tgcli server`) to process.',
+    );
+  } else {
+    console.log(`Sync disabled for ${result.channelId}`);
+  }
 }
 
 async function runChannelsMarkRead(globalFlags, options = {}) {
@@ -2669,337 +2497,109 @@ async function runChannelsMarkRead(globalFlags, options = {}) {
   if (messageId === null) {
     throw new Error('--message-id must be a positive integer');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const result = await telegramClient.markChannelRead(options.chat, messageId);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Marked channel ${result.channelId} as read up to message ${result.messageId}.`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'channelMarkRead',
+    args: { chat: options.chat, messageId },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Marked channel ${result.channelId} as read up to message ${result.messageId}.`);
+  }
 }
 
-function createLiveMetadataResolver(messageSyncService, telegramClient) {
-  return async (channelId, fallback = {}) => {
-    const meta = messageSyncService.getChannelMetadata(channelId);
-    let peerTitle = meta?.peerTitle ?? fallback.peerTitle ?? null;
-    let username = meta?.username ?? fallback.username ?? null;
-    if (!peerTitle || !username) {
-      const live = await telegramClient.getPeerMetadata(channelId);
-      peerTitle = peerTitle ?? live?.peerTitle ?? null;
-      username = username ?? live?.username ?? null;
+function renderMessageGroups(messages, outputSource) {
+  const groups = groupMessagesByChannel(messages);
+  for (const group of groups) {
+    const label = formatPeerHeaderLabel(group);
+    const count = group.messages.length;
+    console.log(`Showing ${count} message${count === 1 ? '' : 's'} for ${label}:`);
+    for (const message of group.messages) {
+      const sender = getMessageSenderLabel(message) || 'unknown';
+      const text = (message.text || '').replace(/\s+/g, ' ').trim();
+      const prefix = outputSource === 'both' ? `[${message.source}] ` : '';
+      console.log(`${prefix}${message.date ?? ''} ${sender} #${message.messageId}: ${text}`);
     }
-    return { peerTitle, username };
-  };
+    if (groups.length > 1) {
+      console.log('');
+    }
+  }
 }
 
 async function runMessagesList(globalFlags, options = {}) {
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    const resolveLiveMetadata = createLiveMetadataResolver(messageSyncService, telegramClient);
-    const resolvedSource = resolveSource(options.source);
-    const channelIds = parseListValues(options.chat);
-    const topicId = parsePositiveInt(options.topic, '--topic');
-    const finalLimit = parsePositiveInt(options.limit, '--limit') ?? 50;
-    const { beforeId, afterId } = parseMessageIdWindow(options, { allowOffsetAlias: true });
-    let archivedResults = [];
-    let liveResults = [];
-    let usedLiveFallback = false;
-    let authChecked = false;
-
-    const ensureAuthorized = async () => {
-      if (authChecked) {
-        return;
-      }
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      authChecked = true;
-    };
-
-    const fetchLiveMessages = async (liveChannelIds) => {
-      await ensureAuthorized();
-      const results = [];
-      for (const id of liveChannelIds) {
-        let peerTitle = null;
-        let username = null;
-        let liveMessages = [];
-
-        if (topicId) {
-          const response = await telegramClient.getTopicMessages(id, topicId, finalLimit, {
-            beforeId,
-            afterId,
-          });
-          liveMessages = filterMessagesById(response.messages, beforeId, afterId);
-        } else {
-          const fetchOptions = {};
-          if (beforeId) {
-            fetchOptions.beforeId = beforeId;
-          }
-          if (afterId) {
-            fetchOptions.afterId = afterId;
-          }
-          const response = await telegramClient.getMessagesByChannelId(id, finalLimit, fetchOptions);
-          liveMessages = filterMessagesById(response.messages, beforeId, afterId);
-          peerTitle = response.peerTitle ?? null;
-        }
-
-        const meta = await resolveLiveMetadata(id, { peerTitle, username });
-        peerTitle = meta.peerTitle;
-        username = meta.username;
-
-        const filtered = filterLiveMessagesByDate(liveMessages, options.after, options.before);
-        const formatted = filtered.map((message) => ({
-          ...formatLiveMessage(message, { channelId: String(id), peerTitle, username }),
-          source: 'live',
-        }));
-        results.push(...formatted);
-      }
-      return results;
-    };
-
-    if (resolvedSource === 'archive' || resolvedSource === 'both') {
-      const archived = messageSyncService.listArchivedMessages({
-        channelIds: channelIds.length ? channelIds : null,
-        topicId,
-        fromDate: options.after,
-        toDate: options.before,
-        beforeId,
-        afterId,
-        limit: finalLimit,
-      });
-      archivedResults = archived.map((message) => ({ ...message, source: 'archive' }));
-    }
-
-    if (resolvedSource === 'live' || resolvedSource === 'both') {
-      if (!channelIds.length) {
-        throw new Error('--chat is required for live source.');
-      }
-      liveResults = await fetchLiveMessages(channelIds);
-    }
-
-    if (resolvedSource === 'archive' && archivedResults.length === 0 && channelIds.length) {
-      liveResults = await fetchLiveMessages(channelIds);
-      usedLiveFallback = true;
-    }
-
-    let messages = [];
-    let outputSource = resolvedSource;
-    if (resolvedSource === 'both') {
-      messages = mergeMessageSets([archivedResults, liveResults], finalLimit);
-    } else if (resolvedSource === 'live' || usedLiveFallback) {
-      messages = liveResults;
-      outputSource = 'live';
-    } else {
-      messages = archivedResults;
-    }
-
-    if (globalFlags.json) {
-      writeJson(buildMessageListJsonPayload(outputSource, messages, finalLimit));
-    } else {
-      const groups = groupMessagesByChannel(messages);
-      for (const group of groups) {
-        const label = formatPeerHeaderLabel(group);
-        const count = group.messages.length;
-        console.log(`Showing ${count} message${count === 1 ? '' : 's'} for ${label}:`);
-        for (const message of group.messages) {
-          const sender = getMessageSenderLabel(message) || 'unknown';
-          const text = (message.text || '').replace(/\s+/g, ' ').trim();
-          const prefix = outputSource === 'both' ? `[${message.source}] ` : '';
-          console.log(`${prefix}${message.date ?? ''} ${sender} #${message.messageId}: ${text}`);
-        }
-        if (groups.length > 1) {
-          console.log('');
-        }
-      }
-      if (usedLiveFallback) {
-        printArchiveFallbackNote(channelIds);
-      }
-    }
+  const channelIds = parseListValues(options.chat);
+  const topicId = parsePositiveInt(options.topic, '--topic');
+  const finalLimit = parsePositiveInt(options.limit, '--limit') ?? 50;
+  const { beforeId, afterId } = parseMessageIdWindow(options, { allowOffsetAlias: true });
+  const result = await runOperation(globalFlags, {
+    op: 'messagesList',
+    args: {
+      channelIds: channelIds.length ? channelIds : null,
+      topicId,
+      source: options.source,
+      fromDate: options.after,
+      toDate: options.before,
+      beforeId,
+      afterId,
+      limit: finalLimit,
+    },
   });
+  const { usedLiveFallback, ...payload } = result;
+
+  if (globalFlags.json) {
+    writeJson(payload);
+  } else {
+    renderMessageGroups(payload.messages, payload.source);
+    if (usedLiveFallback) {
+      printArchiveFallbackNote(channelIds);
+    }
+  }
 }
 
 async function runMessagesSearch(globalFlags, queryParts, options = {}) {
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    const resolveLiveMetadata = createLiveMetadataResolver(messageSyncService, telegramClient);
-    const query = options.query || (queryParts || []).join(' ').trim();
-    const resolvedSource = resolveSource(options.source);
-    const channelIds = parseListValues(options.chat);
-    const tagList = [
-      ...parseListValues(options.tag),
-      ...parseListValues(options.tags),
-    ];
-    const topicId = parsePositiveInt(options.topic, '--topic');
-    const finalLimit = parsePositiveInt(options.limit, '--limit') ?? 100;
-    const { beforeId, afterId } = parseMessageIdWindow(options);
-    const caseInsensitive = !options.caseSensitive;
+  const query = options.query || (queryParts || []).join(' ').trim();
+  const channelIds = parseListValues(options.chat);
+  const tagList = [
+    ...parseListValues(options.tag),
+    ...parseListValues(options.tags),
+  ];
+  const topicId = parsePositiveInt(options.topic, '--topic');
+  const finalLimit = parsePositiveInt(options.limit, '--limit') ?? 100;
+  const { beforeId, afterId } = parseMessageIdWindow(options);
 
-    if (!query && !options.regex && tagList.length === 0) {
-      throw new Error('Provide query, regex, or tag for messages search.');
-    }
+  if (!query && !options.regex && tagList.length === 0) {
+    throw new Error('Provide query, regex, or tag for messages search.');
+  }
 
-    let archivedResults = [];
-    let liveResults = [];
-    let usedLiveFallback = false;
-    let authChecked = false;
-
-    const ensureAuthorized = async () => {
-      if (authChecked) {
-        return;
-      }
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      authChecked = true;
-    };
-
-    const buildLiveChannelIds = () => {
-      let liveChannelIds = channelIds;
-      if (!liveChannelIds.length && tagList.length) {
-        const tagged = new Map();
-        for (const tag of tagList) {
-          const channels = messageSyncService.listTaggedChannels(tag, { limit: 200 });
-          for (const channel of channels) {
-            tagged.set(channel.channelId, channel);
-          }
-        }
-        liveChannelIds = Array.from(tagged.keys());
-      }
-      return liveChannelIds;
-    };
-
-    const fetchLiveResults = async (liveChannelIds) => {
-      await ensureAuthorized();
-      let liveRegex = null;
-      if (options.regex) {
-        try {
-          liveRegex = new RegExp(options.regex, caseInsensitive ? 'i' : '');
-        } catch (error) {
-          throw new Error(`Invalid regex: ${error.message}`);
-        }
-      }
-
-      const results = [];
-      for (const id of liveChannelIds) {
-        let peerTitle = null;
-        let username = null;
-        let liveMessages = [];
-
-        if (query) {
-          const response = await telegramClient.searchChannelMessages(id, {
-            query,
-            limit: finalLimit,
-            topicId,
-            beforeId,
-            afterId,
-          });
-          liveMessages = response.messages;
-          peerTitle = response.peerTitle ?? null;
-        } else if (topicId) {
-          const response = await telegramClient.getTopicMessages(id, topicId, finalLimit, {
-            beforeId,
-            afterId,
-          });
-          liveMessages = response.messages;
-        } else {
-          const response = await telegramClient.getMessagesByChannelId(id, finalLimit, {
-            beforeId,
-            afterId,
-          });
-          liveMessages = response.messages;
-          peerTitle = response.peerTitle ?? null;
-        }
-
-        const meta = await resolveLiveMetadata(id, { peerTitle, username });
-        peerTitle = meta.peerTitle;
-        username = meta.username;
-
-        let filtered = filterLiveMessagesByDate(liveMessages, options.after, options.before);
-        filtered = filterMessagesById(filtered, beforeId, afterId);
-        if (liveRegex) {
-          filtered = filtered.filter((message) =>
-            liveRegex.test(message.text ?? message.message ?? ''),
-          );
-        }
-
-        const formatted = filtered.map((message) => ({
-          ...formatLiveMessage(message, { channelId: String(id), peerTitle, username }),
-          source: 'live',
-        }));
-        results.push(...formatted);
-      }
-      return results;
-    };
-
-    if (resolvedSource === 'archive' || resolvedSource === 'both') {
-      const archived = messageSyncService.searchArchiveMessages({
-        query,
-        regex: options.regex,
-        tags: tagList.length ? tagList : null,
-        channelIds: channelIds.length ? channelIds : null,
-        topicId,
-        fromDate: options.after,
-        toDate: options.before,
-        beforeId,
-        afterId,
-        limit: finalLimit,
-        caseInsensitive,
-      });
-      archivedResults = archived.map((message) => ({ ...message, source: 'archive' }));
-    }
-
-    if (resolvedSource === 'live' || resolvedSource === 'both') {
-      const liveChannelIds = buildLiveChannelIds();
-      if (!liveChannelIds.length) {
-        throw new Error('--chat is required for live search.');
-      }
-      liveResults = await fetchLiveResults(liveChannelIds);
-    }
-
-    if (resolvedSource === 'archive' && archivedResults.length === 0) {
-      const liveChannelIds = buildLiveChannelIds();
-      if (liveChannelIds.length) {
-        liveResults = await fetchLiveResults(liveChannelIds);
-        usedLiveFallback = true;
-      }
-    }
-
-    let messages = [];
-    let outputSource = resolvedSource;
-    if (resolvedSource === 'both') {
-      messages = mergeMessageSets([archivedResults, liveResults], finalLimit);
-    } else if (resolvedSource === 'live' || usedLiveFallback) {
-      messages = liveResults;
-      outputSource = 'live';
-    } else {
-      messages = archivedResults;
-    }
-
-    if (globalFlags.json) {
-      writeJson({ source: outputSource, returned: messages.length, messages });
-    } else {
-      const groups = groupMessagesByChannel(messages);
-      for (const group of groups) {
-        const label = formatPeerHeaderLabel(group);
-        const count = group.messages.length;
-        console.log(`Showing ${count} message${count === 1 ? '' : 's'} for ${label}:`);
-        for (const message of group.messages) {
-          const sender = getMessageSenderLabel(message) || 'unknown';
-          const text = (message.text || '').replace(/\s+/g, ' ').trim();
-          const prefix = outputSource === 'both' ? `[${message.source}] ` : '';
-          console.log(`${prefix}${message.date ?? ''} ${sender} #${message.messageId}: ${text}`);
-        }
-        if (groups.length > 1) {
-          console.log('');
-        }
-      }
-      if (usedLiveFallback) {
-        printArchiveFallbackNote(buildLiveChannelIds());
-      }
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'messagesSearch',
+    args: {
+      query,
+      regex: options.regex,
+      source: options.source,
+      channelIds: channelIds.length ? channelIds : null,
+      tags: tagList.length ? tagList : null,
+      topicId,
+      fromDate: options.after,
+      toDate: options.before,
+      beforeId,
+      afterId,
+      limit: finalLimit,
+      caseInsensitive: !options.caseSensitive,
+    },
   });
+  const { usedLiveFallback, source, returned, messages } = result;
+
+  if (globalFlags.json) {
+    writeJson({ source, returned, messages });
+  } else {
+    renderMessageGroups(messages, source);
+    if (usedLiveFallback) {
+      // Fallback hint targets whatever channels the search resolved against.
+      const hintChannels = channelIds.length ? channelIds : tagList;
+      printArchiveFallbackNote(hintChannels);
+    }
+  }
 }
 
 async function runMessagesShow(globalFlags, options = {}) {
@@ -3009,70 +2609,21 @@ async function runMessagesShow(globalFlags, options = {}) {
   if (!options.id) {
     throw new Error('--id is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    const resolveLiveMetadata = createLiveMetadataResolver(messageSyncService, telegramClient);
-    const messageId = parsePositiveInt(options.id, '--id');
-    const resolvedSource = resolveSource(options.source);
-    let message = null;
-    let resolvedFrom = null;
-    let usedLiveFallback = false;
-
-    if (resolvedSource === 'live' || resolvedSource === 'both') {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      const live = await telegramClient.getMessageById(options.chat, messageId);
-      if (live) {
-        const meta = await resolveLiveMetadata(options.chat);
-        message = {
-          ...formatLiveMessage(live, { channelId: String(options.chat), ...meta }),
-          source: 'live',
-        };
-        resolvedFrom = 'live';
-      }
-    }
-
-    if (!message && (resolvedSource === 'archive' || resolvedSource === 'both')) {
-      const archived = messageSyncService.getArchivedMessage({
-        channelId: options.chat,
-        messageId,
-      });
-      if (archived) {
-        message = { ...archived, source: 'archive' };
-        resolvedFrom = 'archive';
-      }
-    }
-
-    if (!message && resolvedSource === 'archive') {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      const live = await telegramClient.getMessageById(options.chat, messageId);
-      if (live) {
-        const meta = await resolveLiveMetadata(options.chat);
-        message = {
-          ...formatLiveMessage(live, { channelId: String(options.chat), ...meta }),
-          source: 'live',
-        };
-        resolvedFrom = 'live';
-        usedLiveFallback = true;
-      }
-    }
-
-    if (!message) {
-      throw new Error('Message not found.');
-    }
-
-    const payload = { source: resolvedFrom ?? resolvedSource, message };
-    if (globalFlags.json) {
-      writeJson(payload);
-    } else {
-      console.log(JSON.stringify(payload, null, 2));
-      if (usedLiveFallback) {
-        printArchiveFallbackNote([options.chat]);
-      }
-    }
+  const messageId = parsePositiveInt(options.id, '--id');
+  const result = await runOperation(globalFlags, {
+    op: 'messagesGet',
+    args: { channelId: options.chat, messageId, source: options.source },
   });
+  const { usedLiveFallback, source, message } = result;
+  const payload = { source, message };
+  if (globalFlags.json) {
+    writeJson(payload);
+  } else {
+    console.log(JSON.stringify(payload, null, 2));
+    if (usedLiveFallback) {
+      printArchiveFallbackNote([options.chat]);
+    }
+  }
 }
 
 async function runMessagesContext(globalFlags, options = {}) {
@@ -3082,104 +2633,29 @@ async function runMessagesContext(globalFlags, options = {}) {
   if (!options.id) {
     throw new Error('--id is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    const resolveLiveMetadata = createLiveMetadataResolver(messageSyncService, telegramClient);
-    const messageId = parsePositiveInt(options.id, '--id');
-    const resolvedSource = resolveSource(options.source);
-    const safeBefore = parseNonNegativeInt(options.before, '--before') ?? 20;
-    const safeAfter = parseNonNegativeInt(options.after, '--after') ?? 20;
-    let context = null;
-    let resolvedFrom = null;
-    let usedLiveFallback = false;
-
-    if (resolvedSource === 'live' || resolvedSource === 'both') {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      const liveContext = await telegramClient.getMessageContext(options.chat, messageId, {
-        before: safeBefore,
-        after: safeAfter,
-      });
-      if (liveContext.target) {
-        const meta = await resolveLiveMetadata(options.chat);
-        context = {
-          target: {
-            ...formatLiveMessage(liveContext.target, { channelId: String(options.chat), ...meta }),
-            source: 'live',
-          },
-          before: liveContext.before.map((message) => ({
-            ...formatLiveMessage(message, { channelId: String(options.chat), ...meta }),
-            source: 'live',
-          })),
-          after: liveContext.after.map((message) => ({
-            ...formatLiveMessage(message, { channelId: String(options.chat), ...meta }),
-            source: 'live',
-          })),
-        };
-        resolvedFrom = 'live';
-      }
-    }
-
-    if (!context && (resolvedSource === 'archive' || resolvedSource === 'both')) {
-      const archiveContext = messageSyncService.getArchivedMessageContext({
-        channelId: options.chat,
-        messageId,
-        before: safeBefore,
-        after: safeAfter,
-      });
-      if (archiveContext.target) {
-        context = {
-          target: { ...archiveContext.target, source: 'archive' },
-          before: archiveContext.before.map((message) => ({ ...message, source: 'archive' })),
-          after: archiveContext.after.map((message) => ({ ...message, source: 'archive' })),
-        };
-        resolvedFrom = 'archive';
-      }
-    }
-
-    if (!context && resolvedSource === 'archive') {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      const liveContext = await telegramClient.getMessageContext(options.chat, messageId, {
-        before: safeBefore,
-        after: safeAfter,
-      });
-      if (liveContext.target) {
-        const meta = await resolveLiveMetadata(options.chat);
-        context = {
-          target: {
-            ...formatLiveMessage(liveContext.target, { channelId: String(options.chat), ...meta }),
-            source: 'live',
-          },
-          before: liveContext.before.map((message) => ({
-            ...formatLiveMessage(message, { channelId: String(options.chat), ...meta }),
-            source: 'live',
-          })),
-          after: liveContext.after.map((message) => ({
-            ...formatLiveMessage(message, { channelId: String(options.chat), ...meta }),
-            source: 'live',
-          })),
-        };
-        resolvedFrom = 'live';
-        usedLiveFallback = true;
-      }
-    }
-
-    if (!context) {
-      throw new Error('Message not found.');
-    }
-
-    const payload = { source: resolvedFrom ?? resolvedSource, ...context };
-    if (globalFlags.json) {
-      writeJson(payload);
-    } else {
-      console.log(JSON.stringify(payload, null, 2));
-      if (usedLiveFallback) {
-        printArchiveFallbackNote([options.chat]);
-      }
-    }
+  const messageId = parsePositiveInt(options.id, '--id');
+  const safeBefore = parseNonNegativeInt(options.before, '--before') ?? 20;
+  const safeAfter = parseNonNegativeInt(options.after, '--after') ?? 20;
+  const result = await runOperation(globalFlags, {
+    op: 'messagesContext',
+    args: {
+      channelId: options.chat,
+      messageId,
+      before: safeBefore,
+      after: safeAfter,
+      source: options.source,
+    },
   });
+  const { usedLiveFallback, source, target, before, after } = result;
+  const payload = { source, target, before, after };
+  if (globalFlags.json) {
+    writeJson(payload);
+  } else {
+    console.log(JSON.stringify(payload, null, 2));
+    if (usedLiveFallback) {
+      printArchiveFallbackNote([options.chat]);
+    }
+  }
 }
 
 function parseSendParseMode(value) {
@@ -3212,16 +2688,6 @@ function normalizeSendCommandError(error, { method, retries, attempt = 1 } = {})
   return new SendCommandError(classifySendError(error, { method, retries, attempt }));
 }
 
-// Brief progress note on stderr so users/agents see the command is alive while
-// the MTProto connection is established. stderr keeps stdout --json output clean.
-// Suppressed by the global --quiet flag.
-function printSendStatus(message, globalFlags) {
-  if (globalFlags?.quiet) {
-    return;
-  }
-  process.stderr.write(`${message}\n`);
-}
-
 function logSendRetry(details, globalFlags) {
   if (globalFlags.json) {
     process.stderr.write(`${JSON.stringify({ event: 'retry', type: details.type, method: details.method, message: details.message, attempt: details.attempt, retries: details.retries })}\n`);
@@ -3246,6 +2712,34 @@ function buildSendPhotoSuccessPayload({ method, inputChatId, result, attempts })
   });
 }
 
+// Map a client-side invoke timeout (AbortSignal.timeout fires a TimeoutError, an
+// aborted request fires an AbortError) to the clear send-timeout SendCommandError.
+function isInvokeTimeoutError(error) {
+  return error?.name === 'TimeoutError' || error?.name === 'AbortError';
+}
+
+// Run a send op through the warm server and surface its result. invokeTimeoutMs
+// bounds the CLI's wait; the server runs the existing retry/flood logic against
+// the warm client, so retry/FLOOD_WAIT/rate-limit behavior is preserved there.
+async function runSendOperation(globalFlags, { op, method, retries, args, invokeTimeoutMs }) {
+  try {
+    return await runOperation(globalFlags, { op, args, invokeTimeoutMs });
+  } catch (error) {
+    if (isInvokeTimeoutError(error)) {
+      throw new SendCommandError({
+        type: 'timeout',
+        method,
+        message: formatSendTimeoutMessage(invokeTimeoutMs),
+        code: null,
+        attempt: 1,
+        retries,
+        retryable: false,
+      });
+    }
+    throw normalizeSendCommandError(error, { method, retries });
+  }
+}
+
 async function runSendText(globalFlags, options = {}) {
   resolveSendAliases(options);
   const timeoutMs = resolveSendTimeoutMs(globalFlags.timeoutMs);
@@ -3258,46 +2752,38 @@ async function runSendText(globalFlags, options = {}) {
     const parseMode = parseSendParseMode(options.parseMode);
     retries = parseNonNegativeInt(options.retries, '--retries') ?? DEFAULT_SEND_RETRIES;
     const retryBackoff = parseRetryBackoff(options.retryBackoff);
-    return await withCommand(
-      globalFlags,
-      { need: 'telegram', lock: 'write', timeoutMs, timeoutMessage: formatSendTimeoutMessage(timeoutMs) },
-      async ({ telegramClient }) => {
-        printSendStatus('Connecting to Telegram…', globalFlags);
-        if (!(await telegramClient.isAuthorized().catch(() => false))) {
-          throw new Error('Not authenticated. Run `node cli.js auth` first.');
-        }
-        const topicId = parsePositiveInt(options.topic, '--topic');
-        const replyToMessageId = parsePositiveInt(options.replyTo, '--reply-to');
-        const scheduleDate = parseScheduleDate(options.schedule);
-        const { result, attempts } = await executeSendWithRetries(
-          () => telegramClient.sendTextMessage(options.to, options.message, {
-            topicId,
-            replyToMessageId,
-            parseMode,
-            noPreview: options.noPreview,
-            silent: options.silent || false,
-            noforwards: options.forwards === false,
-            scheduleDate,
-          }),
-          {
-            method,
-            retries,
-            retryBackoff,
-            timeoutMs,
-            sleep: (ms) => delay(ms),
-          },
-        );
-        const payload = { channelId: options.to, ...result };
-        if (attempts > 1) {
-          payload.attempts = attempts;
-        }
-        if (globalFlags.json) {
-          writeJson(payload);
-        } else {
-          console.log(`Message sent (${result.messageId}).`);
-        }
+    const topicId = parsePositiveInt(options.topic, '--topic');
+    const replyToMessageId = parsePositiveInt(options.replyTo, '--reply-to');
+    const scheduleDate = parseScheduleDate(options.schedule);
+    const { result, attempts } = await runSendOperation(globalFlags, {
+      op: 'sendText',
+      method,
+      retries,
+      invokeTimeoutMs: timeoutMs,
+      args: {
+        chat: options.to,
+        text: options.message,
+        topicId,
+        replyToMessageId,
+        parseMode,
+        noPreview: options.noPreview,
+        silent: options.silent || false,
+        noforwards: options.forwards === false,
+        scheduleDate,
+        retries,
+        retryBackoff,
+        timeoutMs,
       },
-    );
+    });
+    const payload = { channelId: options.to, ...result };
+    if (attempts > 1) {
+      payload.attempts = attempts;
+    }
+    if (globalFlags.json) {
+      writeJson(payload);
+    } else {
+      console.log(`Message sent (${result.messageId}).`);
+    }
   } catch (error) {
     throw normalizeSendCommandError(error, { method, retries });
   }
@@ -3318,47 +2804,36 @@ async function runSendPhoto(globalFlags, options = {}) {
     }
     retries = parseNonNegativeInt(options.retries, '--retries') ?? DEFAULT_SEND_RETRIES;
     const retryBackoff = parseRetryBackoff(options.retryBackoff);
-    return await withCommand(
-      globalFlags,
-      { need: 'telegram', lock: 'write', timeoutMs, timeoutMessage: formatSendTimeoutMessage(timeoutMs) },
-      async ({ telegramClient }) => {
-        printSendStatus('Connecting to Telegram…', globalFlags);
-        if (!(await telegramClient.isAuthorized().catch(() => false))) {
-          throw new Error('Not authenticated. Run `node cli.js auth` first.');
-        }
-        const topicId = parsePositiveInt(options.topic, '--topic');
-        const replyToMessageId = parsePositiveInt(options.replyTo, '--reply-to');
-        const scheduleDate = parseScheduleDate(options.schedule);
-        const sendOptions = {
-          caption: options.caption,
-          topicId,
-          replyToMessageId,
-          parseMode,
-          silent: options.silent || false,
-          noforwards: options.forwards === false,
-          captionAbove: options.captionAbove || false,
-          spoiler: options.spoiler || false,
-          scheduleDate,
-        };
-        const prepared = await telegramClient.preparePhotoMessage(options.to, options.photo, sendOptions);
-        const { result, attempts } = await executeSendWithRetries(
-          () => telegramClient.sendPreparedPhotoMessage(prepared),
-          {
-            method,
-            retries,
-            retryBackoff,
-            timeoutMs,
-            sleep: (ms) => delay(ms),
-            onRetry: (details) => logSendRetry(details, globalFlags),
-          },
-        );
-        if (globalFlags.json) {
-          writeJson(buildSendPhotoSuccessPayload({ method, inputChatId: options.to, result, attempts }));
-        } else {
-          console.log(`Photo sent (${result.messageId}).`);
-        }
+    const topicId = parsePositiveInt(options.topic, '--topic');
+    const replyToMessageId = parsePositiveInt(options.replyTo, '--reply-to');
+    const scheduleDate = parseScheduleDate(options.schedule);
+    const { result, attempts } = await runSendOperation(globalFlags, {
+      op: 'sendPhoto',
+      method,
+      retries,
+      invokeTimeoutMs: timeoutMs,
+      args: {
+        chat: options.to,
+        photo: options.photo,
+        caption: options.caption,
+        topicId,
+        replyToMessageId,
+        parseMode,
+        silent: options.silent || false,
+        noforwards: options.forwards === false,
+        captionAbove: options.captionAbove || false,
+        spoiler: options.spoiler || false,
+        scheduleDate,
+        retries,
+        retryBackoff,
+        timeoutMs,
       },
-    );
+    });
+    if (globalFlags.json) {
+      writeJson(buildSendPhotoSuccessPayload({ method, inputChatId: options.to, result, attempts }));
+    } else {
+      console.log(`Photo sent (${result.messageId}).`);
+    }
   } catch (error) {
     throw normalizeSendCommandError(error, { method, retries });
   }
@@ -3379,50 +2854,42 @@ async function runSendFile(globalFlags, options = {}) {
     }
     retries = parseNonNegativeInt(options.retries, '--retries') ?? DEFAULT_SEND_RETRIES;
     const retryBackoff = parseRetryBackoff(options.retryBackoff);
-    return await withCommand(
-      globalFlags,
-      { need: 'telegram', lock: 'write', timeoutMs, timeoutMessage: formatSendTimeoutMessage(timeoutMs) },
-      async ({ telegramClient }) => {
-        printSendStatus('Connecting to Telegram…', globalFlags);
-        if (!(await telegramClient.isAuthorized().catch(() => false))) {
-          throw new Error('Not authenticated. Run `node cli.js auth` first.');
-        }
-        const topicId = parsePositiveInt(options.topic, '--topic');
-        const replyToMessageId = parsePositiveInt(options.replyTo, '--reply-to');
-        const scheduleDate = parseScheduleDate(options.schedule);
-        const { result, attempts } = await executeSendWithRetries(
-          () => telegramClient.sendFileMessage(options.to, options.file, {
-            caption: options.caption,
-            filename: options.filename,
-            topicId,
-            replyToMessageId,
-            parseMode,
-            silent: options.silent || false,
-            noforwards: options.forwards === false,
-            captionAbove: options.captionAbove || false,
-            spoiler: options.spoiler || false,
-            scheduleDate,
-            forceDocument: options.forceDocument || false,
-          }),
-          {
-            method,
-            retries,
-            retryBackoff,
-            timeoutMs,
-            sleep: (ms) => delay(ms),
-          },
-        );
-        const payload = { channelId: options.to, ...result };
-        if (attempts > 1) {
-          payload.attempts = attempts;
-        }
-        if (globalFlags.json) {
-          writeJson(payload);
-        } else {
-          console.log(`File sent (${result.messageId}).`);
-        }
+    const topicId = parsePositiveInt(options.topic, '--topic');
+    const replyToMessageId = parsePositiveInt(options.replyTo, '--reply-to');
+    const scheduleDate = parseScheduleDate(options.schedule);
+    const { result, attempts } = await runSendOperation(globalFlags, {
+      op: 'sendFile',
+      method,
+      retries,
+      invokeTimeoutMs: timeoutMs,
+      args: {
+        chat: options.to,
+        file: options.file,
+        caption: options.caption,
+        filename: options.filename,
+        topicId,
+        replyToMessageId,
+        parseMode,
+        silent: options.silent || false,
+        noforwards: options.forwards === false,
+        captionAbove: options.captionAbove || false,
+        spoiler: options.spoiler || false,
+        scheduleDate,
+        forceDocument: options.forceDocument || false,
+        retries,
+        retryBackoff,
+        timeoutMs,
       },
-    );
+    });
+    const payload = { channelId: options.to, ...result };
+    if (attempts > 1) {
+      payload.attempts = attempts;
+    }
+    if (globalFlags.json) {
+      writeJson(payload);
+    } else {
+      console.log(`File sent (${result.messageId}).`);
+    }
   } catch (error) {
     throw normalizeSendCommandError(error, { method, retries });
   }
@@ -3436,42 +2903,33 @@ async function runMediaDownload(globalFlags, options = {}) {
     throw new Error('--id is required');
   }
   const messageId = parsePositiveInt(options.id, '--id');
-  return withCommand(globalFlags, { need: 'telegram', lock: 'read' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const result = await telegramClient.downloadMessageMedia(options.chat, messageId, {
-      outputPath: options.output,
-    });
-
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Downloaded to ${result.path} (${result.bytes} bytes).`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'mediaDownload',
+    args: { channelId: options.chat, messageId, outputPath: options.output },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Downloaded to ${result.path} (${result.bytes} bytes).`);
+  }
 }
 
 async function runTopicsList(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const limit = parsePositiveInt(options.limit, '--limit') ?? 100;
-    const topics = await telegramClient.listForumTopics(options.chat, { limit });
-    messageSyncService.upsertTopics(options.chat, topics);
-
-    if (globalFlags.json) {
-      writeJson({ total: topics.total ?? topics.length, topics });
-    } else {
-      for (const topic of topics) {
-        console.log(`#${topic.id} ${topic.title ?? ''}`.trim());
-      }
-    }
+  const limit = parsePositiveInt(options.limit, '--limit') ?? 100;
+  const result = await runOperation(globalFlags, {
+    op: 'topicsList',
+    args: { channelId: options.chat, limit },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    for (const topic of result.topics) {
+      console.log(`#${topic.id} ${topic.title ?? ''}`.trim());
+    }
+  }
 }
 
 async function runTopicsSearch(globalFlags, options = {}) {
@@ -3481,25 +2939,18 @@ async function runTopicsSearch(globalFlags, options = {}) {
   if (!options.query) {
     throw new Error('--query is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const limit = parsePositiveInt(options.limit, '--limit') ?? 100;
-    const topics = await telegramClient.listForumTopics(options.chat, {
-      query: options.query,
-      limit,
-    });
-    messageSyncService.upsertTopics(options.chat, topics);
-
-    if (globalFlags.json) {
-      writeJson({ total: topics.total ?? topics.length, topics });
-    } else {
-      for (const topic of topics) {
-        console.log(`#${topic.id} ${topic.title ?? ''}`.trim());
-      }
-    }
+  const limit = parsePositiveInt(options.limit, '--limit') ?? 100;
+  const result = await runOperation(globalFlags, {
+    op: 'topicsList',
+    args: { channelId: options.chat, query: options.query, limit },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    for (const topic of result.topics) {
+      console.log(`#${topic.id} ${topic.title ?? ''}`.trim());
+    }
+  }
 }
 
 async function runTagsSet(globalFlags, options = {}) {
@@ -3514,126 +2965,104 @@ async function runTagsSet(globalFlags, options = {}) {
   if (!hasTagFlag) {
     throw new Error('--tags or --tag is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    const finalTags = messageSyncService.setChannelTags(options.chat, tagValues, {
-      source: options.source,
-    });
-    if (globalFlags.json) {
-      writeJson({ channelId: options.chat, tags: finalTags });
-    } else {
-      console.log(`Tags set for ${options.chat}: ${finalTags.join(', ')}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'tagsSet',
+    args: { chat: options.chat, tags: tagValues, source: options.source },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Tags set for ${options.chat}: ${result.tags.join(', ')}`);
+  }
 }
 
 async function runTagsList(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'read' }, async ({ messageSyncService }) => {
-    const tags = messageSyncService.listChannelTags(options.chat, { source: options.source });
-    if (globalFlags.json) {
-      writeJson(tags);
-    } else {
-      console.log(tags.map((tag) => tag.tag).join(', '));
-    }
+  const tags = await runOperation(globalFlags, {
+    op: 'tagsList',
+    args: { chat: options.chat, source: options.source },
   });
+  if (globalFlags.json) {
+    writeJson(tags);
+  } else {
+    console.log(tags.map((tag) => tag.tag).join(', '));
+  }
 }
 
 async function runTagsSearch(globalFlags, options = {}) {
   if (!options.tag) {
     throw new Error('--tag is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'read' }, async ({ messageSyncService }) => {
-    const limit = parsePositiveInt(options.limit, '--limit') ?? 100;
-    const channels = messageSyncService.listTaggedChannels(options.tag, {
-      source: options.source,
-      limit,
-    });
-    if (globalFlags.json) {
-      writeJson(channels);
-    } else {
-      for (const channel of channels) {
-        const label = channel.peerTitle || channel.username || channel.channelId;
-        console.log(`${label} (${channel.channelId})`);
-      }
-    }
+  const limit = parsePositiveInt(options.limit, '--limit') ?? 100;
+  const channels = await runOperation(globalFlags, {
+    op: 'tagsSearch',
+    args: { tag: options.tag, source: options.source, limit },
   });
+  if (globalFlags.json) {
+    writeJson(channels);
+  } else {
+    for (const channel of channels) {
+      const label = channel.peerTitle || channel.username || channel.channelId;
+      console.log(`${label} (${channel.channelId})`);
+    }
+  }
 }
 
 async function runTagsAuto(globalFlags, options = {}) {
-  return withCommand(globalFlags, { need: 'full', lock: 'write' }, async ({ telegramClient, messageSyncService }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const channelIds = parseListValues(options.chat);
-    const limit = parsePositiveInt(options.limit, '--limit') ?? 50;
-    const results = await messageSyncService.autoTagChannels({
+  const channelIds = parseListValues(options.chat);
+  const limit = parsePositiveInt(options.limit, '--limit') ?? 50;
+  const results = await runOperation(globalFlags, {
+    op: 'tagsAuto',
+    args: {
       channelIds: channelIds.length ? channelIds : null,
       limit,
       source: options.source,
       refreshMetadata: options.refreshMetadata !== false,
-    });
-    if (globalFlags.json) {
-      writeJson(results);
-    } else {
-      for (const entry of results) {
-        console.log(`${entry.channelId}: ${entry.tags.map((tag) => tag.tag).join(', ')}`);
-      }
-    }
+    },
   });
+  if (globalFlags.json) {
+    writeJson(results);
+  } else {
+    for (const entry of results) {
+      console.log(`${entry.channelId}: ${entry.tags.map((tag) => tag.tag).join(', ')}`);
+    }
+  }
 }
 
 async function runMetadataGet(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    let metadata = messageSyncService.getChannelMetadata(options.chat);
-    if (!metadata) {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      const live = await telegramClient.getPeerMetadata(options.chat);
-      metadata = {
-        channelId: String(options.chat),
-        peerTitle: live?.peerTitle ?? null,
-        peerType: live?.peerType ?? null,
-        chatType: live?.chatType ?? null,
-        isForum: live?.isForum ?? null,
-        username: live?.username ?? null,
-        about: live?.about ?? null,
-        metadataUpdatedAt: null,
-        source: 'live',
-      };
-    }
-    if (globalFlags.json) {
-      writeJson(metadata);
-    } else {
-      console.log(JSON.stringify(metadata, null, 2));
-    }
+  const metadata = await runOperation(globalFlags, {
+    op: 'metadataGet',
+    args: { chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson(metadata);
+  } else {
+    console.log(JSON.stringify(metadata, null, 2));
+  }
 }
 
 async function runMetadataRefresh(globalFlags, options = {}) {
-  return withCommand(globalFlags, { need: 'full', lock: 'write' }, async ({ telegramClient, messageSyncService }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const channelIds = parseListValues(options.chat);
-    const limit = parsePositiveInt(options.limit, '--limit') ?? 20;
-    const results = await messageSyncService.refreshChannelMetadata({
+  const channelIds = parseListValues(options.chat);
+  const limit = parsePositiveInt(options.limit, '--limit') ?? 20;
+  const results = await runOperation(globalFlags, {
+    op: 'metadataRefresh',
+    args: {
       channelIds: channelIds.length ? channelIds : null,
       limit,
       force: Boolean(options.force),
       onlyMissing: Boolean(options.onlyMissing),
-    });
-    if (globalFlags.json) {
-      writeJson(results);
-    } else {
-      console.log(JSON.stringify(results, null, 2));
-    }
+    },
   });
+  if (globalFlags.json) {
+    writeJson(results);
+  } else {
+    console.log(JSON.stringify(results, null, 2));
+  }
 }
 
 async function runContactsSearch(globalFlags, queryParts, options = {}) {
@@ -3641,49 +3070,33 @@ async function runContactsSearch(globalFlags, queryParts, options = {}) {
   if (!query) {
     throw new Error('search requires a query');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'write' }, async ({ telegramClient, messageSyncService }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    await messageSyncService.refreshContacts();
-    const contacts = messageSyncService.searchContacts(query, {
-      limit: parsePositiveInt(options.limit, '--limit') ?? 50,
-    });
-
-    if (globalFlags.json) {
-      writeJson(contacts);
-    } else {
-      for (const contact of contacts) {
-        const label = contact.alias || contact.displayName || contact.username || contact.userId;
-        console.log(`${label} (${contact.userId})`);
-      }
-    }
+  const contacts = await runOperation(globalFlags, {
+    op: 'contactsSearch',
+    args: { query, limit: parsePositiveInt(options.limit, '--limit') ?? 50 },
   });
+  if (globalFlags.json) {
+    writeJson(contacts);
+  } else {
+    for (const contact of contacts) {
+      const label = contact.alias || contact.displayName || contact.username || contact.userId;
+      console.log(`${label} (${contact.userId})`);
+    }
+  }
 }
 
 async function runContactsShow(globalFlags, options = {}) {
   if (!options.user) {
     throw new Error('--user is required');
   }
-  return withCommand(globalFlags, { need: 'full', lock: 'read' }, async ({ telegramClient, messageSyncService }) => {
-    let contact = messageSyncService.getContact(options.user);
-    if (!contact) {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-      await messageSyncService.refreshContacts();
-      contact = messageSyncService.getContact(options.user);
-    }
-    if (!contact) {
-      throw new Error('Contact not found.');
-    }
-
-    if (globalFlags.json) {
-      writeJson(contact);
-    } else {
-      console.log(JSON.stringify(contact, null, 2));
-    }
+  const contact = await runOperation(globalFlags, {
+    op: 'contactsShow',
+    args: { userId: options.user },
   });
+  if (globalFlags.json) {
+    writeJson(contact);
+  } else {
+    console.log(JSON.stringify(contact, null, 2));
+  }
 }
 
 async function runContactsAliasSet(globalFlags, options = {}) {
@@ -3693,28 +3106,30 @@ async function runContactsAliasSet(globalFlags, options = {}) {
   if (!options.alias) {
     throw new Error('--alias is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    const alias = messageSyncService.setContactAlias(options.user, options.alias);
-    if (globalFlags.json) {
-      writeJson({ userId: options.user, alias });
-    } else {
-      console.log(`Alias set for ${options.user}: ${alias}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'contactsAliasSet',
+    args: { userId: options.user, alias: options.alias },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Alias set for ${result.userId}: ${result.alias}`);
+  }
 }
 
 async function runContactsAliasRm(globalFlags, options = {}) {
   if (!options.user) {
     throw new Error('--user is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    messageSyncService.removeContactAlias(options.user);
-    if (globalFlags.json) {
-      writeJson({ userId: options.user, removed: true });
-    } else {
-      console.log(`Alias removed for ${options.user}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'contactsAliasRemove',
+    args: { userId: options.user },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Alias removed for ${result.userId}`);
+  }
 }
 
 async function runContactsTagsAdd(globalFlags, options = {}) {
@@ -3725,14 +3140,15 @@ async function runContactsTagsAdd(globalFlags, options = {}) {
   if (!tags.length) {
     throw new Error('--tag is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    const updated = messageSyncService.addContactTags(options.user, tags);
-    if (globalFlags.json) {
-      writeJson({ userId: options.user, tags: updated });
-    } else {
-      console.log(`Tags updated for ${options.user}: ${updated.join(', ')}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'contactsTagsAdd',
+    args: { userId: options.user, tags },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Tags updated for ${result.userId}: ${result.tags.join(', ')}`);
+  }
 }
 
 async function runContactsTagsRm(globalFlags, options = {}) {
@@ -3743,14 +3159,15 @@ async function runContactsTagsRm(globalFlags, options = {}) {
   if (!tags.length) {
     throw new Error('--tag is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    const updated = messageSyncService.removeContactTags(options.user, tags);
-    if (globalFlags.json) {
-      writeJson({ userId: options.user, tags: updated });
-    } else {
-      console.log(`Tags updated for ${options.user}: ${updated.join(', ')}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'contactsTagsRemove',
+    args: { userId: options.user, tags },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Tags updated for ${result.userId}: ${result.tags.join(', ')}`);
+  }
 }
 
 async function runContactsNotesSet(globalFlags, options = {}) {
@@ -3760,51 +3177,44 @@ async function runContactsNotesSet(globalFlags, options = {}) {
   if (options.notes === undefined) {
     throw new Error('--notes is required');
   }
-  return withCommand(globalFlags, { need: 'archive', lock: 'write' }, async ({ messageSyncService }) => {
-    const notes = messageSyncService.setContactNotes(options.user, options.notes);
-    if (globalFlags.json) {
-      writeJson({ userId: options.user, notes });
-    } else {
-      console.log(`Notes updated for ${options.user}.`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'contactsNotesSet',
+    args: { userId: options.user, notes: options.notes },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Notes updated for ${result.userId}.`);
+  }
 }
 
 async function runGroupsList(globalFlags, options = {}) {
-  return withCommand(globalFlags, { need: 'telegram', lock: 'read' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const groups = await telegramClient.listGroups({
-      query: options.query,
-      limit: parsePositiveInt(options.limit, '--limit') ?? 100,
-    });
-
-    if (globalFlags.json) {
-      writeJson(groups);
-    } else {
-      for (const group of groups) {
-        console.log(`${group.title} (${group.id})`);
-      }
-    }
+  const groups = await runOperation(globalFlags, {
+    op: 'groupsList',
+    args: { query: options.query, limit: parsePositiveInt(options.limit, '--limit') ?? 100 },
   });
+  if (globalFlags.json) {
+    writeJson(groups);
+  } else {
+    for (const group of groups) {
+      console.log(`${group.title} (${group.id})`);
+    }
+  }
 }
 
 async function runGroupsInfo(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'read' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const info = await telegramClient.getGroupInfo(options.chat);
-    if (globalFlags.json) {
-      writeJson(info);
-    } else {
-      console.log(JSON.stringify(info, null, 2));
-    }
+  const info = await runOperation(globalFlags, {
+    op: 'groupsInfo',
+    args: { chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson(info);
+  } else {
+    console.log(JSON.stringify(info, null, 2));
+  }
 }
 
 async function runGroupsRename(globalFlags, options = {}) {
@@ -3814,17 +3224,15 @@ async function runGroupsRename(globalFlags, options = {}) {
   if (!options.name) {
     throw new Error('--name is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    await telegramClient.renameGroup(options.chat, options.name);
-    if (globalFlags.json) {
-      writeJson({ channelId: options.chat, name: options.name });
-    } else {
-      console.log(`Group renamed: ${options.name}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'groupsRename',
+    args: { chat: options.chat, name: options.name },
   });
+  if (globalFlags.json) {
+    writeJson({ channelId: result.channelId, name: result.name });
+  } else {
+    console.log(`Group renamed: ${result.name}`);
+  }
 }
 
 async function runGroupMembersAdd(globalFlags, options = {}) {
@@ -3835,19 +3243,17 @@ async function runGroupMembersAdd(globalFlags, options = {}) {
   if (!users.length) {
     throw new Error('--user is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const failed = await telegramClient.addGroupMembers(options.chat, users);
-    if (globalFlags.json) {
-      writeJson({ channelId: options.chat, failed });
-    } else if (failed.length) {
-      console.log(`Some members failed: ${JSON.stringify(failed, null, 2)}`);
-    } else {
-      console.log('Members added.');
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'groupMembersAdd',
+    args: { chat: options.chat, userIds: users },
   });
+  if (globalFlags.json) {
+    writeJson({ channelId: result.channelId, failed: result.failed });
+  } else if (result.failed.length) {
+    console.log(`Some members failed: ${JSON.stringify(result.failed, null, 2)}`);
+  } else {
+    console.log('Members added.');
+  }
 }
 
 async function runGroupMembersRemove(globalFlags, options = {}) {
@@ -3858,20 +3264,18 @@ async function runGroupMembersRemove(globalFlags, options = {}) {
   if (!users.length) {
     throw new Error('--user is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const result = await telegramClient.removeGroupMembers(options.chat, users);
-    if (globalFlags.json) {
-      writeJson({ channelId: options.chat, ...result });
-    } else {
-      console.log(`Removed: ${result.removed.join(', ')}`);
-      if (result.failed.length) {
-        console.log(`Failed: ${JSON.stringify(result.failed, null, 2)}`);
-      }
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'groupMembersRemove',
+    args: { chat: options.chat, userIds: users },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Removed: ${result.removed.join(', ')}`);
+    if (result.failed.length) {
+      console.log(`Failed: ${JSON.stringify(result.failed, null, 2)}`);
+    }
+  }
 }
 
 async function runGroupInviteLinkGet(globalFlags, options = {}) {
@@ -3881,9 +3285,6 @@ async function runGroupInviteLinkGet(globalFlags, options = {}) {
   const link = await runOperation(globalFlags, {
     op: 'getGroupInviteLink',
     args: { chat: options.chat },
-    need: 'telegram',
-    lock: 'read',
-    requireAuth: true,
   });
   if (globalFlags.json) {
     writeJson({ link: link.link });
@@ -3896,18 +3297,15 @@ async function runGroupInviteLinkRevoke(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const existing = await telegramClient.getGroupInviteLink(options.chat);
-    const link = await telegramClient.revokeGroupInviteLink(options.chat, existing);
-    if (globalFlags.json) {
-      writeJson({ link: link.link });
-    } else {
-      console.log(link.link);
-    }
+  const link = await runOperation(globalFlags, {
+    op: 'revokeGroupInviteLink',
+    args: { chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson({ link: link.link });
+  } else {
+    console.log(link.link);
+  }
 }
 
 async function runGroupsJoin(globalFlags, options = {}) {
@@ -3918,118 +3316,105 @@ async function runGroupsJoin(globalFlags, options = {}) {
   if (!invite) {
     throw new Error('Invalid invite code.');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    const chat = await telegramClient.joinGroup(invite);
-    if (globalFlags.json) {
-      writeJson({
-        id: chat.id?.toString?.() ?? null,
-        title: chat.displayName || chat.title || 'Unknown',
-        username: chat.username ?? null,
-      });
-    } else {
-      console.log(`Joined: ${chat.displayName || chat.title || 'Unknown'}`);
-    }
+  const chat = await runOperation(globalFlags, {
+    op: 'groupsJoin',
+    args: { invite },
   });
+  if (globalFlags.json) {
+    writeJson({
+      id: chat.id?.toString?.() ?? null,
+      title: chat.displayName || chat.title || 'Unknown',
+      username: chat.username ?? null,
+    });
+  } else {
+    console.log(`Joined: ${chat.displayName || chat.title || 'Unknown'}`);
+  }
 }
 
 async function runGroupsLeave(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    await telegramClient.leaveGroup(options.chat);
-    if (globalFlags.json) {
-      writeJson({ channelId: options.chat, left: true });
-    } else {
-      console.log(`Left ${options.chat}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'groupsLeave',
+    args: { chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson({ channelId: result.channelId, left: true });
+  } else {
+    console.log(`Left ${options.chat}`);
+  }
 }
 
 // --- Folders handlers ---
 
 async function runFoldersList(globalFlags) {
-  return withCommand(globalFlags, { need: 'telegram', lock: 'read' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
+  const folders = await runOperation(globalFlags, { op: 'foldersList', args: {} });
+  if (globalFlags.json) {
+    writeJson(folders);
+  } else {
+    for (const f of folders) {
+      console.log(`${f.title} (id=${f.id}, type=${f.type})`);
     }
-    const folders = await telegramClient.getFolders();
-    if (globalFlags.json) {
-      writeJson(folders);
-    } else {
-      for (const f of folders) {
-        console.log(`${f.title} (id=${f.id}, type=${f.type})`);
-      }
-    }
-  });
+  }
 }
 
 async function runFoldersShow(globalFlags, folder, opts = {}) {
-  return withCommand(globalFlags, { need: 'telegram', lock: 'read' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const info = await telegramClient.showFolder(folder, { resolve: opts.resolve });
-    if (globalFlags.json) {
-      writeJson(info);
-    } else {
-      console.log(`${info.title} (id=${info.id}, type=${info.type})`);
-      if (info.emoji) console.log(`  emoji: ${info.emoji}`);
-      const flags = ['contacts', 'nonContacts', 'groups', 'broadcasts', 'bots'].filter((f) => info[f]);
-      if (flags.length) console.log(`  includes: ${flags.join(', ')}`);
-      const excludes = ['excludeMuted', 'excludeRead', 'excludeArchived'].filter((f) => info[f]);
-      if (excludes.length) console.log(`  excludes: ${excludes.join(', ')}`);
-
-      if (opts.resolve) {
-        const printResolvedPeers = (peers, label) => {
-          if (!peers?.length) return;
-          if (label) console.log(`  ${label}:`);
-          const indent = label ? '    ' : '  ';
-          const grouped = {};
-          for (const p of peers) {
-            const group = p.type + 's';
-            if (!grouped[group]) grouped[group] = [];
-            const displayName = p.name ?? p.title ?? '(unresolved)';
-            grouped[group].push(`${displayName} (${p.id})`);
-          }
-          for (const [group, items] of Object.entries(grouped)) {
-            console.log(`${indent}${group}:`);
-            for (const item of items) console.log(`${indent}  - ${item}`);
-          }
-        };
-        printResolvedPeers(info.includePeers);
-        printResolvedPeers(info.excludePeers, 'excluded');
-        printResolvedPeers(info.pinnedPeers, 'pinned');
-      } else {
-        const printPeers = (peers, label) => {
-          if (!peers?.length) {
-            console.log(`  ${label}: (none)`);
-            return;
-          }
-          console.log(`  ${label}:`);
-          for (const p of peers) console.log(`    - ${p.type}:${p.id}`);
-        };
-        printPeers(info.includePeers, 'includePeers');
-        printPeers(info.excludePeers, 'excludePeers');
-        printPeers(info.pinnedPeers, 'pinnedPeers');
-      }
-    }
+  const info = await runOperation(globalFlags, {
+    op: 'foldersShow',
+    args: { folder, resolve: opts.resolve },
   });
+  if (globalFlags.json) {
+    writeJson(info);
+  } else {
+    console.log(`${info.title} (id=${info.id}, type=${info.type})`);
+    if (info.emoji) console.log(`  emoji: ${info.emoji}`);
+    const flags = ['contacts', 'nonContacts', 'groups', 'broadcasts', 'bots'].filter((f) => info[f]);
+    if (flags.length) console.log(`  includes: ${flags.join(', ')}`);
+    const excludes = ['excludeMuted', 'excludeRead', 'excludeArchived'].filter((f) => info[f]);
+    if (excludes.length) console.log(`  excludes: ${excludes.join(', ')}`);
+
+    if (opts.resolve) {
+      const printResolvedPeers = (peers, label) => {
+        if (!peers?.length) return;
+        if (label) console.log(`  ${label}:`);
+        const indent = label ? '    ' : '  ';
+        const grouped = {};
+        for (const p of peers) {
+          const group = p.type + 's';
+          if (!grouped[group]) grouped[group] = [];
+          const displayName = p.name ?? p.title ?? '(unresolved)';
+          grouped[group].push(`${displayName} (${p.id})`);
+        }
+        for (const [group, items] of Object.entries(grouped)) {
+          console.log(`${indent}${group}:`);
+          for (const item of items) console.log(`${indent}  - ${item}`);
+        }
+      };
+      printResolvedPeers(info.includePeers);
+      printResolvedPeers(info.excludePeers, 'excluded');
+      printResolvedPeers(info.pinnedPeers, 'pinned');
+    } else {
+      const printPeers = (peers, label) => {
+        if (!peers?.length) {
+          console.log(`  ${label}: (none)`);
+          return;
+        }
+        console.log(`  ${label}:`);
+        for (const p of peers) console.log(`    - ${p.type}:${p.id}`);
+      };
+      printPeers(info.includePeers, 'includePeers');
+      printPeers(info.excludePeers, 'excludePeers');
+      printPeers(info.pinnedPeers, 'pinnedPeers');
+    }
+  }
 }
 
 async function runFoldersCreate(globalFlags, options) {
   if (!options.title || options.title.length > 12) throw new Error('Folder title must be 1-12 characters');
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const result = await telegramClient.createFolder({
+  const result = await runOperation(globalFlags, {
+    op: 'foldersCreate',
+    args: {
       title: options.title,
       emoji: options.emoji,
       contacts: options.includeContacts,
@@ -4043,115 +3428,103 @@ async function runFoldersCreate(globalFlags, options) {
       includePeers: options.chat?.length ? options.chat : undefined,
       excludePeers: options.excludeChat?.length ? options.excludeChat : undefined,
       pinnedPeers: options.pinChat?.length ? options.pinChat : undefined,
-    });
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Created folder: ${result.title} (id=${result.id})`);
-    }
+    },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Created folder: ${result.title} (id=${result.id})`);
+  }
 }
 
 async function runFoldersEdit(globalFlags, folder, options) {
   if (options.title !== undefined && (options.title.length === 0 || options.title.length > 12)) throw new Error('Folder title must be 1-12 characters');
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const modification = {};
-    if (options.title !== undefined) modification.title = options.title;
-    if (options.emoji !== undefined) modification.emoji = options.emoji;
-    if (options.includeContacts !== undefined) modification.contacts = options.includeContacts;
-    if (options.includeNonContacts !== undefined) modification.nonContacts = options.includeNonContacts;
-    if (options.includeGroups !== undefined) modification.groups = options.includeGroups;
-    if (options.includeChannels !== undefined) modification.broadcasts = options.includeChannels;
-    if (options.includeBots !== undefined) modification.bots = options.includeBots;
-    if (options.excludeMuted !== undefined) modification.excludeMuted = options.excludeMuted;
-    if (options.excludeRead !== undefined) modification.excludeRead = options.excludeRead;
-    if (options.excludeArchived !== undefined) modification.excludeArchived = options.excludeArchived;
-    if (options.chat?.length) modification.includePeers = options.chat;
-    if (options.excludeChat?.length) modification.excludePeers = options.excludeChat;
-    if (options.pinChat?.length) modification.pinnedPeers = options.pinChat;
-    const result = await telegramClient.editFolder(folder, modification);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Updated folder: ${result.title} (id=${result.id})`);
-    }
+  const modification = {};
+  if (options.title !== undefined) modification.title = options.title;
+  if (options.emoji !== undefined) modification.emoji = options.emoji;
+  if (options.includeContacts !== undefined) modification.contacts = options.includeContacts;
+  if (options.includeNonContacts !== undefined) modification.nonContacts = options.includeNonContacts;
+  if (options.includeGroups !== undefined) modification.groups = options.includeGroups;
+  if (options.includeChannels !== undefined) modification.broadcasts = options.includeChannels;
+  if (options.includeBots !== undefined) modification.bots = options.includeBots;
+  if (options.excludeMuted !== undefined) modification.excludeMuted = options.excludeMuted;
+  if (options.excludeRead !== undefined) modification.excludeRead = options.excludeRead;
+  if (options.excludeArchived !== undefined) modification.excludeArchived = options.excludeArchived;
+  if (options.chat?.length) modification.includePeers = options.chat;
+  if (options.excludeChat?.length) modification.excludePeers = options.excludeChat;
+  if (options.pinChat?.length) modification.pinnedPeers = options.pinChat;
+  const result = await runOperation(globalFlags, {
+    op: 'foldersEdit',
+    args: { folder, modification },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Updated folder: ${result.title} (id=${result.id})`);
+  }
 }
 
 async function runFoldersDelete(globalFlags, folder) {
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const result = await telegramClient.deleteFolder(folder);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Deleted folder id=${result.id}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'foldersDelete',
+    args: { folder },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Deleted folder id=${result.id}`);
+  }
 }
 
 async function runFoldersReorder(globalFlags, options) {
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const ids = options.ids.split(',').map((s) => s.trim()).filter((s) => s !== '').map(Number);
-    const result = await telegramClient.setFoldersOrder(ids);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log('Folders reordered');
-    }
+  const ids = options.ids.split(',').map((s) => s.trim()).filter((s) => s !== '').map(Number);
+  const result = await runOperation(globalFlags, {
+    op: 'foldersReorder',
+    args: { ids },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log('Folders reordered');
+  }
 }
 
 async function runFoldersChatsAdd(globalFlags, folder, options) {
   if (!options.chat) throw new Error('--chat is required');
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const result = await telegramClient.addChatToFolder(folder, options.chat);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Chat added to folder id=${result.folderId}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'foldersChatsAdd',
+    args: { folder, chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Chat added to folder id=${result.folderId}`);
+  }
 }
 
 async function runFoldersChatsRemove(globalFlags, folder, options) {
   if (!options.chat) throw new Error('--chat is required');
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const result = await telegramClient.removeChatFromFolder(folder, options.chat);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Chat removed from folder id=${result.folderId}`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'foldersChatsRemove',
+    args: { folder, chat: options.chat },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Chat removed from folder id=${result.folderId}`);
+  }
 }
 
 async function runFoldersJoin(globalFlags, link) {
-  return withCommand(globalFlags, { need: 'telegram', lock: 'write' }, async ({ telegramClient }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `tgcli auth` first.');
-    }
-    const result = await telegramClient.joinChatlist(link);
-    if (globalFlags.json) {
-      writeJson(result);
-    } else {
-      console.log(`Joined folder: ${result.title} (id=${result.id})`);
-    }
+  const result = await runOperation(globalFlags, {
+    op: 'foldersJoin',
+    args: { link },
   });
+  if (globalFlags.json) {
+    writeJson(result);
+  } else {
+    console.log(`Joined folder: ${result.title} (id=${result.id})`);
+  }
 }
 
 function isCliEntrypoint(argvPath = process.argv[1]) {

--- a/core/command-context.js
+++ b/core/command-context.js
@@ -1,7 +1,7 @@
 import { resolveStoreDir } from './store.js';
 import { acquireReadLock, acquireStoreLock } from '../store-lock.js';
 import { createMessageSyncService, createTelegramClient, resolveValidatedConfig } from './services.js';
-import { invoke, pingServer } from './control-client.js';
+import { ensureServer, invoke } from './control-client.js';
 import { OPERATIONS } from './operations.js';
 
 // Runs fn(ctx) with exactly the services a command needs, owning the surrounding
@@ -79,34 +79,25 @@ export async function withCommand(globalFlags, opts, fn) {
   }, timeoutMs, onTimeout, timeoutMessage);
 }
 
-// Runs a shared operation server-first with a local fallback, returning its
-// structured result. Both paths execute the SAME OPERATIONS[op], so the result —
-// and therefore whatever the caller renders from it — is identical regardless of
-// who served it.
+// Runs a shared operation against the always-on control server, returning its
+// structured result. The server is the single warm backend: it owns the live
+// MTProto connection, the open DB, auth, and store locking, so the CLI is a thin
+// client here.
 //
-//   - If a control server is already running, ask it to run the op against its
-//     warm (already-authed) services via POST /control/invoke.
-//   - Otherwise run the op locally inside withCommand with the requested
-//     services/lock. requireAuth enforces the local auth check; the warm path
-//     needs none because the server's client is already logged in.
+//   - Auto-start the server when it is not already running (ensureServer), then
+//     ask it to run OPERATIONS[op] against its warm services via POST
+//     /control/invoke and return that result.
+//   - invokeTimeoutMs bounds the client's wait on that request (e.g. the 30s
+//     send default); it is independent of the global --timeout.
 //
-// Opportunistic only: this never starts a server, so an offline run keeps the
-// current local behavior.
-export async function runOperation(globalFlags, { op, args, need, lock, requireAuth = false }) {
-  const handler = OPERATIONS[op];
-  if (!handler) {
+// A failure to reach or start the server surfaces as a clear error.
+export async function runOperation(globalFlags, { op, args, invokeTimeoutMs } = {}) {
+  if (!OPERATIONS[op]) {
     throw new Error(`runOperation: unknown operation "${op}"`);
   }
   const storeDir = resolveStoreDir();
-  if (await pingServer(storeDir)) {
-    return invoke(storeDir, { op, args });
-  }
-  return withCommand(globalFlags, { need, lock }, async (ctx) => {
-    if (requireAuth && !(await ctx.telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
-    return handler(ctx, args);
-  });
+  await ensureServer(storeDir, { idleExit: '60s' });
+  return invoke(storeDir, { op, args, timeoutMs: invokeTimeoutMs });
 }
 
 const VALID_NEEDS = new Set(['telegram', 'archive', 'full', 'worker']);

--- a/core/control-client.js
+++ b/core/control-client.js
@@ -13,6 +13,7 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 
 import { CONTROL_FILE, CONTROL_TOKEN_HEADER } from './control-server.js';
+import { SendCommandError } from './send-utils.js';
 
 // Path to this package's CLI, used to (re)spawn `tgcli server`.
 const CLI_ENTRYPOINT = fileURLToPath(new URL('../cli.js', import.meta.url));
@@ -125,18 +126,26 @@ export async function cancelBackfill(storeDir, { chatId, jobId } = {}) {
 
 // POST /control/invoke { op, args } → the operation's result. Runs the shared
 // operation handler against the server's warm services and returns `result`.
-// Throws on a non-2xx response so the caller surfaces the server's error.
-export async function invoke(storeDir, { op, args } = {}) {
+// timeoutMs bounds the request wait (defaults to the enqueue budget); a value of
+// 0 disables it. A send op that fails reports structured details under
+// `sendError`, which we re-throw as a SendCommandError so the CLI renders the
+// same human/JSON error as a local send would. Other non-2xx responses surface
+// the server's error message.
+export async function invoke(storeDir, { op, args, timeoutMs } = {}) {
   const control = readControlFile(storeDir);
   if (!control) {
     throw new Error('No control server is running.');
   }
+  const effectiveTimeoutMs = timeoutMs === undefined ? ENQUEUE_TIMEOUT_MS : timeoutMs;
   const { status, json } = await controlFetch(control, '/control/invoke', {
     method: 'POST',
     body: { op, args },
-    timeoutMs: ENQUEUE_TIMEOUT_MS,
+    timeoutMs: effectiveTimeoutMs > 0 ? effectiveTimeoutMs : undefined,
   });
   if (status !== 200) {
+    if (json?.sendError) {
+      throw new SendCommandError(json.sendError);
+    }
     throw new Error(json?.error ?? `Operation failed (HTTP ${status})`);
   }
   return json?.result;

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 
 import { readJsonBody, sendJson } from './http-util.js';
 import { OPERATIONS } from './operations.js';
+import { SendCommandError } from './send-utils.js';
 
 export const CONTROL_FILE = 'control.json';
 export const CONTROL_TOKEN_HEADER = 'x-tgcli-control-token';
@@ -148,13 +149,23 @@ export function createControlRequestHandler({
           sendJson(res, 400, { error: `Unknown operation: ${op ?? ''}` });
           return;
         }
-        // The warm client serves these reads, so make sure it is logged in
+        // The warm client serves these operations, so make sure it is logged in
         // before the handler touches MTProto.
         if (typeof ensureLogin === 'function') {
           await ensureLogin();
         }
-        const result = await handler(warmServices, body?.args ?? {});
-        sendJson(res, 200, { result });
+        try {
+          const result = await handler(warmServices, body?.args ?? {});
+          sendJson(res, 200, { result });
+        } catch (error) {
+          // A send op carries structured failure details; relay them so the CLI
+          // renders the same human/JSON error a local send would.
+          if (error instanceof SendCommandError) {
+            sendJson(res, 500, { error: error.message, sendError: error.details });
+          } else {
+            sendJson(res, 500, { error: error?.message ?? 'Operation failed' });
+          }
+        }
         return;
       }
 

--- a/core/operations.js
+++ b/core/operations.js
@@ -1,17 +1,175 @@
-// Shared operation handlers: the single source of truth for read operations that
-// both the CLI and the MCP tools expose. Each handler is a pure function of the
-// services it needs plus its args, returning the structured data a caller renders.
+// Shared operation handlers: the single source of truth for every Telegram and
+// archive operation the CLI commands and the MCP tools perform. Each handler is
+// `async (ctx, args) => result`, a function of the warm services it needs plus
+// its args, returning the structured data a caller renders.
 //
-// ctx is the warm-or-local service bundle: { telegramClient, messageSyncService }.
-// The same handler runs whether a warm server serves the call (via
-// /control/invoke) or the one-shot CLI runs it locally, so the result shape — and
-// therefore the rendered output — is identical across both paths.
+// ctx is the warm service bundle the control server owns:
+// { telegramClient, messageSyncService }. Handlers may use either service;
+// `messages` ops honor `source: archive|live|both`. The same handler backs both
+// the CLI (via runOperation -> /control/invoke) and the MCP tools, so one
+// implementation serves both surfaces with no duplicated logic.
 //
 // OPERATIONS is a fixed allowlist: the control server dispatches only the keys
 // present here.
 
-// args: { query?: string, limit?: number }. With a query, search dialogs by title
-// or username; otherwise list dialogs. Returns the dialog array as-is.
+import {
+  buildSendSuccessPayload,
+  executeSendWithRetries,
+  SendCommandError,
+} from './send-utils.js';
+
+// --- shared helpers ---
+
+function resolveSource(source) {
+  const resolved = source ? String(source).toLowerCase() : 'archive';
+  if (!['archive', 'live', 'both'].includes(resolved)) {
+    throw new Error(`Invalid source: ${source}`);
+  }
+  return resolved;
+}
+
+function parseDateMs(value, label) {
+  if (!value) {
+    return null;
+  }
+  const ts = Date.parse(value);
+  if (Number.isNaN(ts)) {
+    throw new Error(`Invalid ${label}: ${value}`);
+  }
+  return ts;
+}
+
+function filterLiveMessagesByDate(messages, fromDate, toDate) {
+  const fromMs = parseDateMs(fromDate, 'after');
+  const toMs = parseDateMs(toDate, 'before');
+  if (!fromMs && !toMs) {
+    return messages;
+  }
+  return messages.filter((message) => {
+    const ts = typeof message.date === 'number' ? message.date * 1000 : null;
+    if (!ts) {
+      return false;
+    }
+    if (fromMs && ts < fromMs) {
+      return false;
+    }
+    if (toMs && ts > toMs) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function getMessageIdValue(message) {
+  const value = message?.messageId ?? message?.id;
+  return Number.isFinite(value) ? value : null;
+}
+
+function filterMessagesById(messages, beforeId, afterId) {
+  if (!beforeId && !afterId) {
+    return messages;
+  }
+  return messages.filter((message) => {
+    const messageId = getMessageIdValue(message);
+    if (!messageId) {
+      return false;
+    }
+    if (beforeId && messageId >= beforeId) {
+      return false;
+    }
+    if (afterId && messageId <= afterId) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function formatLiveMessage(message, context) {
+  const dateIso = message.date ? new Date(message.date * 1000).toISOString() : null;
+  return {
+    channelId: context.channelId ?? message.peer_id ?? null,
+    peerTitle: context.peerTitle ?? null,
+    username: context.username ?? null,
+    messageId: message.id,
+    date: dateIso,
+    fromId: message.from_id ?? null,
+    fromUsername: message.from_username ?? null,
+    fromDisplayName: message.from_display_name ?? null,
+    fromPeerType: message.from_peer_type ?? null,
+    fromIsBot: typeof message.from_is_bot === 'boolean' ? message.from_is_bot : null,
+    text: message.text ?? message.message ?? '',
+    urls: message.urls ?? null,
+    media: message.media ?? null,
+    topicId: message.topic_id ?? null,
+  };
+}
+
+function messageDateMs(message) {
+  const ts = Date.parse(message.date ?? '');
+  return Number.isNaN(ts) ? 0 : ts;
+}
+
+function mergeMessageSets(sets, limit) {
+  const map = new Map();
+  for (const list of sets) {
+    for (const message of list) {
+      const channelId = message.channelId ?? '';
+      const messageId = message.messageId ?? message.id;
+      const key = `${String(channelId)}:${String(messageId)}`;
+      if (!map.has(key) || message.source === 'live') {
+        map.set(key, message);
+      }
+    }
+  }
+  const merged = Array.from(map.values());
+  merged.sort((a, b) => messageDateMs(b) - messageDateMs(a));
+  return limit && limit > 0 ? merged.slice(0, limit) : merged;
+}
+
+function buildMessageListPayload(source, messages, requestedLimit) {
+  const hasMore = requestedLimit ? messages.length === requestedLimit : false;
+  const payload = {
+    source,
+    returned: messages.length,
+    hasMore,
+    messages,
+  };
+  if (hasMore) {
+    const nextBeforeId = getMessageIdValue(messages[messages.length - 1]);
+    if (nextBeforeId) {
+      payload.nextBeforeId = nextBeforeId;
+    }
+  }
+  return payload;
+}
+
+function normalizeChannelIds(value) {
+  if (Array.isArray(value)) {
+    return value.filter((id) => id !== null && id !== undefined && String(id).trim() !== '');
+  }
+  if (value === null || value === undefined || String(value).trim() === '') {
+    return [];
+  }
+  return [value];
+}
+
+// Resolve peerTitle/username for a channel, preferring cached metadata and
+// falling back to a live peer lookup so live-formatted messages carry a label.
+async function resolveLiveMetadata(ctx, channelId, fallback = {}) {
+  const meta = ctx.messageSyncService.getChannelMetadata(channelId);
+  let peerTitle = meta?.peerTitle ?? fallback.peerTitle ?? null;
+  let username = meta?.username ?? fallback.username ?? null;
+  if (!peerTitle || !username) {
+    const live = await ctx.telegramClient.getPeerMetadata(channelId);
+    peerTitle = peerTitle ?? live?.peerTitle ?? null;
+    username = username ?? live?.username ?? null;
+  }
+  return { peerTitle, username };
+}
+
+// --- channels ---
+
+// args: { query?, limit? }. With a query, search dialogs; otherwise list them.
 async function listChannels(ctx, args = {}) {
   const limit = args.limit ?? 50;
   if (args.query) {
@@ -20,13 +178,816 @@ async function listChannels(ctx, args = {}) {
   return ctx.telegramClient.listDialogs(limit);
 }
 
-// args: { chat: string|number }. Returns the primary invite-link descriptor for
-// the group as the Telegram client reports it.
+// args: { chat }. Returns the archive channel record, or a live-metadata-derived
+// record when the chat is not tracked in the archive.
+async function channelShow(ctx, args = {}) {
+  let channel = ctx.messageSyncService.getChannel(args.chat);
+  if (channel) {
+    return channel;
+  }
+  const meta = await ctx.telegramClient.getPeerMetadata(args.chat);
+  return {
+    channelId: String(args.chat),
+    peerTitle: meta?.peerTitle ?? null,
+    peerType: meta?.peerType ?? null,
+    chatType: meta?.chatType ?? null,
+    isForum: meta?.isForum ?? null,
+    username: meta?.username ?? null,
+    syncEnabled: null,
+    lastMessageId: null,
+    lastMessageDate: null,
+    oldestMessageId: null,
+    oldestMessageDate: null,
+    about: meta?.about ?? null,
+    metadataUpdatedAt: null,
+    createdAt: null,
+    updatedAt: null,
+    source: 'live',
+  };
+}
+
+// args: { chat, enable }. Toggle the per-chat archive flag; enabling also queues
+// a backfill job when none exists. Returns the new sync state plus job info.
+async function channelSetSync(ctx, args = {}) {
+  const result = ctx.messageSyncService.setChannelSync(args.chat, Boolean(args.enable));
+  let job = null;
+  let jobQueued = false;
+  if (args.enable) {
+    const existing = ctx.messageSyncService.listJobs({ channelId: args.chat, limit: 1 });
+    if (existing.length > 0) {
+      job = existing[0];
+    } else {
+      job = ctx.messageSyncService.addJob(args.chat);
+      jobQueued = true;
+      void ctx.messageSyncService.processQueue();
+    }
+  }
+  return {
+    channelId: result.channel_id,
+    syncEnabled: Boolean(result.sync_enabled),
+    jobId: job?.id ?? null,
+    jobStatus: job?.status ?? null,
+    jobQueued,
+  };
+}
+
+// args: { chat, messageId }. Marks the channel read up to messageId.
+async function channelMarkRead(ctx, args = {}) {
+  return ctx.telegramClient.markChannelRead(args.chat, args.messageId);
+}
+
+// --- messages ---
+
+async function fetchLiveMessagesForChannel(ctx, id, options = {}) {
+  const { query, topicId, limit, beforeId, afterId } = options;
+  let peerTitle = null;
+  let username = null;
+  let liveMessages = [];
+
+  if (query) {
+    const response = await ctx.telegramClient.searchChannelMessages(id, {
+      query,
+      limit,
+      topicId,
+      beforeId,
+      afterId,
+    });
+    liveMessages = response.messages;
+    peerTitle = response.peerTitle ?? null;
+  } else if (topicId) {
+    const response = await ctx.telegramClient.getTopicMessages(id, topicId, limit, {
+      beforeId,
+      afterId,
+    });
+    liveMessages = response.messages;
+  } else {
+    const fetchOptions = {};
+    if (beforeId) fetchOptions.beforeId = beforeId;
+    if (afterId) fetchOptions.afterId = afterId;
+    const response = await ctx.telegramClient.getMessagesByChannelId(id, limit, fetchOptions);
+    liveMessages = response.messages;
+    peerTitle = response.peerTitle ?? null;
+  }
+
+  const meta = await resolveLiveMetadata(ctx, id, { peerTitle, username });
+  return { messages: liveMessages, peerTitle: meta.peerTitle, username: meta.username };
+}
+
+// args: { channelIds?, topicId?, source?, fromDate?, toDate?, beforeId?, afterId?,
+// limit? }. Lists messages from the archive and/or live API. With source 'archive'
+// and no archived rows, falls back to live and flags usedLiveFallback so callers
+// can hint the user. Returns a list payload plus { usedLiveFallback }.
+async function messagesList(ctx, args = {}) {
+  const resolvedSource = resolveSource(args.source);
+  const channelIds = normalizeChannelIds(args.channelIds ?? args.channelId);
+  const topicId = args.topicId ?? null;
+  const limit = args.limit ?? 50;
+  const beforeId = args.beforeId ?? null;
+  const afterId = args.afterId ?? null;
+
+  let archivedResults = [];
+  let liveResults = [];
+  let usedLiveFallback = false;
+
+  const fetchLive = async (liveChannelIds) => {
+    const results = [];
+    for (const id of liveChannelIds) {
+      const fetched = await fetchLiveMessagesForChannel(ctx, id, {
+        topicId,
+        limit,
+        beforeId,
+        afterId,
+      });
+      const filtered = filterMessagesById(
+        filterLiveMessagesByDate(fetched.messages, args.fromDate, args.toDate),
+        beforeId,
+        afterId,
+      );
+      results.push(...filtered.map((message) => ({
+        ...formatLiveMessage(message, {
+          channelId: String(id),
+          peerTitle: fetched.peerTitle,
+          username: fetched.username,
+        }),
+        source: 'live',
+      })));
+    }
+    return results;
+  };
+
+  if (resolvedSource === 'archive' || resolvedSource === 'both') {
+    const archived = ctx.messageSyncService.listArchivedMessages({
+      channelIds: channelIds.length ? channelIds : null,
+      topicId,
+      fromDate: args.fromDate,
+      toDate: args.toDate,
+      beforeId,
+      afterId,
+      limit,
+    });
+    archivedResults = archived.map((message) => ({ ...message, source: 'archive' }));
+  }
+
+  if (resolvedSource === 'live' || resolvedSource === 'both') {
+    if (!channelIds.length) {
+      throw new Error('--chat is required for live source.');
+    }
+    liveResults = await fetchLive(channelIds);
+  }
+
+  if (resolvedSource === 'archive' && archivedResults.length === 0 && channelIds.length) {
+    liveResults = await fetchLive(channelIds);
+    usedLiveFallback = true;
+  }
+
+  let messages = [];
+  let outputSource = resolvedSource;
+  if (resolvedSource === 'both') {
+    messages = mergeMessageSets([archivedResults, liveResults], limit);
+  } else if (resolvedSource === 'live' || usedLiveFallback) {
+    messages = liveResults;
+    outputSource = 'live';
+  } else {
+    messages = archivedResults;
+  }
+
+  return { ...buildMessageListPayload(outputSource, messages, limit), usedLiveFallback };
+}
+
+// args: { query?, regex?, source?, channelIds?, tags?, topicId?, fromDate?,
+// toDate?, beforeId?, afterId?, limit?, caseInsensitive? }. Searches archive and/or
+// live. Falls back to live when archive search is empty. Returns
+// { source, returned, messages, usedLiveFallback }.
+async function messagesSearch(ctx, args = {}) {
+  const resolvedSource = resolveSource(args.source);
+  const channelIds = normalizeChannelIds(args.channelIds ?? args.channelId);
+  const tagList = normalizeChannelIds(args.tags ?? args.tag);
+  const topicId = args.topicId ?? null;
+  const limit = args.limit ?? 100;
+  const beforeId = args.beforeId ?? null;
+  const afterId = args.afterId ?? null;
+  const caseInsensitive = args.caseInsensitive !== false;
+  const query = args.query;
+
+  if (!query && !args.regex && tagList.length === 0) {
+    throw new Error('Provide query, regex, or tag for messages search.');
+  }
+
+  let archivedResults = [];
+  let liveResults = [];
+  let usedLiveFallback = false;
+
+  const buildLiveChannelIds = () => {
+    let liveChannelIds = channelIds;
+    if (!liveChannelIds.length && tagList.length) {
+      const tagged = new Map();
+      for (const tag of tagList) {
+        const channels = ctx.messageSyncService.listTaggedChannels(tag, { limit: 200 });
+        for (const channel of channels) {
+          tagged.set(channel.channelId, channel);
+        }
+      }
+      liveChannelIds = Array.from(tagged.keys());
+    }
+    return liveChannelIds;
+  };
+
+  const fetchLive = async (liveChannelIds) => {
+    let liveRegex = null;
+    if (args.regex) {
+      try {
+        liveRegex = new RegExp(args.regex, caseInsensitive ? 'i' : '');
+      } catch (error) {
+        throw new Error(`Invalid regex: ${error.message}`);
+      }
+    }
+    const results = [];
+    for (const id of liveChannelIds) {
+      const fetched = await fetchLiveMessagesForChannel(ctx, id, {
+        query,
+        topicId,
+        limit,
+        beforeId,
+        afterId,
+      });
+      let filtered = filterLiveMessagesByDate(fetched.messages, args.fromDate, args.toDate);
+      filtered = filterMessagesById(filtered, beforeId, afterId);
+      if (liveRegex) {
+        filtered = filtered.filter((message) =>
+          liveRegex.test(message.text ?? message.message ?? ''),
+        );
+      }
+      results.push(...filtered.map((message) => ({
+        ...formatLiveMessage(message, {
+          channelId: String(id),
+          peerTitle: fetched.peerTitle,
+          username: fetched.username,
+        }),
+        source: 'live',
+      })));
+    }
+    return results;
+  };
+
+  if (resolvedSource === 'archive' || resolvedSource === 'both') {
+    const archived = ctx.messageSyncService.searchArchiveMessages({
+      query,
+      regex: args.regex,
+      tags: tagList.length ? tagList : null,
+      channelIds: channelIds.length ? channelIds : null,
+      topicId,
+      fromDate: args.fromDate,
+      toDate: args.toDate,
+      beforeId,
+      afterId,
+      limit,
+      caseInsensitive,
+    });
+    archivedResults = archived.map((message) => ({ ...message, source: 'archive' }));
+  }
+
+  if (resolvedSource === 'live' || resolvedSource === 'both') {
+    const liveChannelIds = buildLiveChannelIds();
+    if (!liveChannelIds.length) {
+      throw new Error('--chat is required for live search.');
+    }
+    liveResults = await fetchLive(liveChannelIds);
+  }
+
+  if (resolvedSource === 'archive' && archivedResults.length === 0) {
+    const liveChannelIds = buildLiveChannelIds();
+    if (liveChannelIds.length) {
+      liveResults = await fetchLive(liveChannelIds);
+      usedLiveFallback = true;
+    }
+  }
+
+  let messages = [];
+  let outputSource = resolvedSource;
+  if (resolvedSource === 'both') {
+    messages = mergeMessageSets([archivedResults, liveResults], limit);
+  } else if (resolvedSource === 'live' || usedLiveFallback) {
+    messages = liveResults;
+    outputSource = 'live';
+  } else {
+    messages = archivedResults;
+  }
+
+  return { source: outputSource, returned: messages.length, messages, usedLiveFallback };
+}
+
+// args: { channelId, messageId, source? }. Returns { source, message, usedLiveFallback }.
+async function messagesGet(ctx, args = {}) {
+  const resolvedSource = resolveSource(args.source);
+  const channelId = args.channelId;
+  const messageId = args.messageId;
+  let message = null;
+  let resolvedFrom = null;
+  let usedLiveFallback = false;
+
+  const fetchLive = async () => {
+    const live = await ctx.telegramClient.getMessageById(channelId, messageId);
+    if (!live) {
+      return null;
+    }
+    const meta = await resolveLiveMetadata(ctx, channelId);
+    return {
+      ...formatLiveMessage(live, { channelId: String(channelId), ...meta }),
+      source: 'live',
+    };
+  };
+
+  if (resolvedSource === 'live' || resolvedSource === 'both') {
+    message = await fetchLive();
+    if (message) {
+      resolvedFrom = 'live';
+    }
+  }
+
+  if (!message && (resolvedSource === 'archive' || resolvedSource === 'both')) {
+    const archived = ctx.messageSyncService.getArchivedMessage({ channelId, messageId });
+    if (archived) {
+      message = { ...archived, source: 'archive' };
+      resolvedFrom = 'archive';
+    }
+  }
+
+  if (!message && resolvedSource === 'archive') {
+    message = await fetchLive();
+    if (message) {
+      resolvedFrom = 'live';
+      usedLiveFallback = true;
+    }
+  }
+
+  if (!message) {
+    throw new Error('Message not found.');
+  }
+
+  return { source: resolvedFrom ?? resolvedSource, message, usedLiveFallback };
+}
+
+// args: { channelId, messageId, before?, after?, source? }.
+// Returns { source, target, before, after, usedLiveFallback }.
+async function messagesContext(ctx, args = {}) {
+  const resolvedSource = resolveSource(args.source);
+  const channelId = args.channelId;
+  const messageId = args.messageId;
+  const safeBefore = Number.isFinite(args.before) ? args.before : 20;
+  const safeAfter = Number.isFinite(args.after) ? args.after : 20;
+  let context = null;
+  let resolvedFrom = null;
+  let usedLiveFallback = false;
+
+  const fetchLive = async () => {
+    const liveContext = await ctx.telegramClient.getMessageContext(channelId, messageId, {
+      before: safeBefore,
+      after: safeAfter,
+    });
+    if (!liveContext.target) {
+      return null;
+    }
+    const meta = await resolveLiveMetadata(ctx, channelId);
+    const toLive = (message) => ({
+      ...formatLiveMessage(message, { channelId: String(channelId), ...meta }),
+      source: 'live',
+    });
+    return {
+      target: toLive(liveContext.target),
+      before: liveContext.before.map(toLive),
+      after: liveContext.after.map(toLive),
+    };
+  };
+
+  if (resolvedSource === 'live' || resolvedSource === 'both') {
+    context = await fetchLive();
+    if (context) {
+      resolvedFrom = 'live';
+    }
+  }
+
+  if (!context && (resolvedSource === 'archive' || resolvedSource === 'both')) {
+    const archiveContext = ctx.messageSyncService.getArchivedMessageContext({
+      channelId,
+      messageId,
+      before: safeBefore,
+      after: safeAfter,
+    });
+    if (archiveContext.target) {
+      context = {
+        target: { ...archiveContext.target, source: 'archive' },
+        before: archiveContext.before.map((message) => ({ ...message, source: 'archive' })),
+        after: archiveContext.after.map((message) => ({ ...message, source: 'archive' })),
+      };
+      resolvedFrom = 'archive';
+    }
+  }
+
+  if (!context && resolvedSource === 'archive') {
+    context = await fetchLive();
+    if (context) {
+      resolvedFrom = 'live';
+      usedLiveFallback = true;
+    }
+  }
+
+  if (!context) {
+    throw new Error('Message not found.');
+  }
+
+  return { source: resolvedFrom ?? resolvedSource, ...context, usedLiveFallback };
+}
+
+// --- send ---
+
+// Shared send executor: runs the existing send-utils retry/flood/timeout logic
+// against the warm client. `sendFn` performs one send attempt; on exhausted
+// retries this throws a SendCommandError carrying structured details, which the
+// control server serializes and the CLI reconstructs.
+async function runSend(sendFn, { method, retries, retryBackoff, timeoutMs }) {
+  return executeSendWithRetries(sendFn, {
+    method,
+    retries,
+    retryBackoff,
+    timeoutMs,
+  });
+}
+
+// args: { chat, text, parseMode?, topicId?, replyToMessageId?, noPreview?, silent?,
+// noforwards?, scheduleDate?, retries?, retryBackoff?, timeoutMs? }.
+// Returns { result, attempts }.
+async function sendText(ctx, args = {}) {
+  return runSend(
+    () => ctx.telegramClient.sendTextMessage(args.chat, args.text, {
+      topicId: args.topicId,
+      replyToMessageId: args.replyToMessageId,
+      parseMode: args.parseMode,
+      noPreview: args.noPreview,
+      silent: args.silent || false,
+      noforwards: args.noforwards || false,
+      scheduleDate: args.scheduleDate,
+    }),
+    { method: 'sendText', retries: args.retries, retryBackoff: args.retryBackoff, timeoutMs: args.timeoutMs },
+  );
+}
+
+// args: like sendText plus { photo, caption?, captionAbove?, spoiler? }.
+// Returns { result, attempts }.
+async function sendPhoto(ctx, args = {}) {
+  const prepared = await ctx.telegramClient.preparePhotoMessage(args.chat, args.photo, {
+    caption: args.caption,
+    topicId: args.topicId,
+    replyToMessageId: args.replyToMessageId,
+    parseMode: args.parseMode,
+    silent: args.silent || false,
+    noforwards: args.noforwards || false,
+    captionAbove: args.captionAbove || false,
+    spoiler: args.spoiler || false,
+    scheduleDate: args.scheduleDate,
+  });
+  return runSend(
+    () => ctx.telegramClient.sendPreparedPhotoMessage(prepared),
+    { method: 'sendPhoto', retries: args.retries, retryBackoff: args.retryBackoff, timeoutMs: args.timeoutMs },
+  );
+}
+
+// args: like sendText plus { file, caption?, filename?, captionAbove?, spoiler?,
+// forceDocument? }. Returns { result, attempts }.
+async function sendFile(ctx, args = {}) {
+  return runSend(
+    () => ctx.telegramClient.sendFileMessage(args.chat, args.file, {
+      caption: args.caption,
+      filename: args.filename,
+      topicId: args.topicId,
+      replyToMessageId: args.replyToMessageId,
+      parseMode: args.parseMode,
+      silent: args.silent || false,
+      noforwards: args.noforwards || false,
+      captionAbove: args.captionAbove || false,
+      spoiler: args.spoiler || false,
+      scheduleDate: args.scheduleDate,
+      forceDocument: args.forceDocument || false,
+    }),
+    { method: 'sendFile', retries: args.retries, retryBackoff: args.retryBackoff, timeoutMs: args.timeoutMs },
+  );
+}
+
+// --- media ---
+
+// args: { channelId, messageId, outputPath? }. Returns the download descriptor.
+async function mediaDownload(ctx, args = {}) {
+  return ctx.telegramClient.downloadMessageMedia(args.channelId, args.messageId, {
+    outputPath: args.outputPath,
+  });
+}
+
+// --- topics ---
+
+// args: { channelId, query?, limit? }. Lists/searches forum topics and refreshes
+// the archive topic cache. Returns { total, topics }.
+async function topicsList(ctx, args = {}) {
+  const limit = args.limit ?? 100;
+  const listOptions = { limit };
+  if (args.query) {
+    listOptions.query = args.query;
+  }
+  const topics = await ctx.telegramClient.listForumTopics(args.channelId, listOptions);
+  ctx.messageSyncService.upsertTopics(args.channelId, topics);
+  return { total: topics.total ?? topics.length, topics };
+}
+
+// --- tags ---
+
+// args: { chat, tags, source? }. Returns the channel's tags after the set.
+async function tagsSet(ctx, args = {}) {
+  const finalTags = ctx.messageSyncService.setChannelTags(args.chat, args.tags, {
+    source: args.source,
+  });
+  return { channelId: args.chat, tags: finalTags };
+}
+
+// args: { chat, source? }. Lists a channel's tags.
+async function tagsList(ctx, args = {}) {
+  return ctx.messageSyncService.listChannelTags(args.chat, { source: args.source });
+}
+
+// args: { tag, source?, limit? }. Lists channels carrying a tag.
+async function tagsSearch(ctx, args = {}) {
+  const limit = args.limit ?? 100;
+  return ctx.messageSyncService.listTaggedChannels(args.tag, {
+    source: args.source,
+    limit,
+  });
+}
+
+// args: { channelIds?, limit?, source?, refreshMetadata? }. Auto-tags channels.
+async function tagsAuto(ctx, args = {}) {
+  const channelIds = normalizeChannelIds(args.channelIds ?? args.channelId);
+  const limit = args.limit ?? 50;
+  return ctx.messageSyncService.autoTagChannels({
+    channelIds: channelIds.length ? channelIds : null,
+    limit,
+    source: args.source,
+    refreshMetadata: args.refreshMetadata !== false,
+  });
+}
+
+// --- metadata ---
+
+// args: { chat }. Returns cached channel metadata, falling back to a live lookup.
+async function metadataGet(ctx, args = {}) {
+  const metadata = ctx.messageSyncService.getChannelMetadata(args.chat);
+  if (metadata) {
+    return metadata;
+  }
+  const live = await ctx.telegramClient.getPeerMetadata(args.chat);
+  return {
+    channelId: String(args.chat),
+    peerTitle: live?.peerTitle ?? null,
+    peerType: live?.peerType ?? null,
+    chatType: live?.chatType ?? null,
+    isForum: live?.isForum ?? null,
+    username: live?.username ?? null,
+    about: live?.about ?? null,
+    metadataUpdatedAt: null,
+    source: 'live',
+  };
+}
+
+// args: { channelIds?, limit?, force?, onlyMissing? }. Refreshes cached metadata.
+async function metadataRefresh(ctx, args = {}) {
+  const channelIds = normalizeChannelIds(args.channelIds ?? args.channelId);
+  const limit = args.limit ?? 20;
+  return ctx.messageSyncService.refreshChannelMetadata({
+    channelIds: channelIds.length ? channelIds : null,
+    limit,
+    force: Boolean(args.force),
+    onlyMissing: Boolean(args.onlyMissing),
+  });
+}
+
+// --- contacts ---
+
+// args: { query, limit? }. Refreshes contacts then searches them.
+async function contactsSearch(ctx, args = {}) {
+  await ctx.messageSyncService.refreshContacts();
+  return ctx.messageSyncService.searchContacts(args.query, {
+    limit: args.limit ?? 50,
+  });
+}
+
+// args: { userId }. Returns a contact, refreshing from the network when missing.
+async function contactsShow(ctx, args = {}) {
+  let contact = ctx.messageSyncService.getContact(args.userId);
+  if (!contact) {
+    await ctx.messageSyncService.refreshContacts();
+    contact = ctx.messageSyncService.getContact(args.userId);
+  }
+  if (!contact) {
+    throw new Error('Contact not found.');
+  }
+  return contact;
+}
+
+// args: { userId, alias }. Sets a contact alias.
+async function contactsAliasSet(ctx, args = {}) {
+  const alias = ctx.messageSyncService.setContactAlias(args.userId, args.alias);
+  return { userId: args.userId, alias };
+}
+
+// args: { userId }. Removes a contact alias.
+async function contactsAliasRemove(ctx, args = {}) {
+  ctx.messageSyncService.removeContactAlias(args.userId);
+  return { userId: args.userId, removed: true };
+}
+
+// args: { userId, tags }. Adds contact tags, returning the updated set.
+async function contactsTagsAdd(ctx, args = {}) {
+  const tags = ctx.messageSyncService.addContactTags(args.userId, args.tags);
+  return { userId: args.userId, tags };
+}
+
+// args: { userId, tags }. Removes contact tags, returning the updated set.
+async function contactsTagsRemove(ctx, args = {}) {
+  const tags = ctx.messageSyncService.removeContactTags(args.userId, args.tags);
+  return { userId: args.userId, tags };
+}
+
+// args: { userId, notes }. Sets contact notes.
+async function contactsNotesSet(ctx, args = {}) {
+  const notes = ctx.messageSyncService.setContactNotes(args.userId, args.notes);
+  return { userId: args.userId, notes };
+}
+
+// --- groups ---
+
+// args: { query?, limit? }. Lists group chats and supergroups.
+async function groupsList(ctx, args = {}) {
+  return ctx.telegramClient.listGroups({
+    query: args.query,
+    limit: args.limit ?? 100,
+  });
+}
+
+// args: { chat }. Returns group info and metadata.
+async function groupsInfo(ctx, args = {}) {
+  return ctx.telegramClient.getGroupInfo(args.chat);
+}
+
+// args: { chat, name }. Renames a group.
+async function groupsRename(ctx, args = {}) {
+  await ctx.telegramClient.renameGroup(args.chat, args.name);
+  return { channelId: args.chat, name: args.name };
+}
+
+// args: { chat, userIds }. Adds members; returns { failed }.
+async function groupMembersAdd(ctx, args = {}) {
+  const failed = await ctx.telegramClient.addGroupMembers(args.chat, args.userIds);
+  return { channelId: args.chat, failed };
+}
+
+// args: { chat, userIds }. Removes members; returns { removed, failed }.
+async function groupMembersRemove(ctx, args = {}) {
+  const result = await ctx.telegramClient.removeGroupMembers(args.chat, args.userIds);
+  return { channelId: args.chat, ...result };
+}
+
+// args: { chat }. Returns the primary invite-link descriptor.
 async function getGroupInviteLink(ctx, args = {}) {
   return ctx.telegramClient.getGroupInviteLink(args.chat);
 }
 
+// args: { chat }. Revokes the primary invite link, returning the new descriptor.
+async function revokeGroupInviteLink(ctx, args = {}) {
+  const existing = await ctx.telegramClient.getGroupInviteLink(args.chat);
+  return ctx.telegramClient.revokeGroupInviteLink(args.chat, existing);
+}
+
+// args: { invite }. Joins a group via invite link/code.
+async function groupsJoin(ctx, args = {}) {
+  return ctx.telegramClient.joinGroup(args.invite);
+}
+
+// args: { chat }. Leaves a group.
+async function groupsLeave(ctx, args = {}) {
+  await ctx.telegramClient.leaveGroup(args.chat);
+  return { channelId: args.chat, left: true };
+}
+
+// --- folders ---
+
+// args: {}. Lists all chat folders.
+async function foldersList(ctx) {
+  return ctx.telegramClient.getFolders();
+}
+
+// args: { folder, resolve? }. Shows folder details.
+async function foldersShow(ctx, args = {}) {
+  return ctx.telegramClient.showFolder(args.folder, { resolve: args.resolve });
+}
+
+// args: folder definition fields. Creates a folder.
+async function foldersCreate(ctx, args = {}) {
+  return ctx.telegramClient.createFolder({
+    title: args.title,
+    emoji: args.emoji,
+    contacts: args.contacts,
+    nonContacts: args.nonContacts,
+    groups: args.groups,
+    broadcasts: args.broadcasts,
+    bots: args.bots,
+    excludeMuted: args.excludeMuted,
+    excludeRead: args.excludeRead,
+    excludeArchived: args.excludeArchived,
+    includePeers: args.includePeers,
+    excludePeers: args.excludePeers,
+    pinnedPeers: args.pinnedPeers,
+  });
+}
+
+// args: { folder, modification }. Edits a folder.
+async function foldersEdit(ctx, args = {}) {
+  return ctx.telegramClient.editFolder(args.folder, args.modification ?? {});
+}
+
+// args: { folder }. Deletes a folder.
+async function foldersDelete(ctx, args = {}) {
+  return ctx.telegramClient.deleteFolder(args.folder);
+}
+
+// args: { ids }. Reorders folders.
+async function foldersReorder(ctx, args = {}) {
+  return ctx.telegramClient.setFoldersOrder(args.ids);
+}
+
+// args: { folder, chat }. Adds a chat to a folder.
+async function foldersChatsAdd(ctx, args = {}) {
+  return ctx.telegramClient.addChatToFolder(args.folder, args.chat);
+}
+
+// args: { folder, chat }. Removes a chat from a folder.
+async function foldersChatsRemove(ctx, args = {}) {
+  return ctx.telegramClient.removeChatFromFolder(args.folder, args.chat);
+}
+
+// args: { link }. Joins a shared folder via invite link.
+async function foldersJoin(ctx, args = {}) {
+  return ctx.telegramClient.joinChatlist(args.link);
+}
+
 export const OPERATIONS = {
   listChannels,
+  channelShow,
+  channelSetSync,
+  channelMarkRead,
+  messagesList,
+  messagesSearch,
+  messagesGet,
+  messagesContext,
+  sendText,
+  sendPhoto,
+  sendFile,
+  mediaDownload,
+  topicsList,
+  tagsSet,
+  tagsList,
+  tagsSearch,
+  tagsAuto,
+  metadataGet,
+  metadataRefresh,
+  contactsSearch,
+  contactsShow,
+  contactsAliasSet,
+  contactsAliasRemove,
+  contactsTagsAdd,
+  contactsTagsRemove,
+  contactsNotesSet,
+  groupsList,
+  groupsInfo,
+  groupsRename,
+  groupMembersAdd,
+  groupMembersRemove,
   getGroupInviteLink,
+  revokeGroupInviteLink,
+  groupsJoin,
+  groupsLeave,
+  foldersList,
+  foldersShow,
+  foldersCreate,
+  foldersEdit,
+  foldersDelete,
+  foldersReorder,
+  foldersChatsAdd,
+  foldersChatsRemove,
+  foldersJoin,
+};
+
+// Re-exported so the CLI and MCP layers can render live/merged message sets
+// without re-deriving the shared formatting the ops produce.
+export {
+  buildSendSuccessPayload,
+  formatLiveMessage,
+  mergeMessageSets,
+  resolveSource,
+  SendCommandError,
 };

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,13 +2,26 @@
 
 CLI goal: human-readable output by default with --json for scripting.
 
+## Execution model
+Every Telegram and archive command (channels, messages, send, media, topics,
+tags, metadata, contacts, groups, folders) runs through the always-on control
+server, not in the CLI process. The CLI is a thin one-shot client: it auto-starts
+`tgcli server --idle-exit 60s` in the background when one isn't already running,
+asks it to execute the operation against its warm (already-authed) MTProto
+connection and open database over the loopback control API, then renders the
+result. The server is the single writer; the auto-started server shuts itself
+down once the queue drains and nothing is watched.
+
+Commands that stay local (no server): `config`, `service`, `doctor`, and `auth`
+(interactive login bootstraps the session the server then uses).
+
 ## Global flags
 - --json
 - --timeout DURATION
   - No default for most commands (long-running ones like `backfill`, `--follow`, and `server` stay unbounded).
   - `send` commands default to `30s` so agents/scripts never hang on a stuck connection. Override with `--timeout 5m`, or `--timeout 0` to disable.
 - --quiet
-  - Suppress informational progress/status output on stderr (e.g. the `Connecting to Telegram…` note from `send`). Errors and primary stdout/`--json` output are unaffected.
+  - Suppress informational progress/status output on stderr (e.g. backfill progress lines). Errors and primary stdout/`--json` output are unaffected.
 - --version
 
 Store location: OS app data dir (override with TGCLI_STORE).
@@ -138,9 +151,10 @@ Legacy `--offset-id` is accepted as a hidden alias for `--before-id`.
 - send text --to <id|username> --message "..." [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-preview] [--no-forwards] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]
 - send photo --to <id|username> --photo PATH [--caption "..."] [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-forwards] [--spoiler] [--caption-above] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]
 - send file --to <id|username> --file PATH [--caption "..."] [--filename NAME] [--topic <id>] [--parse-mode markdown|html|none] [--reply-to <id>] [--schedule <iso>] [--silent] [--no-forwards] [--spoiler] [--caption-above] [--force-document] [--retries <n>] [--retry-backoff constant|linear|exponential|<ms>]
-  - `--retries` defaults to `2` for all send commands.
-  - Send commands default to a `30s` wall-clock timeout so a stuck Telegram connection fails fast instead of hanging. Override with `--timeout <duration>` (e.g. `--timeout 5m`) or disable with `--timeout 0`. On timeout the command exits non-zero with: `Send timed out after 30s (no response from Telegram).`
-  - If Telegram returns a `FLOOD_WAIT` whose required wait exceeds the remaining timeout budget, the command aborts early reporting the rate limit (e.g. `Telegram rate-limited this send (FLOOD_WAIT 120s), which exceeds the 30s timeout.`) rather than silently timing out. Retry later or pass `--timeout 0`.
+  - Sends are executed by the warm server (the single writer): the CLI routes the send through the control server, which runs the retry/`FLOOD_WAIT` logic against its live connection.
+  - `--retries` defaults to `2` for all send commands. Retries and `FLOOD_WAIT` waits happen server-side.
+  - Send commands default to a `30s` wall-clock timeout, which bounds the CLI's wait on the server. A stuck send fails fast instead of hanging. Override with `--timeout <duration>` (e.g. `--timeout 5m`) or disable with `--timeout 0`. On timeout the command exits non-zero with: `Send timed out after 30s (no response from Telegram).`
+  - If Telegram returns a `FLOOD_WAIT` whose required wait exceeds the timeout budget, the command reports the rate limit (e.g. `Telegram rate-limited this send (FLOOD_WAIT 120s), which exceeds the 30s timeout.`) rather than silently timing out. Retry later or pass `--timeout 0`.
 
 ## media
 - media download --chat <id|username> --id <msgId> [--output PATH]

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -54,6 +54,7 @@ const IDLE_CHECK_INTERVAL_MS = 5000;
 const { telegramClient, messageSyncService } = createServices({ storeDir, config });
 
 let telegramReady = false;
+let telegramConnectPromise = null;
 let serviceState = null;
 let controlToken = null;
 let controlServer = null;
@@ -134,21 +135,47 @@ function updateServiceState(patch) {
   writeServiceState(serviceState);
 }
 
-async function initializeTelegram() {
-  if (telegramReady) return;
-
-  console.log("[startup] Initializing Telegram dialogs...");
-  const dialogsReady = await telegramClient.initializeDialogCache();
-
-  if (!dialogsReady) {
-    throw new Error("Failed to initialize Telegram dialog list");
+// Connect the warm Telegram client (login + realtime updates). This is the
+// readiness gate for operations: it does NOT seed the dialog archive, so it
+// completes in a few seconds even on a large account. A single in-flight promise
+// is shared so concurrent callers (the ensureLogin hook each control handler
+// runs) await one connect rather than starting several.
+function ensureTelegramConnected() {
+  if (telegramReady) {
+    return Promise.resolve();
   }
+  if (!telegramConnectPromise) {
+    telegramConnectPromise = (async () => {
+      console.log("[startup] Connecting Telegram client...");
+      const dialogsReady = await telegramClient.initializeDialogCache();
+      if (!dialogsReady) {
+        throw new Error("Failed to initialize Telegram dialog list");
+      }
+      telegramReady = true;
+      console.log("[startup] Telegram client connected.");
+      // Seed the archive registry and start realtime/queue work in the
+      // background; ops do their own live fetches and must not wait on the full
+      // dialog refresh, which is slow on large accounts.
+      void seedArchiveInBackground();
+    })().catch((error) => {
+      // Reset so a later operation can retry the connect instead of being stuck
+      // on a permanently rejected promise.
+      telegramConnectPromise = null;
+      throw error;
+    });
+  }
+  return telegramConnectPromise;
+}
 
-  const dialogCount = await messageSyncService.refreshChannelsFromDialogs();
-  console.log(`[startup] Seeded ${dialogCount} dialogs into archive registry.`);
-  messageSyncService.startRealtimeSync();
-  messageSyncService.resumePendingJobs();
-  telegramReady = true;
+async function seedArchiveInBackground() {
+  try {
+    const dialogCount = await messageSyncService.refreshChannelsFromDialogs();
+    console.log(`[startup] Seeded ${dialogCount} dialogs into archive registry.`);
+    messageSyncService.startRealtimeSync();
+    messageSyncService.resumePendingJobs();
+  } catch (error) {
+    console.error(`[startup] Background archive seeding failed: ${error?.message ?? error}`);
+  }
 }
 
 /**
@@ -625,7 +652,7 @@ function createServerInstance() {
     "Lists available Telegram dialogs for the authenticated account, including unread message counts.",
     listChannelsSchema,
     async ({ limit }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const dialogs = await OPERATIONS.listChannels(warmServices, { limit });
 
       return {
@@ -644,7 +671,7 @@ function createServerInstance() {
     "Searches dialogs by title or username.",
     searchChannelsSchema,
     async ({ keywords, limit }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const matches = await OPERATIONS.listChannels(warmServices, { query: keywords, limit: limit ?? 100 });
 
       return {
@@ -735,7 +762,7 @@ function createServerInstance() {
     "Fetches and caches extended metadata for channels.",
     refreshChannelMetadataSchema,
     async ({ channelIds, limit, force, onlyMissing }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const results = await OPERATIONS.metadataRefresh(warmServices, {
         channelIds,
         limit,
@@ -777,7 +804,7 @@ function createServerInstance() {
     "Auto-tags channels based on title, username, and cached metadata.",
     autoTagChannelsSchema,
     async ({ channelIds, limit, source, refreshMetadata }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const results = await OPERATIONS.tagsAuto(warmServices, {
         channelIds,
         limit,
@@ -801,7 +828,7 @@ function createServerInstance() {
     "Lists forum topics for a supergroup.",
     topicsListSchema,
     async ({ channelId, limit }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const { topics } = await OPERATIONS.topicsList(warmServices, { channelId, limit: limit ?? 100 });
 
       const formatted = topics.map((topic) => {
@@ -852,7 +879,7 @@ function createServerInstance() {
     "Searches forum topics by title.",
     topicsSearchSchema,
     async ({ channelId, query, limit }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const { topics } = await OPERATIONS.topicsList(warmServices, { channelId, query, limit: limit ?? 100 });
 
       const formatted = topics.map((topic) => ({
@@ -891,7 +918,7 @@ function createServerInstance() {
       if ((source === "live" || source === "both") && !channelId) {
         throw new Error("channelId is required for live source.");
       }
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.messagesList(warmServices, {
         channelId,
         topicId,
@@ -925,7 +952,7 @@ function createServerInstance() {
     "Fetches a specific message from the archive or live Telegram API.",
     messagesGetSchema,
     async ({ channelId, messageId, source }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.messagesGet(warmServices, { channelId, messageId, source });
 
       return {
@@ -951,7 +978,7 @@ function createServerInstance() {
     "Returns surrounding messages for a target message.",
     messagesContextSchema,
     async ({ channelId, messageId, before, after, source }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.messagesContext(warmServices, {
         channelId,
         messageId,
@@ -1000,7 +1027,7 @@ function createServerInstance() {
     }) => {
       const resolvedChannelIds = resolveChannelIds(channelIds, channelId);
       const resolvedTags = Array.isArray(tags) ? tags : (tag ? [tag] : null);
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.messagesSearch(warmServices, {
         query,
         regex,
@@ -1038,7 +1065,7 @@ function createServerInstance() {
     "Sends a text message to a channel or chat.",
     messagesSendSchema,
     async ({ channelId, text, topicId, replyToMessageId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const { result } = await OPERATIONS.sendText(warmServices, {
         chat: channelId,
         text,
@@ -1062,7 +1089,7 @@ function createServerInstance() {
     "Sends a file with an optional caption.",
     messagesSendFileSchema,
     async ({ channelId, filePath, caption, filename, topicId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const { result } = await OPERATIONS.sendFile(warmServices, {
         chat: channelId,
         file: filePath,
@@ -1087,7 +1114,7 @@ function createServerInstance() {
     "Downloads media from a message to a local file.",
     mediaDownloadSchema,
     async ({ channelId, messageId, outputPath }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.mediaDownload(warmServices, { channelId, messageId, outputPath });
 
       return {
@@ -1106,7 +1133,7 @@ function createServerInstance() {
     "Searches contacts/users with aliases, tags, and notes.",
     contactsSearchSchema,
     async ({ query, limit }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const contacts = await OPERATIONS.contactsSearch(warmServices, { query, limit });
 
       return {
@@ -1125,7 +1152,7 @@ function createServerInstance() {
     "Returns a contact profile from the local store.",
     contactsGetSchema,
     async ({ userId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const contact = await OPERATIONS.contactsShow(warmServices, { userId });
 
       return {
@@ -1234,7 +1261,7 @@ function createServerInstance() {
     "Lists group chats and supergroups.",
     groupsListSchema,
     async ({ query, limit }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const groups = await OPERATIONS.groupsList(warmServices, { query, limit });
 
       return {
@@ -1253,7 +1280,7 @@ function createServerInstance() {
     "Fetches group information and metadata.",
     groupsInfoSchema,
     async ({ channelId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const info = await OPERATIONS.groupsInfo(warmServices, { chat: channelId });
 
       return {
@@ -1272,7 +1299,7 @@ function createServerInstance() {
     "Renames a group chat or supergroup.",
     groupsRenameSchema,
     async ({ channelId, name }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       await OPERATIONS.groupsRename(warmServices, { chat: channelId, name });
 
       return {
@@ -1291,7 +1318,7 @@ function createServerInstance() {
     "Adds members to a group.",
     groupsMembersAddSchema,
     async ({ channelId, userIds }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.groupMembersAdd(warmServices, { chat: channelId, userIds });
 
       return {
@@ -1310,7 +1337,7 @@ function createServerInstance() {
     "Removes members from a group.",
     groupsMembersRemoveSchema,
     async ({ channelId, userIds }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.groupMembersRemove(warmServices, { chat: channelId, userIds });
 
       return {
@@ -1329,7 +1356,7 @@ function createServerInstance() {
     "Gets the primary invite link for a group.",
     groupsInviteLinkGetSchema,
     async ({ channelId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const link = await OPERATIONS.getGroupInviteLink(warmServices, { chat: channelId });
 
       return {
@@ -1348,7 +1375,7 @@ function createServerInstance() {
     "Revokes the primary invite link for a group.",
     groupsInviteLinkRevokeSchema,
     async ({ channelId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const link = await OPERATIONS.revokeGroupInviteLink(warmServices, { chat: channelId });
 
       return {
@@ -1367,7 +1394,7 @@ function createServerInstance() {
     "Joins a group using an invite link or code.",
     groupsJoinSchema,
     async ({ invite }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const chat = await OPERATIONS.groupsJoin(warmServices, { invite });
 
       return {
@@ -1395,7 +1422,7 @@ function createServerInstance() {
     "Leaves a group chat or channel.",
     groupsLeaveSchema,
     async ({ channelId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       await OPERATIONS.groupsLeave(warmServices, { chat: channelId });
 
       return {
@@ -1414,7 +1441,7 @@ function createServerInstance() {
     "Schedules a background job to archive channel messages locally.",
     scheduleMessageSyncSchema,
     async ({ channelId, depth, minDate }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const job = messageSyncService.addJob(channelId, { depth, minDate });
       void messageSyncService.processQueue();
 
@@ -1477,7 +1504,7 @@ function createServerInstance() {
     "Marks a Telegram channel as read up to the specified message ID.",
     markChannelReadSchema,
     async ({ channelId, messageId }) => {
-      await telegramClient.ensureLogin();
+      await ensureTelegramConnected();
       const result = await OPERATIONS.channelMarkRead(warmServices, { chat: channelId, messageId });
 
       return {
@@ -1658,10 +1685,12 @@ async function handleSessionRequest(req, res) {
 // TODO: MCP server should participate in the store locking protocol.
 // Currently it opens the SQLite DB and Telegram session without any lock,
 // which can cause conflicts with concurrent CLI commands.
-await initializeTelegram().catch((error) => {
-  console.error(`[startup] Telegram initialization failed: ${error?.message ?? error}`);
-  process.exit(1);
-});
+//
+// The listeners below start first so /control/ping succeeds and control.json is
+// written within ~1s of spawn, independent of the Telegram connection. The
+// connect runs in the background; each control handler's ensureLogin hook awaits
+// the shared connect promise before touching MTProto, so the first operation —
+// not the readiness probe — pays the connect cost.
 
 serviceState = {
   pid: process.pid,
@@ -1759,7 +1788,9 @@ if (controlEnabled) {
     onActivity: () => {
       lastControlActivityAt = Date.now();
     },
-    ensureLogin: () => telegramClient.ensureLogin(),
+    // Await the shared connect before any op touches MTProto; the connect is
+    // kicked off in the background once the listeners are up.
+    ensureLogin: () => ensureTelegramConnected(),
   });
 
   controlServer = http.createServer((req, res) => {
@@ -1797,6 +1828,14 @@ if (controlEnabled) {
     controlPort: CONTROL_PORT,
   });
 }
+
+// Warm the Telegram connection in the background now that the listeners are up
+// and reachable. Operations await this same promise via ensureTelegramConnected,
+// so a connect that is still in flight when the first op arrives is shared, not
+// restarted. A failure here is logged; the next operation retries the connect.
+void ensureTelegramConnected().catch((error) => {
+  console.error(`[startup] Telegram connect failed: ${error?.message ?? error}`);
+});
 
 // --- Idle-exit monitor (active only when --idle-exit is configured) ---
 if (IDLE_EXIT_MS > 0) {

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -578,14 +578,6 @@ const groupsLeaveSchema = {
   channelId: channelIdSchema.describe("Group ID or username"),
 };
 
-function resolveSource(source) {
-  const resolved = source ? String(source).toLowerCase() : "archive";
-  if (!["archive", "live", "both"].includes(resolved)) {
-    throw new Error(`Invalid source: ${source}`);
-  }
-  return resolved;
-}
-
 function resolveChannelIds(channelIds, channelId) {
   const resolved = [];
   if (Array.isArray(channelIds)) {
@@ -598,55 +590,6 @@ function resolveChannelIds(channelIds, channelId) {
   }
   const filtered = resolved.filter((id) => id !== null && id !== undefined && String(id).trim() !== "");
   return filtered.length ? filtered : null;
-}
-
-function parseDateMs(value, label) {
-  if (!value) return null;
-  const ts = Date.parse(value);
-  if (Number.isNaN(ts)) {
-    throw new Error(`${label} must be a valid ISO-8601 string`);
-  }
-  return ts;
-}
-
-function filterLiveMessagesByDate(messages, fromDate, toDate) {
-  const fromMs = parseDateMs(fromDate, "fromDate");
-  const toMs = parseDateMs(toDate, "toDate");
-  if (!fromMs && !toMs) {
-    return messages;
-  }
-  return messages.filter((message) => {
-    const ts = typeof message.date === "number" ? message.date * 1000 : null;
-    if (!ts) {
-      return false;
-    }
-    if (fromMs && ts < fromMs) {
-      return false;
-    }
-    if (toMs && ts > toMs) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function formatLiveMessage(message, context) {
-  const dateIso = message.date ? new Date(message.date * 1000).toISOString() : null;
-  return {
-    channelId: context.channelId ?? message.peer_id ?? null,
-    peerTitle: context.peerTitle ?? null,
-    username: context.username ?? null,
-    messageId: message.id,
-    date: dateIso,
-    fromId: message.from_id ?? null,
-    fromUsername: message.from_username ?? null,
-    fromDisplayName: message.from_display_name ?? null,
-    fromPeerType: message.from_peer_type ?? null,
-    fromIsBot: typeof message.from_is_bot === "boolean" ? message.from_is_bot : null,
-    text: message.text ?? message.message ?? "",
-    media: message.media ?? null,
-    topicId: message.topic_id ?? null,
-  };
 }
 
 function formatInviteLink(link) {
@@ -667,33 +610,15 @@ function formatInviteLink(link) {
   };
 }
 
-function messageDateMs(message) {
-  const ts = Date.parse(message.date ?? "");
-  return Number.isNaN(ts) ? 0 : ts;
-}
-
-function mergeMessageSets(sets, limit) {
-  const map = new Map();
-  for (const list of sets) {
-    for (const message of list) {
-      const channelId = message.channelId ?? "";
-      const messageId = message.messageId ?? message.id;
-      const key = `${String(channelId)}:${String(messageId)}`;
-      if (!map.has(key) || message.source === "live") {
-        map.set(key, message);
-      }
-    }
-  }
-  const merged = Array.from(map.values());
-  merged.sort((a, b) => messageDateMs(b) - messageDateMs(a));
-  return limit && limit > 0 ? merged.slice(0, limit) : merged;
-}
-
 function createServerInstance() {
   const server = new McpServer({
     name: "example-mcp-server",
     version: "1.0.0",
   });
+
+  // The shared operation handlers run against the same warm services the control
+  // API uses, so an MCP tool and the matching CLI command execute identical logic.
+  const warmServices = { telegramClient, messageSyncService };
 
   server.tool(
     "listChannels",
@@ -701,7 +626,7 @@ function createServerInstance() {
     listChannelsSchema,
     async ({ limit }) => {
       await telegramClient.ensureLogin();
-      const dialogs = await OPERATIONS.listChannels({ telegramClient, messageSyncService }, { limit });
+      const dialogs = await OPERATIONS.listChannels(warmServices, { limit });
 
       return {
         content: [
@@ -720,7 +645,7 @@ function createServerInstance() {
     searchChannelsSchema,
     async ({ keywords, limit }) => {
       await telegramClient.ensureLogin();
-      const matches = await telegramClient.searchDialogs(keywords, limit ?? 100);
+      const matches = await OPERATIONS.listChannels(warmServices, { query: keywords, limit: limit ?? 100 });
 
       return {
         content: [
@@ -756,13 +681,13 @@ function createServerInstance() {
     "Assign tags to a channel for later cross-channel search.",
     setChannelTagsSchema,
     async ({ channelId, tags, source }) => {
-      const finalTags = messageSyncService.setChannelTags(channelId, tags, { source });
+      const result = await OPERATIONS.tagsSet(warmServices, { chat: channelId, tags, source });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ channelId, tags: finalTags }, null, 2),
+            text: JSON.stringify({ channelId, tags: result.tags }, null, 2),
           },
         ],
       };
@@ -774,7 +699,7 @@ function createServerInstance() {
     "List tags attached to a channel.",
     listChannelTagsSchema,
     async ({ channelId, source }) => {
-      const tags = messageSyncService.listChannelTags(channelId, { source });
+      const tags = await OPERATIONS.tagsList(warmServices, { chat: channelId, source });
 
       return {
         content: [
@@ -792,7 +717,7 @@ function createServerInstance() {
     "List channels that carry a specific tag.",
     listTaggedChannelsSchema,
     async ({ tag, source, limit }) => {
-      const channels = messageSyncService.listTaggedChannels(tag, { source, limit });
+      const channels = await OPERATIONS.tagsSearch(warmServices, { tag, source, limit });
 
       return {
         content: [
@@ -811,7 +736,7 @@ function createServerInstance() {
     refreshChannelMetadataSchema,
     async ({ channelIds, limit, force, onlyMissing }) => {
       await telegramClient.ensureLogin();
-      const results = await messageSyncService.refreshChannelMetadata({
+      const results = await OPERATIONS.metadataRefresh(warmServices, {
         channelIds,
         limit,
         force,
@@ -853,7 +778,7 @@ function createServerInstance() {
     autoTagChannelsSchema,
     async ({ channelIds, limit, source, refreshMetadata }) => {
       await telegramClient.ensureLogin();
-      const results = await messageSyncService.autoTagChannels({
+      const results = await OPERATIONS.tagsAuto(warmServices, {
         channelIds,
         limit,
         source,
@@ -877,8 +802,7 @@ function createServerInstance() {
     topicsListSchema,
     async ({ channelId, limit }) => {
       await telegramClient.ensureLogin();
-      const topics = await telegramClient.listForumTopics(channelId, { limit: limit ?? 100 });
-      messageSyncService.upsertTopics(channelId, topics);
+      const { topics } = await OPERATIONS.topicsList(warmServices, { channelId, limit: limit ?? 100 });
 
       const formatted = topics.map((topic) => {
         let lastMessage = null;
@@ -929,8 +853,7 @@ function createServerInstance() {
     topicsSearchSchema,
     async ({ channelId, query, limit }) => {
       await telegramClient.ensureLogin();
-      const topics = await telegramClient.listForumTopics(channelId, { query, limit: limit ?? 100 });
-      messageSyncService.upsertTopics(channelId, topics);
+      const { topics } = await OPERATIONS.topicsList(warmServices, { channelId, query, limit: limit ?? 100 });
 
       const formatted = topics.map((topic) => ({
         id: topic.id,
@@ -965,58 +888,18 @@ function createServerInstance() {
     "Lists messages from the archive or live Telegram API.",
     messagesListSchema,
     async ({ channelId, topicId, source, fromDate, toDate, limit }) => {
-      const resolvedSource = resolveSource(source);
-      const finalLimit = limit ?? 50;
-      const sets = [];
-
-      if (resolvedSource === "archive" || resolvedSource === "both") {
-        const archived = messageSyncService.listArchivedMessages({
-          channelIds: channelId ? [channelId] : null,
-          topicId,
-          fromDate,
-          toDate,
-          limit: finalLimit,
-        });
-        sets.push(archived.map((message) => ({ ...message, source: "archive" })));
+      if ((source === "live" || source === "both") && !channelId) {
+        throw new Error("channelId is required for live source.");
       }
-
-      if (resolvedSource === "live" || resolvedSource === "both") {
-        if (!channelId) {
-          throw new Error("channelId is required for live source.");
-        }
-        await telegramClient.ensureLogin();
-        const channelMeta = messageSyncService.getChannelMetadata(channelId);
-        let peerTitle = channelMeta?.peerTitle ?? null;
-        let username = channelMeta?.username ?? null;
-        let peerId = channelMeta?.channelId ?? String(channelId);
-        let liveMessages = [];
-
-        if (topicId) {
-          const results = await telegramClient.getTopicMessages(channelId, topicId, finalLimit);
-          liveMessages = results.messages;
-          if (!peerTitle || !username) {
-            const meta = await telegramClient.getPeerMetadata(channelId);
-            peerTitle = peerTitle ?? meta?.peerTitle ?? null;
-            username = username ?? meta?.username ?? null;
-          }
-        } else {
-          const results = await telegramClient.getMessagesByChannelId(channelId, finalLimit);
-          liveMessages = results.messages;
-          peerTitle = peerTitle ?? results.peerTitle ?? null;
-          peerId = results.peerId ?? peerId;
-        }
-
-        const filtered = filterLiveMessagesByDate(liveMessages, fromDate, toDate);
-        const formatted = filtered.map((message) => ({
-          ...formatLiveMessage(message, { channelId: peerId, peerTitle, username }),
-          source: "live",
-        }));
-        sets.push(formatted);
-      }
-
-      const messages = resolvedSource === "both"
-        ? mergeMessageSets(sets, finalLimit)
-        : (sets[0] ?? []);
+      await telegramClient.ensureLogin();
+      const result = await OPERATIONS.messagesList(warmServices, {
+        channelId,
+        topicId,
+        source,
+        fromDate,
+        toDate,
+        limit: limit ?? 50,
+      });
 
       return {
         content: [
@@ -1024,9 +907,9 @@ function createServerInstance() {
             type: "text",
             text: JSON.stringify(
               {
-                source: resolvedSource,
-                returned: messages.length,
-                messages,
+                source: result.source,
+                returned: result.returned,
+                messages: result.messages,
               },
               null,
               2,
@@ -1042,41 +925,8 @@ function createServerInstance() {
     "Fetches a specific message from the archive or live Telegram API.",
     messagesGetSchema,
     async ({ channelId, messageId, source }) => {
-      const resolvedSource = resolveSource(source);
-      const channelMeta = messageSyncService.getChannelMetadata(channelId);
-      let message = null;
-      let resolvedFrom = null;
-
-      if (resolvedSource === "live" || resolvedSource === "both") {
-        await telegramClient.ensureLogin();
-        const live = await telegramClient.getMessageById(channelId, messageId);
-        if (live) {
-          let peerTitle = channelMeta?.peerTitle ?? null;
-          let username = channelMeta?.username ?? null;
-          if (!peerTitle || !username) {
-            const meta = await telegramClient.getPeerMetadata(channelId);
-            peerTitle = peerTitle ?? meta?.peerTitle ?? null;
-            username = username ?? meta?.username ?? null;
-          }
-          message = {
-            ...formatLiveMessage(live, { channelId: String(channelId), peerTitle, username }),
-            source: "live",
-          };
-          resolvedFrom = "live";
-        }
-      }
-
-      if (!message && (resolvedSource === "archive" || resolvedSource === "both")) {
-        const archived = messageSyncService.getArchivedMessage({ channelId, messageId });
-        if (archived) {
-          message = { ...archived, source: "archive" };
-          resolvedFrom = "archive";
-        }
-      }
-
-      if (!message) {
-        throw new Error("Message not found.");
-      }
+      await telegramClient.ensureLogin();
+      const result = await OPERATIONS.messagesGet(warmServices, { channelId, messageId, source });
 
       return {
         content: [
@@ -1084,8 +934,8 @@ function createServerInstance() {
             type: "text",
             text: JSON.stringify(
               {
-                source: resolvedFrom ?? resolvedSource,
-                message,
+                source: result.source,
+                message: result.message,
               },
               null,
               2,
@@ -1101,65 +951,14 @@ function createServerInstance() {
     "Returns surrounding messages for a target message.",
     messagesContextSchema,
     async ({ channelId, messageId, before, after, source }) => {
-      const resolvedSource = resolveSource(source);
-      const safeBefore = Number.isFinite(before) ? before : 20;
-      const safeAfter = Number.isFinite(after) ? after : 20;
-      const channelMeta = messageSyncService.getChannelMetadata(channelId);
-      let context = null;
-      let resolvedFrom = null;
-
-      if (resolvedSource === "live" || resolvedSource === "both") {
-        await telegramClient.ensureLogin();
-        const liveContext = await telegramClient.getMessageContext(channelId, messageId, {
-          before: safeBefore,
-          after: safeAfter,
-        });
-        if (liveContext.target) {
-          let peerTitle = channelMeta?.peerTitle ?? null;
-          let username = channelMeta?.username ?? null;
-          if (!peerTitle || !username) {
-            const meta = await telegramClient.getPeerMetadata(channelId);
-            peerTitle = peerTitle ?? meta?.peerTitle ?? null;
-            username = username ?? meta?.username ?? null;
-          }
-          context = {
-            target: {
-              ...formatLiveMessage(liveContext.target, { channelId: String(channelId), peerTitle, username }),
-              source: "live",
-            },
-            before: liveContext.before.map((message) => ({
-              ...formatLiveMessage(message, { channelId: String(channelId), peerTitle, username }),
-              source: "live",
-            })),
-            after: liveContext.after.map((message) => ({
-              ...formatLiveMessage(message, { channelId: String(channelId), peerTitle, username }),
-              source: "live",
-            })),
-          };
-          resolvedFrom = "live";
-        }
-      }
-
-      if (!context && (resolvedSource === "archive" || resolvedSource === "both")) {
-        const archiveContext = messageSyncService.getArchivedMessageContext({
-          channelId,
-          messageId,
-          before: safeBefore,
-          after: safeAfter,
-        });
-        if (archiveContext.target) {
-          context = {
-            target: { ...archiveContext.target, source: "archive" },
-            before: archiveContext.before.map((message) => ({ ...message, source: "archive" })),
-            after: archiveContext.after.map((message) => ({ ...message, source: "archive" })),
-          };
-          resolvedFrom = "archive";
-        }
-      }
-
-      if (!context) {
-        throw new Error("Message not found.");
-      }
+      await telegramClient.ensureLogin();
+      const result = await OPERATIONS.messagesContext(warmServices, {
+        channelId,
+        messageId,
+        before,
+        after,
+        source,
+      });
 
       return {
         content: [
@@ -1167,8 +966,10 @@ function createServerInstance() {
             type: "text",
             text: JSON.stringify(
               {
-                source: resolvedFrom ?? resolvedSource,
-                ...context,
+                source: result.source,
+                target: result.target,
+                before: result.before,
+                after: result.after,
               },
               null,
               2,
@@ -1197,110 +998,21 @@ function createServerInstance() {
       limit,
       caseInsensitive,
     }) => {
-      const resolvedSource = resolveSource(source);
-      const finalLimit = limit ?? 100;
-      const resolvedTags = Array.isArray(tags) ? tags : (tag ? [tag] : null);
       const resolvedChannelIds = resolveChannelIds(channelIds, channelId);
-
-      if (!query && !regex && (!resolvedTags || resolvedTags.length === 0)) {
-        throw new Error("Provide query, regex, or tags for messagesSearch.");
-      }
-
-      const sets = [];
-
-      if (resolvedSource === "archive" || resolvedSource === "both") {
-        const archived = messageSyncService.searchArchiveMessages({
-          query,
-          regex,
-          tags: resolvedTags,
-          channelIds: resolvedChannelIds,
-          topicId,
-          fromDate,
-          toDate,
-          limit: finalLimit,
-          caseInsensitive,
-        });
-        sets.push(archived.map((message) => ({ ...message, source: "archive" })));
-      }
-
-      if (resolvedSource === "live" || resolvedSource === "both") {
-        let liveChannelIds = resolvedChannelIds;
-        if ((!liveChannelIds || liveChannelIds.length === 0) && resolvedTags?.length) {
-          const tagged = new Map();
-          for (const tagValue of resolvedTags) {
-            const channels = messageSyncService.listTaggedChannels(tagValue, { limit: 200 });
-            for (const channel of channels) {
-              tagged.set(channel.channelId, channel);
-            }
-          }
-          liveChannelIds = Array.from(tagged.keys());
-        }
-
-        if (!liveChannelIds || liveChannelIds.length === 0) {
-          throw new Error("channelIds are required for live search.");
-        }
-
-        let liveRegex = null;
-        if (regex) {
-          try {
-            liveRegex = new RegExp(regex, caseInsensitive === false ? "" : "i");
-          } catch (error) {
-            throw new Error(`Invalid regex: ${error.message}`);
-          }
-        }
-
-        await telegramClient.ensureLogin();
-        const liveResults = [];
-
-        for (const id of liveChannelIds) {
-          const channelMeta = messageSyncService.getChannelMetadata(id);
-          let peerTitle = channelMeta?.peerTitle ?? null;
-          let username = channelMeta?.username ?? null;
-          let liveMessages = [];
-
-          if (query) {
-            const results = await telegramClient.searchChannelMessages(id, {
-              query,
-              limit: finalLimit,
-              topicId,
-            });
-            liveMessages = results.messages;
-            peerTitle = peerTitle ?? results.peerTitle ?? null;
-          } else if (topicId) {
-            const results = await telegramClient.getTopicMessages(id, topicId, finalLimit);
-            liveMessages = results.messages;
-          } else {
-            const results = await telegramClient.getMessagesByChannelId(id, finalLimit);
-            liveMessages = results.messages;
-            peerTitle = peerTitle ?? results.peerTitle ?? null;
-          }
-
-          if (!peerTitle || !username) {
-            const meta = await telegramClient.getPeerMetadata(id);
-            peerTitle = peerTitle ?? meta?.peerTitle ?? null;
-            username = username ?? meta?.username ?? null;
-          }
-
-          let filtered = filterLiveMessagesByDate(liveMessages, fromDate, toDate);
-          if (liveRegex) {
-            filtered = filtered.filter((message) =>
-              liveRegex.test(message.text ?? message.message ?? ""),
-            );
-          }
-
-          const formatted = filtered.map((message) => ({
-            ...formatLiveMessage(message, { channelId: String(id), peerTitle, username }),
-            source: "live",
-          }));
-          liveResults.push(...formatted);
-        }
-
-        sets.push(liveResults);
-      }
-
-      const messages = resolvedSource === "both"
-        ? mergeMessageSets(sets, finalLimit)
-        : (sets[0] ?? []);
+      const resolvedTags = Array.isArray(tags) ? tags : (tag ? [tag] : null);
+      await telegramClient.ensureLogin();
+      const result = await OPERATIONS.messagesSearch(warmServices, {
+        query,
+        regex,
+        source,
+        channelIds: resolvedChannelIds,
+        tags: resolvedTags,
+        topicId,
+        fromDate,
+        toDate,
+        limit: limit ?? 100,
+        caseInsensitive,
+      });
 
       return {
         content: [
@@ -1308,9 +1020,9 @@ function createServerInstance() {
             type: "text",
             text: JSON.stringify(
               {
-                source: resolvedSource,
-                returned: messages.length,
-                messages,
+                source: result.source,
+                returned: result.returned,
+                messages: result.messages,
               },
               null,
               2,
@@ -1327,7 +1039,9 @@ function createServerInstance() {
     messagesSendSchema,
     async ({ channelId, text, topicId, replyToMessageId }) => {
       await telegramClient.ensureLogin();
-      const result = await telegramClient.sendTextMessage(channelId, text, {
+      const { result } = await OPERATIONS.sendText(warmServices, {
+        chat: channelId,
+        text,
         topicId,
         replyToMessageId,
       });
@@ -1349,7 +1063,9 @@ function createServerInstance() {
     messagesSendFileSchema,
     async ({ channelId, filePath, caption, filename, topicId }) => {
       await telegramClient.ensureLogin();
-      const result = await telegramClient.sendFileMessage(channelId, filePath, {
+      const { result } = await OPERATIONS.sendFile(warmServices, {
+        chat: channelId,
+        file: filePath,
         caption,
         filename,
         topicId,
@@ -1372,9 +1088,7 @@ function createServerInstance() {
     mediaDownloadSchema,
     async ({ channelId, messageId, outputPath }) => {
       await telegramClient.ensureLogin();
-      const result = await telegramClient.downloadMessageMedia(channelId, messageId, {
-        outputPath,
-      });
+      const result = await OPERATIONS.mediaDownload(warmServices, { channelId, messageId, outputPath });
 
       return {
         content: [
@@ -1393,8 +1107,7 @@ function createServerInstance() {
     contactsSearchSchema,
     async ({ query, limit }) => {
       await telegramClient.ensureLogin();
-      await messageSyncService.refreshContacts();
-      const contacts = messageSyncService.searchContacts(query, { limit });
+      const contacts = await OPERATIONS.contactsSearch(warmServices, { query, limit });
 
       return {
         content: [
@@ -1412,16 +1125,8 @@ function createServerInstance() {
     "Returns a contact profile from the local store.",
     contactsGetSchema,
     async ({ userId }) => {
-      let contact = messageSyncService.getContact(userId);
-      if (!contact) {
-        await telegramClient.ensureLogin();
-        await messageSyncService.refreshContacts();
-        contact = messageSyncService.getContact(userId);
-      }
-
-      if (!contact) {
-        throw new Error("Contact not found.");
-      }
+      await telegramClient.ensureLogin();
+      const contact = await OPERATIONS.contactsShow(warmServices, { userId });
 
       return {
         content: [
@@ -1439,13 +1144,13 @@ function createServerInstance() {
     "Sets an alias for a contact.",
     contactsAliasSetSchema,
     async ({ userId, alias }) => {
-      const value = messageSyncService.setContactAlias(userId, alias);
+      const result = await OPERATIONS.contactsAliasSet(warmServices, { userId, alias });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ userId, alias: value }, null, 2),
+            text: JSON.stringify({ userId, alias: result.alias }, null, 2),
           },
         ],
       };
@@ -1457,7 +1162,7 @@ function createServerInstance() {
     "Removes alias for a contact.",
     contactsAliasRemoveSchema,
     async ({ userId }) => {
-      messageSyncService.removeContactAlias(userId);
+      await OPERATIONS.contactsAliasRemove(warmServices, { userId });
 
       return {
         content: [
@@ -1475,13 +1180,13 @@ function createServerInstance() {
     "Adds tags to a contact.",
     contactsTagsAddSchema,
     async ({ userId, tags }) => {
-      const updated = messageSyncService.addContactTags(userId, tags);
+      const result = await OPERATIONS.contactsTagsAdd(warmServices, { userId, tags });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ userId, tags: updated }, null, 2),
+            text: JSON.stringify({ userId, tags: result.tags }, null, 2),
           },
         ],
       };
@@ -1493,13 +1198,13 @@ function createServerInstance() {
     "Removes tags from a contact.",
     contactsTagsRemoveSchema,
     async ({ userId, tags }) => {
-      const updated = messageSyncService.removeContactTags(userId, tags);
+      const result = await OPERATIONS.contactsTagsRemove(warmServices, { userId, tags });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ userId, tags: updated }, null, 2),
+            text: JSON.stringify({ userId, tags: result.tags }, null, 2),
           },
         ],
       };
@@ -1511,13 +1216,13 @@ function createServerInstance() {
     "Sets notes for a contact.",
     contactsNotesSetSchema,
     async ({ userId, notes }) => {
-      const updated = messageSyncService.setContactNotes(userId, notes);
+      const result = await OPERATIONS.contactsNotesSet(warmServices, { userId, notes });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ userId, notes: updated }, null, 2),
+            text: JSON.stringify({ userId, notes: result.notes }, null, 2),
           },
         ],
       };
@@ -1530,7 +1235,7 @@ function createServerInstance() {
     groupsListSchema,
     async ({ query, limit }) => {
       await telegramClient.ensureLogin();
-      const groups = await telegramClient.listGroups({ query, limit });
+      const groups = await OPERATIONS.groupsList(warmServices, { query, limit });
 
       return {
         content: [
@@ -1549,7 +1254,7 @@ function createServerInstance() {
     groupsInfoSchema,
     async ({ channelId }) => {
       await telegramClient.ensureLogin();
-      const info = await telegramClient.getGroupInfo(channelId);
+      const info = await OPERATIONS.groupsInfo(warmServices, { chat: channelId });
 
       return {
         content: [
@@ -1568,7 +1273,7 @@ function createServerInstance() {
     groupsRenameSchema,
     async ({ channelId, name }) => {
       await telegramClient.ensureLogin();
-      await telegramClient.renameGroup(channelId, name);
+      await OPERATIONS.groupsRename(warmServices, { chat: channelId, name });
 
       return {
         content: [
@@ -1587,13 +1292,13 @@ function createServerInstance() {
     groupsMembersAddSchema,
     async ({ channelId, userIds }) => {
       await telegramClient.ensureLogin();
-      const failed = await telegramClient.addGroupMembers(channelId, userIds);
+      const result = await OPERATIONS.groupMembersAdd(warmServices, { chat: channelId, userIds });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ channelId, failed }, null, 2),
+            text: JSON.stringify({ channelId, failed: result.failed }, null, 2),
           },
         ],
       };
@@ -1606,13 +1311,13 @@ function createServerInstance() {
     groupsMembersRemoveSchema,
     async ({ channelId, userIds }) => {
       await telegramClient.ensureLogin();
-      const result = await telegramClient.removeGroupMembers(channelId, userIds);
+      const result = await OPERATIONS.groupMembersRemove(warmServices, { chat: channelId, userIds });
 
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify({ channelId, ...result }, null, 2),
+            text: JSON.stringify({ channelId, removed: result.removed, failed: result.failed }, null, 2),
           },
         ],
       };
@@ -1625,10 +1330,7 @@ function createServerInstance() {
     groupsInviteLinkGetSchema,
     async ({ channelId }) => {
       await telegramClient.ensureLogin();
-      const link = await OPERATIONS.getGroupInviteLink(
-        { telegramClient, messageSyncService },
-        { chat: channelId },
-      );
+      const link = await OPERATIONS.getGroupInviteLink(warmServices, { chat: channelId });
 
       return {
         content: [
@@ -1647,8 +1349,7 @@ function createServerInstance() {
     groupsInviteLinkRevokeSchema,
     async ({ channelId }) => {
       await telegramClient.ensureLogin();
-      const existing = await telegramClient.getGroupInviteLink(channelId);
-      const link = await telegramClient.revokeGroupInviteLink(channelId, existing);
+      const link = await OPERATIONS.revokeGroupInviteLink(warmServices, { chat: channelId });
 
       return {
         content: [
@@ -1667,7 +1368,7 @@ function createServerInstance() {
     groupsJoinSchema,
     async ({ invite }) => {
       await telegramClient.ensureLogin();
-      const chat = await telegramClient.joinGroup(invite);
+      const chat = await OPERATIONS.groupsJoin(warmServices, { invite });
 
       return {
         content: [
@@ -1695,7 +1396,7 @@ function createServerInstance() {
     groupsLeaveSchema,
     async ({ channelId }) => {
       await telegramClient.ensureLogin();
-      await telegramClient.leaveGroup(channelId);
+      await OPERATIONS.groupsLeave(warmServices, { chat: channelId });
 
       return {
         content: [
@@ -1777,7 +1478,7 @@ function createServerInstance() {
     markChannelReadSchema,
     async ({ channelId, messageId }) => {
       await telegramClient.ensureLogin();
-      const result = await telegramClient.markChannelRead(channelId, messageId);
+      const result = await OPERATIONS.channelMarkRead(warmServices, { chat: channelId, messageId });
 
       return {
         content: [

--- a/tests/backfill-rename.test.js
+++ b/tests/backfill-rename.test.js
@@ -13,6 +13,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const services = vi.hoisted(() => ({ current: null }));
+const control = vi.hoisted(() => ({ ensureServer: null, invoke: null }));
 
 vi.mock('../core/services.js', () => ({
   createServices: vi.fn(() => services.current),
@@ -21,6 +22,17 @@ vi.mock('../core/services.js', () => ({
   createMessageSyncService: vi.fn(() => ({ messageSyncService: services.current.messageSyncService })),
   // Archive-only commands validate config via withCommand; stub it as a no-op.
   resolveValidatedConfig: vi.fn(() => ({})),
+}));
+
+// Commands routed through the warm server reach it via ensureServer + invoke;
+// stub both so `channels watch/unwatch` resolve to a server invoke without any
+// real process or network.
+vi.mock('../core/control-client.js', () => ({
+  ensureServer: (...args) => control.ensureServer(...args),
+  invoke: (...args) => control.invoke(...args),
+  pingServer: vi.fn(),
+  enqueueBackfill: vi.fn(),
+  cancelBackfill: vi.fn(),
 }));
 
 vi.mock('../store-lock.js', () => ({
@@ -128,6 +140,15 @@ describe('channels watch / unwatch', () => {
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    control.ensureServer = vi.fn().mockResolvedValue({ ok: true });
+    // The server runs the channelSetSync op; model its result shape here.
+    control.invoke = vi.fn(async (_storeDir, { args }) => ({
+      channelId: args.chat,
+      syncEnabled: args.enable,
+      jobId: args.enable ? 1 : null,
+      jobStatus: args.enable ? 'pending' : null,
+      jobQueued: Boolean(args.enable),
+    }));
   });
 
   afterEach(() => {
@@ -136,43 +157,50 @@ describe('channels watch / unwatch', () => {
     vi.clearAllMocks();
   });
 
-  it('`channels watch --chat X` enables sync and queues a backfill job', async () => {
-    services.current = makeFakeServices();
+  it('`channels watch --chat X` routes channelSetSync(enable) to the server', async () => {
     await runProgram(['channels', 'watch', '--chat', '@chan']);
-    const svc = services.current.messageSyncService;
-    expect(svc.setChannelSync).toHaveBeenCalledWith('@chan', true);
-    // Queues a job when none exists (parity with `channels sync --enable`).
-    expect(svc.addJob).toHaveBeenCalledWith('@chan');
+    expect(control.ensureServer).toHaveBeenCalledTimes(1);
+    expect(control.invoke).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      op: 'channelSetSync',
+      args: { chat: '@chan', enable: true },
+      timeoutMs: undefined,
+    });
   });
 
-  it('`channels unwatch --chat X` disables sync and queues no job', async () => {
-    services.current = makeFakeServices();
+  it('`channels unwatch --chat X` routes channelSetSync(disable) to the server', async () => {
     await runProgram(['channels', 'unwatch', '--chat', '@chan']);
-    const svc = services.current.messageSyncService;
-    expect(svc.setChannelSync).toHaveBeenCalledWith('@chan', false);
-    expect(svc.addJob).not.toHaveBeenCalled();
+    expect(control.invoke).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      op: 'channelSetSync',
+      args: { chat: '@chan', enable: false },
+      timeoutMs: undefined,
+    });
   });
 
-  it('`channels watch` matches legacy `channels sync --enable` behavior', async () => {
-    services.current = makeFakeServices();
+  it('`channels watch` matches legacy `channels sync --enable` (same op + args)', async () => {
     await runProgram(['channels', 'watch', '--chat', '@chan']);
-    const watchSvc = services.current.messageSyncService;
+    const watchCalls = control.invoke.mock.calls.slice();
 
-    services.current = makeFakeServices();
+    control.invoke.mockClear();
     await runProgram(['channels', 'sync', '--chat', '@chan', '--enable']);
-    const enableSvc = services.current.messageSyncService;
+    const enableCalls = control.invoke.mock.calls.slice();
 
-    expect(watchSvc.setChannelSync.mock.calls).toEqual(enableSvc.setChannelSync.mock.calls);
-    expect(watchSvc.addJob.mock.calls).toEqual(enableSvc.addJob.mock.calls);
+    expect(watchCalls).toEqual(enableCalls);
   });
 
-  it('legacy hidden `channels sync --enable/--disable` still works', async () => {
-    services.current = makeFakeServices();
+  it('legacy hidden `channels sync --enable/--disable` still routes to the server', async () => {
     await runProgram(['channels', 'sync', '--chat', '@chan', '--enable']);
-    expect(services.current.messageSyncService.setChannelSync).toHaveBeenCalledWith('@chan', true);
+    expect(control.invoke).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      op: 'channelSetSync',
+      args: { chat: '@chan', enable: true },
+      timeoutMs: undefined,
+    });
 
-    services.current = makeFakeServices();
+    control.invoke.mockClear();
     await runProgram(['channels', 'sync', '--chat', '@chan', '--disable']);
-    expect(services.current.messageSyncService.setChannelSync).toHaveBeenCalledWith('@chan', false);
+    expect(control.invoke).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      op: 'channelSetSync',
+      args: { chat: '@chan', enable: false },
+      timeoutMs: undefined,
+    });
   });
 });

--- a/tests/control-client.test.js
+++ b/tests/control-client.test.js
@@ -20,6 +20,7 @@ import {
   readControlFile,
 } from '../core/control-client.js';
 import { CONTROL_TOKEN_HEADER } from '../core/control-server.js';
+import { SendCommandError } from '../core/send-utils.js';
 
 let storeDir;
 
@@ -141,6 +142,23 @@ describe('invoke', () => {
   it('throws the server error message on a non-200 response', async () => {
     global.fetch.mockResolvedValue(jsonResponse(400, { error: 'Unknown operation: nope' }));
     await expect(invoke(storeDir, { op: 'nope', args: {} })).rejects.toThrow('Unknown operation: nope');
+  });
+
+  it('reconstructs a SendCommandError from a sendError payload', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(500, {
+      error: 'FLOOD_WAIT_120',
+      sendError: { type: 'rate_limit', method: 'sendText', message: 'FLOOD_WAIT_120', waitSeconds: 120 },
+    }));
+    const error = await invoke(storeDir, { op: 'sendText', args: {} }).catch((e) => e);
+    expect(error).toBeInstanceOf(SendCommandError);
+    expect(error.details).toMatchObject({ type: 'rate_limit', method: 'sendText', waitSeconds: 120 });
+  });
+
+  it('passes timeoutMs through as the request budget (0 disables it)', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, { result: { ok: true } }));
+    await invoke(storeDir, { op: 'sendText', args: {}, timeoutMs: 0 });
+    const [, init] = global.fetch.mock.calls[0];
+    expect(init.signal).toBeUndefined();
   });
 });
 

--- a/tests/control-server-cold-start.test.js
+++ b/tests/control-server-cold-start.test.js
@@ -1,0 +1,130 @@
+// Cold-start readiness: the control listener must be reachable (control.json
+// written, GET /control/ping succeeds) BEFORE the Telegram connection resolves,
+// so a thin client polling for the server does not give up while a large account
+// is still connecting. Operations, by contrast, await the shared connect via the
+// ensureLogin hook each control handler runs before touching MTProto.
+//
+// This mirrors the server wiring (listener up first, connect kicked off in the
+// background) without bootstrapping the full mcp-server entrypoint: the listener,
+// control.json, ping path, and ensureLogin hook are the real components.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createControlRequestHandler,
+  generateControlToken,
+  writeControlFile,
+  CONTROL_TOKEN_HEADER,
+} from '../core/control-server.js';
+import { pingServer, readControlFile } from '../core/control-client.js';
+
+let storeDir;
+let server;
+
+function makeService() {
+  return {
+    getJobCounts: vi.fn(() => ({ pending: 0, inProgress: 0 })),
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Start the listener exactly as the server does: bind, then write control.json in
+// the listen callback. Returns once control.json is on disk.
+function startControl(handler, token) {
+  server = http.createServer((req, res) => void handler(req, res));
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      writeControlFile(storeDir, { pid: process.pid, port, token, startedAt: 's', version: '1' });
+      resolve(port);
+    });
+  });
+}
+
+beforeEach(() => {
+  storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-cold-start-'));
+});
+
+afterEach(() => {
+  if (server) {
+    server.close();
+    server = null;
+  }
+  fs.rmSync(storeDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('control server reachable before Telegram connect resolves', () => {
+  it('writes control.json and answers ping while the connect is still pending', async () => {
+    const token = generateControlToken();
+    // A slow connect that never resolves on its own; the ensureLogin hook awaits it.
+    const connect = deferred();
+    const ensureLogin = vi.fn(() => connect.promise);
+
+    const warmServices = {
+      telegramClient: { listDialogs: vi.fn(() => Promise.resolve([{ id: '1', title: 'Warm' }])) },
+      messageSyncService: {},
+    };
+
+    const handler = createControlRequestHandler({
+      service: makeService(),
+      warmServices,
+      token,
+      pid: process.pid,
+      version: '1',
+      startedAt: 's',
+      ensureLogin,
+    });
+
+    await startControl(handler, token);
+
+    // control.json exists and ping succeeds even though the connect has not
+    // resolved (ensureLogin still pending) — the readiness probe does not pay the
+    // connect cost.
+    expect(readControlFile(storeDir)).toMatchObject({ token });
+    const ping = await pingServer(storeDir);
+    expect(ping).toMatchObject({ ok: true });
+    expect(ensureLogin).not.toHaveBeenCalled();
+
+    // An operation awaits the connect: it must not complete while the connect is
+    // pending.
+    const control = readControlFile(storeDir);
+    let opSettled = false;
+    const opPromise = fetch(`http://127.0.0.1:${control.port}/control/invoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', [CONTROL_TOKEN_HEADER]: token },
+      body: JSON.stringify({ op: 'listChannels', args: { limit: 1 } }),
+    }).then(async (res) => {
+      opSettled = true;
+      return { status: res.status, json: await res.json() };
+    });
+
+    await new Promise((r) => setTimeout(r, 25));
+    expect(ensureLogin).toHaveBeenCalledTimes(1);
+    expect(opSettled).toBe(false);
+    expect(warmServices.telegramClient.listDialogs).not.toHaveBeenCalled();
+
+    // Ping still works while the op is blocked on the connect.
+    expect(await pingServer(storeDir)).toMatchObject({ ok: true });
+
+    // Once the connect resolves, the op runs against the warm services.
+    connect.resolve();
+    const { status, json } = await opPromise;
+    expect(status).toBe(200);
+    expect(json).toEqual({ result: [{ id: '1', title: 'Warm' }] });
+    expect(warmServices.telegramClient.listDialogs).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/control-server.test.js
+++ b/tests/control-server.test.js
@@ -182,7 +182,12 @@ describe('POST /control/invoke', () => {
         searchDialogs: vi.fn(() => Promise.resolve([])),
         getGroupInviteLink: vi.fn(() => Promise.resolve({ link: 'https://t.me/+warm' })),
       },
-      messageSyncService: {},
+      messageSyncService: {
+        setChannelSync: vi.fn(() => ({ channel_id: '@g', sync_enabled: 1 })),
+        listJobs: vi.fn(() => []),
+        addJob: vi.fn(() => ({ id: 5, status: 'pending' })),
+        processQueue: vi.fn(),
+      },
     };
     ensureLogin = vi.fn(() => Promise.resolve());
     const handler = createControlRequestHandler({
@@ -213,6 +218,28 @@ describe('POST /control/invoke', () => {
     expect(warmServices.telegramClient.listDialogs).toHaveBeenCalledWith(10);
     expect(json).toEqual({ result: [{ id: '1', title: 'Warm' }] });
     expect(ensureLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches a write op (channelSetSync) against the warm services', async () => {
+    const { status, json } = await request(port, 'POST', '/control/invoke', {
+      token: TOKEN,
+      body: { op: 'channelSetSync', args: { chat: '@g', enable: true } },
+    });
+    expect(status).toBe(200);
+    expect(warmServices.messageSyncService.setChannelSync).toHaveBeenCalledWith('@g', true);
+    expect(warmServices.messageSyncService.addJob).toHaveBeenCalledWith('@g');
+    expect(json.result).toMatchObject({ channelId: '@g', syncEnabled: true, jobId: 5, jobQueued: true });
+    expect(ensureLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 500 with a sendError payload when a send op fails', async () => {
+    warmServices.telegramClient.sendTextMessage = vi.fn(() => Promise.reject(new Error('FLOOD_WAIT_120')));
+    const { status, json } = await request(port, 'POST', '/control/invoke', {
+      token: TOKEN,
+      body: { op: 'sendText', args: { chat: '@g', text: 'hi', retries: 0, timeoutMs: 30000 } },
+    });
+    expect(status).toBe(500);
+    expect(json.sendError).toMatchObject({ type: 'rate_limit', method: 'sendText', waitSeconds: 120 });
   });
 
   it('returns 400 for an unknown op (no handler invoked)', async () => {

--- a/tests/operations-seam.test.js
+++ b/tests/operations-seam.test.js
@@ -1,28 +1,28 @@
-// Tests for the shared operation registry and the server-first / local-fallback
-// seam. The same OPERATIONS[op] runs on both paths, so the result a caller renders
-// is identical whether a warm server served it or the local fallback did.
-//
-// pingServer/invoke (server path) and the withCommand service factories / lock
-// helpers (local path) are all stubbed — no network, filesystem, or real DB.
+// Tests for the shared operation registry and the runOperation seam. The server
+// is the single warm backend: runOperation auto-starts it (ensureServer) and asks
+// it to run OPERATIONS[op] against its warm services (invoke). Both control-client
+// entry points are stubbed — no network, filesystem, process, or real DB.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hooks = vi.hoisted(() => ({
   telegramClient: null,
   messageSyncService: null,
-  pingServer: null,
+  ensureServer: null,
   invoke: null,
 }));
 
 vi.mock('../core/control-client.js', () => ({
-  pingServer: (...args) => hooks.pingServer(...args),
+  ensureServer: (...args) => hooks.ensureServer(...args),
   invoke: (...args) => hooks.invoke(...args),
 }));
 
+// command-context.js still imports services.js for the retained withCommand seam;
+// stub it so the test never pulls in the real TelegramClient module.
 vi.mock('../core/services.js', () => ({
-  createTelegramClient: () => ({ telegramClient: hooks.telegramClient }),
-  createMessageSyncService: () => ({ messageSyncService: hooks.messageSyncService }),
-  resolveValidatedConfig: () => ({}),
+  createTelegramClient: vi.fn(),
+  createMessageSyncService: vi.fn(),
+  resolveValidatedConfig: vi.fn(() => ({})),
 }));
 
 vi.mock('../store-lock.js', () => ({
@@ -39,17 +39,19 @@ const { runOperation } = await import('../core/command-context.js');
 
 beforeEach(() => {
   hooks.telegramClient = {
-    destroy: vi.fn().mockResolvedValue(undefined),
     isAuthorized: vi.fn().mockResolvedValue(true),
-    listDialogs: vi.fn().mockResolvedValue([{ id: '1', title: 'Local' }]),
-    searchDialogs: vi.fn().mockResolvedValue([{ id: '2', title: 'LocalSearch' }]),
-    getGroupInviteLink: vi.fn().mockResolvedValue({ link: 'https://t.me/+local' }),
+    listDialogs: vi.fn().mockResolvedValue([{ id: '1', title: 'Warm' }]),
+    searchDialogs: vi.fn().mockResolvedValue([{ id: '2', title: 'WarmSearch' }]),
+    getGroupInviteLink: vi.fn().mockResolvedValue({ link: 'https://t.me/+warm' }),
+    markChannelRead: vi.fn().mockResolvedValue({ channelId: '1', messageId: 9 }),
   };
   hooks.messageSyncService = {
-    close: vi.fn().mockResolvedValue(undefined),
-    shutdown: vi.fn().mockResolvedValue(undefined),
+    setChannelSync: vi.fn(() => ({ channel_id: '1', sync_enabled: 1 })),
+    listJobs: vi.fn(() => []),
+    addJob: vi.fn(() => ({ id: 7, status: 'pending' })),
+    processQueue: vi.fn(),
   };
-  hooks.pingServer = vi.fn();
+  hooks.ensureServer = vi.fn().mockResolvedValue({ ok: true });
   hooks.invoke = vi.fn();
 });
 
@@ -58,91 +60,100 @@ afterEach(() => {
 });
 
 describe('OPERATIONS registry', () => {
+  const ctx = () => ({
+    telegramClient: hooks.telegramClient,
+    messageSyncService: hooks.messageSyncService,
+  });
+
   it('listChannels lists dialogs and applies the default limit', async () => {
-    const ctx = { telegramClient: hooks.telegramClient };
-    const result = await OPERATIONS.listChannels(ctx, {});
+    const result = await OPERATIONS.listChannels(ctx(), {});
     expect(hooks.telegramClient.listDialogs).toHaveBeenCalledWith(50);
-    expect(result).toEqual([{ id: '1', title: 'Local' }]);
+    expect(result).toEqual([{ id: '1', title: 'Warm' }]);
   });
 
   it('listChannels searches when a query is given', async () => {
-    const ctx = { telegramClient: hooks.telegramClient };
-    const result = await OPERATIONS.listChannels(ctx, { query: 'foo', limit: 7 });
+    const result = await OPERATIONS.listChannels(ctx(), { query: 'foo', limit: 7 });
     expect(hooks.telegramClient.searchDialogs).toHaveBeenCalledWith('foo', 7);
-    expect(result).toEqual([{ id: '2', title: 'LocalSearch' }]);
+    expect(result).toEqual([{ id: '2', title: 'WarmSearch' }]);
   });
 
   it('getGroupInviteLink returns the link descriptor', async () => {
-    const ctx = { telegramClient: hooks.telegramClient };
-    const result = await OPERATIONS.getGroupInviteLink(ctx, { chat: '@g' });
+    const result = await OPERATIONS.getGroupInviteLink(ctx(), { chat: '@g' });
     expect(hooks.telegramClient.getGroupInviteLink).toHaveBeenCalledWith('@g');
-    expect(result).toEqual({ link: 'https://t.me/+local' });
+    expect(result).toEqual({ link: 'https://t.me/+warm' });
+  });
+
+  it('channelSetSync enables sync and queues a backfill job when none exists', async () => {
+    const result = await OPERATIONS.channelSetSync(ctx(), { chat: '@g', enable: true });
+    expect(hooks.messageSyncService.setChannelSync).toHaveBeenCalledWith('@g', true);
+    expect(hooks.messageSyncService.addJob).toHaveBeenCalledWith('@g');
+    expect(hooks.messageSyncService.processQueue).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ channelId: '1', syncEnabled: true, jobId: 7, jobQueued: true });
+  });
+
+  it('channelMarkRead marks the channel read via the warm client', async () => {
+    const result = await OPERATIONS.channelMarkRead(ctx(), { chat: '@g', messageId: 9 });
+    expect(hooks.telegramClient.markChannelRead).toHaveBeenCalledWith('@g', 9);
+    expect(result).toEqual({ channelId: '1', messageId: 9 });
+  });
+
+  it('exposes a fixed allowlist covering the migrated surface', () => {
+    for (const op of [
+      'listChannels', 'channelShow', 'channelSetSync', 'channelMarkRead',
+      'messagesList', 'messagesSearch', 'messagesGet', 'messagesContext',
+      'sendText', 'sendPhoto', 'sendFile', 'mediaDownload',
+      'topicsList', 'tagsSet', 'tagsList', 'tagsSearch', 'tagsAuto',
+      'metadataGet', 'metadataRefresh',
+      'contactsSearch', 'contactsShow', 'contactsAliasSet', 'contactsAliasRemove',
+      'contactsTagsAdd', 'contactsTagsRemove', 'contactsNotesSet',
+      'groupsList', 'groupsInfo', 'groupsRename', 'groupMembersAdd', 'groupMembersRemove',
+      'getGroupInviteLink', 'revokeGroupInviteLink', 'groupsJoin', 'groupsLeave',
+      'foldersList', 'foldersShow', 'foldersCreate', 'foldersEdit', 'foldersDelete',
+      'foldersReorder', 'foldersChatsAdd', 'foldersChatsRemove', 'foldersJoin',
+    ]) {
+      expect(typeof OPERATIONS[op]).toBe('function');
+    }
   });
 });
 
 describe('runOperation seam', () => {
-  it('routes to the server via invoke when a server is reachable', async () => {
-    hooks.pingServer.mockResolvedValue({ ok: true });
+  it('auto-starts the server then invokes the op, returning its result', async () => {
     hooks.invoke.mockResolvedValue([{ id: 'warm' }]);
 
-    const result = await runOperation(
-      {},
-      { op: 'listChannels', args: { limit: 3 }, need: 'full', lock: 'read', requireAuth: true },
-    );
+    const result = await runOperation({}, { op: 'listChannels', args: { limit: 3 } });
 
+    expect(hooks.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-seam-store', { idleExit: '60s' });
     expect(hooks.invoke).toHaveBeenCalledWith('/tmp/tgcli-seam-store', {
       op: 'listChannels',
       args: { limit: 3 },
+      timeoutMs: undefined,
     });
     expect(result).toEqual([{ id: 'warm' }]);
-    // Server path runs nothing locally.
-    expect(hooks.telegramClient.listDialogs).not.toHaveBeenCalled();
   });
 
-  it('falls back to local withCommand + OPERATIONS[op] when no server is reachable', async () => {
-    hooks.pingServer.mockResolvedValue(null);
+  it('forwards invokeTimeoutMs as the invoke wait budget', async () => {
+    hooks.invoke.mockResolvedValue({ ok: true });
 
-    const result = await runOperation(
-      {},
-      { op: 'listChannels', args: { limit: 3 }, need: 'full', lock: 'read', requireAuth: true },
-    );
+    await runOperation({}, { op: 'sendText', args: { chat: '@g' }, invokeTimeoutMs: 30000 });
 
+    expect(hooks.invoke).toHaveBeenCalledWith('/tmp/tgcli-seam-store', {
+      op: 'sendText',
+      args: { chat: '@g' },
+      timeoutMs: 30000,
+    });
+  });
+
+  it('rejects an unknown operation before reaching the server', async () => {
+    await expect(runOperation({}, { op: 'nope', args: {} })).rejects.toThrow(/unknown operation/);
+    expect(hooks.ensureServer).not.toHaveBeenCalled();
     expect(hooks.invoke).not.toHaveBeenCalled();
-    expect(hooks.telegramClient.isAuthorized).toHaveBeenCalled();
-    expect(hooks.telegramClient.listDialogs).toHaveBeenCalledWith(3);
-    expect(result).toEqual([{ id: '1', title: 'Local' }]);
   });
 
-  it('enforces the local auth check before running the op', async () => {
-    hooks.pingServer.mockResolvedValue(null);
-    hooks.telegramClient.isAuthorized.mockResolvedValue(false);
-
+  it('surfaces a server start failure as a clear error', async () => {
+    hooks.ensureServer.mockRejectedValue(new Error('Timed out waiting for the control server to start.'));
     await expect(
-      runOperation(
-        {},
-        { op: 'listChannels', args: {}, need: 'full', lock: 'read', requireAuth: true },
-      ),
-    ).rejects.toThrow('Not authenticated');
-    expect(hooks.telegramClient.listDialogs).not.toHaveBeenCalled();
-  });
-
-  it('produces identical results via the server path and the local path', async () => {
-    // Local result.
-    hooks.pingServer.mockResolvedValue(null);
-    const local = await runOperation(
-      {},
-      { op: 'getGroupInviteLink', args: { chat: '@g' }, need: 'telegram', lock: 'read', requireAuth: true },
-    );
-
-    // Server path returns whatever the warm OPERATIONS[op] produced — model that
-    // with the same shape the local client returns.
-    hooks.pingServer.mockResolvedValue({ ok: true });
-    hooks.invoke.mockResolvedValue({ link: 'https://t.me/+local' });
-    const served = await runOperation(
-      {},
-      { op: 'getGroupInviteLink', args: { chat: '@g' }, need: 'telegram', lock: 'read', requireAuth: true },
-    );
-
-    expect(served).toEqual(local);
+      runOperation({}, { op: 'listChannels', args: {} }),
+    ).rejects.toThrow('Timed out waiting for the control server to start.');
+    expect(hooks.invoke).not.toHaveBeenCalled();
   });
 });

--- a/tests/send-operations.test.js
+++ b/tests/send-operations.test.js
@@ -1,0 +1,153 @@
+// Tests for the send operations (sendText/sendPhoto/sendFile) and how the control
+// server relays their structured failures. The send ops wrap the existing
+// send-utils retry/flood/timeout logic against the warm client, so retry and
+// rate-limit behavior runs server-side; on failure the control server serializes
+// the SendCommandError details so the CLI can render the same error.
+
+import http from 'node:http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OPERATIONS } from '../core/operations.js';
+import { SendCommandError } from '../core/send-utils.js';
+import { createControlRequestHandler, CONTROL_TOKEN_HEADER } from '../core/control-server.js';
+
+const TOKEN = 'send-token';
+
+function startServer(handler) {
+  const server = http.createServer((req, res) => void handler(req, res));
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function request(port, body) {
+  const res = await fetch(`http://127.0.0.1:${port}/control/invoke`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', [CONTROL_TOKEN_HEADER]: TOKEN },
+    body: JSON.stringify(body),
+  });
+  let json = null;
+  try {
+    json = await res.json();
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json };
+}
+
+describe('send operations against the warm client', () => {
+  it('sendText returns the client result with attempts', async () => {
+    const telegramClient = {
+      sendTextMessage: vi.fn().mockResolvedValue({ messageId: 55 }),
+    };
+    const result = await OPERATIONS.sendText({ telegramClient }, {
+      chat: '@c',
+      text: 'hi',
+      topicId: 3,
+      parseMode: 'markdown',
+      silent: true,
+    });
+    expect(telegramClient.sendTextMessage).toHaveBeenCalledWith('@c', 'hi', expect.objectContaining({
+      topicId: 3,
+      parseMode: 'markdown',
+      silent: true,
+    }));
+    expect(result).toEqual({ result: { messageId: 55 }, attempts: 1 });
+  });
+
+  it('retries a transient failure server-side and reports the attempt count', async () => {
+    const telegramClient = {
+      sendTextMessage: vi.fn()
+        .mockRejectedValueOnce(new Error('A wait of 1 seconds is required'))
+        .mockResolvedValueOnce({ messageId: 88 }),
+    };
+    const result = await OPERATIONS.sendText({ telegramClient }, {
+      chat: '@c',
+      text: 'hi',
+      retries: 2,
+      // Constant 0ms backoff keeps the retry instant for the test.
+      retryBackoff: { kind: 'constant', baseMs: 0 },
+    });
+    expect(telegramClient.sendTextMessage).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ result: { messageId: 88 }, attempts: 2 });
+  });
+
+  it('throws a SendCommandError when a FLOOD_WAIT exceeds the timeout budget', async () => {
+    const telegramClient = {
+      sendFileMessage: vi.fn().mockRejectedValue(new Error('FLOOD_WAIT_120')),
+    };
+    const error = await OPERATIONS.sendFile({ telegramClient }, {
+      chat: '@c',
+      file: '/tmp/x',
+      retries: 2,
+      timeoutMs: 30000,
+    }).catch((e) => e);
+    expect(error).toBeInstanceOf(SendCommandError);
+    expect(error.details).toMatchObject({ type: 'rate_limit', method: 'sendFile', waitSeconds: 120 });
+    expect(error.details.message).toContain('FLOOD_WAIT 120s');
+  });
+
+  it('sendPhoto prepares then sends the prepared media', async () => {
+    const prepared = { method: 'sendPhoto' };
+    const telegramClient = {
+      preparePhotoMessage: vi.fn().mockResolvedValue(prepared),
+      sendPreparedPhotoMessage: vi.fn().mockResolvedValue({ chatId: '1', messageId: 9, method: 'sendPhoto' }),
+    };
+    const result = await OPERATIONS.sendPhoto({ telegramClient }, {
+      chat: '@c',
+      photo: '/tmp/p.png',
+      caption: 'hi',
+    });
+    expect(telegramClient.preparePhotoMessage).toHaveBeenCalledWith('@c', '/tmp/p.png', expect.objectContaining({ caption: 'hi' }));
+    expect(telegramClient.sendPreparedPhotoMessage).toHaveBeenCalledWith(prepared);
+    expect(result.attempts).toBe(1);
+    expect(result.result).toMatchObject({ messageId: 9 });
+  });
+});
+
+describe('/control/invoke send error relay', () => {
+  let server;
+  let port;
+  let telegramClient;
+
+  beforeEach(async () => {
+    telegramClient = {
+      sendTextMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
+    };
+    const handler = createControlRequestHandler({
+      service: { getJobCounts: vi.fn(() => ({})) },
+      warmServices: { telegramClient, messageSyncService: {} },
+      token: TOKEN,
+      pid: 1,
+      version: '1',
+      startedAt: 's',
+      ensureLogin: vi.fn(() => Promise.resolve()),
+    });
+    ({ server, port } = await startServer(handler));
+  });
+
+  afterEach(() => {
+    server.close();
+    vi.restoreAllMocks();
+  });
+
+  it('runs a send op and returns its result', async () => {
+    const { status, json } = await request(port, {
+      op: 'sendText',
+      args: { chat: '@c', text: 'hi' },
+    });
+    expect(status).toBe(200);
+    expect(json).toEqual({ result: { result: { messageId: 1 }, attempts: 1 } });
+  });
+
+  it('relays a SendCommandError as a sendError payload on failure', async () => {
+    telegramClient.sendTextMessage = vi.fn().mockRejectedValue(new Error('FLOOD_WAIT_120'));
+    const { status, json } = await request(port, {
+      op: 'sendText',
+      args: { chat: '@c', text: 'hi', retries: 0, timeoutMs: 30000 },
+    });
+    expect(status).toBe(500);
+    expect(json.sendError).toMatchObject({ type: 'rate_limit', method: 'sendText', waitSeconds: 120 });
+    expect(json.error).toContain('FLOOD_WAIT_120');
+  });
+});

--- a/tests/send-timeout.test.js
+++ b/tests/send-timeout.test.js
@@ -9,12 +9,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // network, filesystem, or auth side effects.
 
 const services = vi.hoisted(() => ({ current: null }));
+const control = vi.hoisted(() => ({ ensureServer: null, invoke: null }));
 
 vi.mock('../core/services.js', () => ({
   createServices: vi.fn(() => services.current),
   // withCommand builds only the needed half via these granular factories.
   createTelegramClient: vi.fn(() => ({ telegramClient: services.current.telegramClient })),
   createMessageSyncService: vi.fn(() => ({ messageSyncService: services.current.messageSyncService })),
+}));
+
+// Send commands route through the warm server (ensureServer + invoke). The CLI's
+// timeoutMs bounds its wait on invoke; modeling that wait here lets us assert the
+// CLI surfaces a clear send-timeout without any real process or network.
+vi.mock('../core/control-client.js', () => ({
+  ensureServer: (...args) => control.ensureServer(...args),
+  invoke: (...args) => control.invoke(...args),
+  pingServer: vi.fn(),
+  enqueueBackfill: vi.fn(),
+  cancelBackfill: vi.fn(),
 }));
 
 vi.mock('../store-lock.js', () => ({
@@ -146,10 +158,9 @@ describe('executeSendWithRetries FLOOD_WAIT budget handling', () => {
 
 // --- CLI integration: scoped default timeout -----------------------------
 
-function makeFakeServices({ sendImpl, refreshImpl } = {}) {
+function makeFakeServices({ refreshImpl } = {}) {
   const telegramClient = {
     isAuthorized: vi.fn().mockResolvedValue(true),
-    sendTextMessage: vi.fn(sendImpl ?? (async () => ({ messageId: 1 }))),
     startUpdates: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
   };
@@ -163,6 +174,27 @@ function makeFakeServices({ sendImpl, refreshImpl } = {}) {
   return { telegramClient, messageSyncService };
 }
 
+// Model the warm server's send execution behind invoke: a hanging send rejects
+// with a TimeoutError once the CLI's invoke timeoutMs elapses (mirroring
+// AbortSignal.timeout aborting the real request); a normal send resolves with the
+// op's { result, attempts } shape.
+function makeInvoke({ resultMessageId, hang = false } = {}) {
+  return vi.fn((_storeDir, { timeoutMs } = {}) => new Promise((resolve, reject) => {
+    if (hang) {
+      if (timeoutMs && timeoutMs > 0) {
+        setTimeout(() => {
+          const error = new Error('The operation was aborted due to timeout');
+          error.name = 'TimeoutError';
+          reject(error);
+        }, timeoutMs);
+      }
+      // timeoutMs === 0 (--timeout 0): never settle.
+      return;
+    }
+    resolve({ result: { messageId: resultMessageId }, attempts: 1 });
+  }));
+}
+
 describe('send command default timeout (CLI integration)', () => {
   let logSpy;
   let errSpy;
@@ -174,6 +206,7 @@ describe('send command default timeout (CLI integration)', () => {
     errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     exitCode = process.exitCode;
     process.exitCode = undefined;
+    control.ensureServer = vi.fn().mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -191,13 +224,11 @@ describe('send command default timeout (CLI integration)', () => {
   }
 
   it('(a) times out a hanging send after the 30s default when no --timeout is given', async () => {
-    // sendTextMessage never resolves -> the only thing that can end the command
-    // is the default timeout.
-    services.current = makeFakeServices({ sendImpl: () => new Promise(() => {}) });
+    control.invoke = makeInvoke({ hang: true });
 
     const done = runProgram(['send', 'text', '--to', '@x', '--message', 'hi']);
 
-    // Let the async work reach the hanging send, then cross the 30s boundary.
+    // Let the async work reach the hanging invoke, then cross the 30s boundary.
     await vi.advanceTimersByTimeAsync(29000);
     expect(process.exitCode).toBeUndefined();
     await vi.advanceTimersByTimeAsync(2000);
@@ -206,11 +237,10 @@ describe('send command default timeout (CLI integration)', () => {
     expect(process.exitCode).toBe(1);
     const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
     expect(stderrText).toContain('Send timed out after 30s');
-    expect(stderrText).toContain('Connecting to Telegram');
   });
 
   it('(d) honors an explicit --timeout value', async () => {
-    services.current = makeFakeServices({ sendImpl: () => new Promise(() => {}) });
+    control.invoke = makeInvoke({ hang: true });
 
     const done = runProgram(['send', 'text', '--to', '@x', '--message', 'hi', '--timeout', '1s']);
 
@@ -223,10 +253,8 @@ describe('send command default timeout (CLI integration)', () => {
   });
 
   it('(c) --timeout 0 disables the timeout (send is unbounded)', async () => {
-    let resolveSend;
-    services.current = makeFakeServices({
-      sendImpl: () => new Promise((resolve) => { resolveSend = resolve; }),
-    });
+    let invokeResolve;
+    control.invoke = vi.fn(() => new Promise((resolve) => { invokeResolve = resolve; }));
 
     const done = runProgram(['send', 'text', '--to', '@x', '--message', 'hi', '--timeout', '0']);
 
@@ -235,11 +263,13 @@ describe('send command default timeout (CLI integration)', () => {
     expect(process.exitCode).toBeUndefined();
 
     // Now let the send finish and confirm success, not a timeout.
-    resolveSend({ messageId: 7 });
+    invokeResolve({ result: { messageId: 7 }, attempts: 1 });
     await done;
 
     expect(process.exitCode).toBeUndefined();
     expect(logSpy.mock.calls.flat().join(' ')).toContain('Message sent (7).');
+    // The CLI passes timeoutMs: 0 so its wait on invoke is unbounded.
+    expect(control.invoke.mock.calls[0][1].timeoutMs).toBe(0);
   });
 
   it('(b) a long-running command (sync) is NOT bounded by the send default', async () => {
@@ -262,26 +292,25 @@ describe('send command default timeout (CLI integration)', () => {
     void done;
   });
 
-  it('prints the Connecting status on stderr by default (no --quiet)', async () => {
-    services.current = makeFakeServices({ sendImpl: async () => ({ messageId: 11 }) });
+  it('passes the 30s default as the invoke timeout and prints success', async () => {
+    control.invoke = makeInvoke({ resultMessageId: 11 });
 
     await runProgram(['send', 'text', '--to', '@x', '--message', 'hi']);
 
     expect(process.exitCode).toBeUndefined();
-    const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
-    expect(stderrText).toContain('Connecting to Telegram');
+    expect(control.invoke).toHaveBeenCalledTimes(1);
+    expect(control.invoke.mock.calls[0][1].timeoutMs).toBe(DEFAULT_SEND_TIMEOUT_MS);
     expect(logSpy.mock.calls.flat().join(' ')).toContain('Message sent (11).');
   });
 
-  it('suppresses the Connecting status with --quiet', async () => {
-    services.current = makeFakeServices({ sendImpl: async () => ({ messageId: 12 }) });
+  it('honors --quiet without emitting the dropped connecting status', async () => {
+    control.invoke = makeInvoke({ resultMessageId: 12 });
 
     await runProgram(['send', 'text', '--to', '@x', '--message', 'hi', '--quiet']);
 
     expect(process.exitCode).toBeUndefined();
     const stderrText = errSpy.mock.calls.map((c) => c[0]).join('');
     expect(stderrText).not.toContain('Connecting to Telegram');
-    // Primary stdout/--json output is unaffected.
     expect(logSpy.mock.calls.flat().join(' ')).toContain('Message sent (12).');
   });
 });


### PR DESCRIPTION
**Variant B, Step 1 of #45** — all Telegram/archive CLI commands are now thin clients over the **warm server** (auto-started), executing operation handlers **shared with the MCP tools**. The local execution fallback is removed.

## Core
- **`runOperation` simplified** to `ensureServer(idleExit '60s') → invoke(op, args)`. No local fallback, no `need`/`lock`/`requireAuth` — the server owns services, auth, and locking. (`withCommand` is retained for the server's own startup, `auth`, and the legacy sync handlers.)
- **`OPERATIONS` — 44 ops** covering the full surface (channels, messages, send, media, topics, tags, metadata, contacts, groups, folders). Message ops own the shared `source: archive|live|both` logic + archive→live fallback; the message-formatting helpers now live once in `operations.js` (removed from `cli.js` and `mcp-server.js`).
- **MCP tools unified** onto the same ops against the same warm services — an MCP tool and its CLI command run identical logic.

## Send (single writer)
`send text/photo/file` run server-side: the ops wrap the existing `executeSendWithRetries` (retry / FLOOD_WAIT / rate-limit) against the warm client. On failure, `/control/invoke` serializes the `SendCommandError.details` as `sendError`, which the control-client re-throws so the CLI renders the **identical** human/`--json` error. The 30s default bounds the client's wait on the invoke. (The `--quiet` "Connecting…" status is dropped — the client no longer connects; `--quiet` stays honored.)

## Kept local
`config`, `service`, `doctor`, and `auth` (interactive login is the bootstrap: it writes the session locally; the warm server uses it).

## Scale
`cli.js` handlers collapse to validate → `runOperation` → format; `mcp-server.js` −483; `operations.js` +983. Net +330 with major consolidation.

## Known follow-ups (not blocking; mostly Step 2)
- Legacy in-process worker (`sync`/`backfill --once/--follow`, `backfill jobs ...`) still runs locally — **Step 2** retires it (server as sole writer, `sync`→shim) and **closes #45**.
- `logSendRetry` is now unused (retries are server-side) — a small follow-up cleanup.
- Send retry progress is no longer streamed to the CLI (it happens server-side).
- Re-running `auth` while a server is already running needs a server restart to pick up the new session (pre-existing; auth was always local).

## Tests
`npm test` → **325 passing** (312 + 13): the simplified seam (ensureServer/invoke, no fallback), the new ops registry, the send op's server-side retry/flood + the `sendError` relay, `/control/invoke` for the new ops, and the migrated commands. No `node_modules` in the commit; comments are behavioral (no history).
