### PR TITLE
feat: retire the legacy in-process worker — server is the sole writer (#45, Step 2)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -68,7 +68,7 @@ tgcli backfill wait                            # block until the queue drains
 tgcli backfill cancel --chat @channel          # stop a chat's backfills
 tgcli channels watch --chat @channel           # subscribe a chat for archiving (queues a backfill)
 tgcli channels unwatch --chat @channel         # stop archiving a chat
-tgcli backfill --follow                         # legacy in-process sync (`sync` is a silent alias)
+tgcli backfill --follow                         # track the server's queue to completion (`sync` is a silent alias)
 tgcli service install
 tgcli service start
 ```

--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,7 @@ import { Command, Option } from 'commander';
 
 import { acquireStoreLock, acquireReadLock, readStoreLock } from './store-lock.js';
 import { loadConfig, normalizeConfig, saveConfig, validateConfig } from './core/config.js';
-import { createMessageSyncService, createServices, createTelegramClient } from './core/services.js';
+import { createServices, createTelegramClient } from './core/services.js';
 import { withCommand, runWithTimeout, runOperation } from './core/command-context.js';
 import {
   buildSendErrorPayload,
@@ -27,6 +27,7 @@ import {
   enqueueBackfill,
   ensureServer,
   pingServer,
+  retryBackfill,
 } from './core/control-client.js';
 
 const CLI_PATH = fileURLToPath(import.meta.url);
@@ -74,7 +75,6 @@ function buildProgram() {
 
   const auth = program.command('auth').description('Authentication and session setup');
   auth
-    .option('--follow', 'Continue syncing after login')
     .option('--force-sms', 'Force SMS code delivery instead of in-app')
     .option('--qr', 'Use QR-code login flow instead of confirmation code')
     .option('--qr-file <path>', 'Save QR code as PNG image file')
@@ -131,16 +131,16 @@ function buildProgram() {
     .alias('sync')
     .description('Archive backfill and realtime sync');
   sync
-    // Server-executed one-shot client (issue #30/#26): `--chat` enqueues a
-    // backfill on the always-on server (auto-starting it) and follows progress.
+    // `--chat` enqueues a single-chat backfill on the always-on server
+    // (auto-starting it) and follows progress.
     .option('--chat <id|username>', 'Backfill a single chat via the control server')
     .option('--depth <n>', 'Maximum messages to backfill (with --chat)')
     .option('--min-date <iso>', 'Earliest date to backfill (with --chat)')
     .option('--background', 'Enqueue and return immediately (with --chat)')
-    // Legacy in-process sync flags (no --chat).
-    .option('--once', 'Run once and exit')
-    .option('--follow', 'Keep syncing realtime updates')
-    .option('--idle-exit <duration>', 'Exit after idle period')
+    // Without --chat: drain the server's queue. --follow tracks progress to the
+    // foreground; --once is a deprecated alias of `backfill wait`.
+    .option('--follow', 'Track the backfill queue until it drains, then exit')
+    .addOption(new Option('--once', 'Deprecated alias of `backfill wait`').hideHelp())
     .action(withGlobalOptions((globalFlags, options) => runBackfill(globalFlags, options)));
   sync
     .command('status')
@@ -1284,40 +1284,6 @@ function normalizeInviteCode(value) {
   return `https://t.me/joinchat/${trimmed}`;
 }
 
-async function withShutdown(handler) {
-  let stopping = false;
-  const stop = async () => {
-    if (stopping) return;
-    stopping = true;
-    try {
-      await handler();
-    } finally {
-      process.exit(0);
-    }
-  };
-  process.on('SIGINT', () => void stop());
-  process.on('SIGTERM', () => void stop());
-}
-
-async function waitForIdle(service, idleExitMs) {
-  let idleStart = null;
-  while (true) {
-    const stats = service.getQueueStats();
-    const active = stats.pending + stats.in_progress;
-    if (!stats.processing && active === 0) {
-      if (!idleStart) {
-        idleStart = Date.now();
-      }
-      if (Date.now() - idleStart >= idleExitMs) {
-        return;
-      }
-    } else {
-      idleStart = null;
-    }
-    await delay(500);
-  }
-}
-
 async function runAuthStatus(globalFlags) {
   const timeoutMs = globalFlags.timeoutMs;
   return runWithTimeout(async () => {
@@ -1394,18 +1360,14 @@ async function runAuthLogout(globalFlags) {
   }, timeoutMs);
 }
 
+// Interactive login + session bootstrap only: write the session and exit. Archive
+// sync and the queue run in the always-on server, which auto-starts on the next
+// command that needs it (or via `tgcli server`).
 export async function runAuthLogin(globalFlags, options = {}) {
   const timeoutMs = globalFlags.timeoutMs;
   let release = null;
   let telegramClient = null;
-  let messageSyncService = null;
-  let keepRunning = false;
   const cleanup = async () => {
-    if (messageSyncService) {
-      const currentService = messageSyncService;
-      messageSyncService = null;
-      await currentService.shutdown();
-    }
     if (telegramClient) {
       const currentClient = telegramClient;
       telegramClient = null;
@@ -1429,23 +1391,11 @@ export async function runAuthLogin(globalFlags, options = {}) {
         useQr: options.qr,
         qrFilePath: options.qrFile,
         json: globalFlags.json,
-        disableUpdates: !options.follow,
+        disableUpdates: true,
       }));
       const loginSuccess = await telegramClient.login();
       if (!loginSuccess) {
         throw new Error('Failed to login to Telegram.');
-      }
-      if (options.follow) {
-        ({ messageSyncService } = createMessageSyncService(telegramClient, { storeDir }));
-        await messageSyncService.refreshChannelsFromDialogs();
-        await telegramClient.startUpdates();
-        messageSyncService.startRealtimeSync();
-        messageSyncService.resumePendingJobs();
-        await withShutdown(async () => {
-          await cleanup();
-        });
-        keepRunning = true;
-        return;
       }
 
       if (globalFlags.json) {
@@ -1454,9 +1404,7 @@ export async function runAuthLogin(globalFlags, options = {}) {
         console.log(`Authenticated. ${AUTH_SYNC_HINT}`);
       }
     } finally {
-      if (!keepRunning) {
-        await cleanup();
-      }
+      await cleanup();
     }
   }, timeoutMs, cleanup);
 }
@@ -1632,11 +1580,10 @@ function writeProgress(globalFlags, line) {
   }
 }
 
-// Server-executed backfill (issue #30/#26). With `--chat`, enqueue on the
-// always-on control server (auto-starting it) and either return the job id
-// (`--background`) or follow progress in the foreground. Without `--chat`, fall
-// through to the unchanged in-process legacy sync (so `sync`/`backfill --once`
-// /`--follow` keep working).
+// With `--chat`, enqueue a single-chat backfill on the always-on control server
+// (auto-starting it) and either return the job id (`--background`) or follow
+// progress in the foreground. Without `--chat`, delegate to the queue-draining
+// path (`--follow`/`--once`/bare usage).
 async function runBackfill(globalFlags, options = {}) {
   if (!options.chat) {
     return runSync(globalFlags, options);
@@ -1741,26 +1688,33 @@ async function runBackfillCount(globalFlags) {
   }, globalFlags.timeoutMs);
 }
 
-// Start the server if needed (so the queue actually drains) and wait until no
-// pending/in-progress backfills remain, showing progress to stderr.
+// Start the server if needed (so the queue actually drains) and poll under brief
+// read snapshots until no pending/in-progress backfills remain, writing per-chat
+// progress to stderr along the way. The server keeps running on its own (realtime
+// continues while it is up / has watched chats); this only tracks the queue.
+async function drainBackfillQueue(globalFlags, storeDir) {
+  await ensureServer(storeDir, { idleExit: '60s' });
+  while (true) {
+    const { active, jobs } = withReadSnapshot(storeDir, (service) => {
+      const counts = service.getJobCounts();
+      const inFlight = service.listJobs({ status: 'in_progress', limit: 50 });
+      return { active: counts.pending + counts.inProgress, jobs: inFlight };
+    });
+    for (const job of jobs) {
+      writeProgress(globalFlags, jobProgressLine(job));
+    }
+    if (active === 0) {
+      break;
+    }
+    await delay(1000);
+  }
+}
+
+// `backfill wait`: start the server if needed and track the queue to completion.
 async function runBackfillWait(globalFlags) {
   return runWithTimeout(async () => {
     const storeDir = resolveStoreDir();
-    await ensureServer(storeDir, { idleExit: '60s' });
-    while (true) {
-      const { active, jobs } = withReadSnapshot(storeDir, (service) => {
-        const counts = service.getJobCounts();
-        const inFlight = service.listJobs({ status: 'in_progress', limit: 50 });
-        return { active: counts.pending + counts.inProgress, jobs: inFlight };
-      });
-      for (const job of jobs) {
-        writeProgress(globalFlags, jobProgressLine(job));
-      }
-      if (active === 0) {
-        break;
-      }
-      await delay(1000);
-    }
+    await drainBackfillQueue(globalFlags, storeDir);
     if (globalFlags.json) {
       writeJson({ ok: true, drained: true });
     } else if (!globalFlags.quiet) {
@@ -1801,52 +1755,20 @@ async function runBackfillCancel(globalFlags, options = {}) {
   }, globalFlags.timeoutMs);
 }
 
+// Bare `backfill`/`sync` (no --chat). Archiving runs in the always-on server; this
+// only tracks its queue. `--follow` and `--once` both drain the queue and exit —
+// they never run a worker or hold the store write lock. With no flag, there is
+// nothing to track, so show usage.
 async function runSync(globalFlags, options = {}) {
-  const timeoutMs = globalFlags.timeoutMs;
-  return runWithTimeout(async () => {
-    const storeDir = resolveStoreDir();
-    const release = acquireStoreLock(storeDir);
-    const { telegramClient, messageSyncService } = createServices({ storeDir });
-    const idleExitMs = parseDuration(options.idleExit || '30s');
-    const follow = options.follow || !options.once;
-
-    try {
-      if (!(await telegramClient.isAuthorized().catch(() => false))) {
-        throw new Error('Not authenticated. Run `node cli.js auth` first.');
-      }
-
-      await messageSyncService.refreshChannelsFromDialogs();
-      messageSyncService.resumePendingJobs();
-
-      if (follow) {
-        await telegramClient.startUpdates();
-        messageSyncService.startRealtimeSync();
-        if (!globalFlags.json) {
-          console.log('Sync running. Press Ctrl+C to stop.');
-        }
-        await withShutdown(async () => {
-          await messageSyncService.shutdown();
-          await telegramClient.destroy();
-          release();
-        });
-        return;
-      }
-
-      await waitForIdle(messageSyncService, idleExitMs);
-      const stats = messageSyncService.getQueueStats();
-      if (globalFlags.json) {
-        writeJson({ ok: true, mode: 'once', queue: stats });
-      } else {
-        console.log('Sync complete.');
-      }
-    } finally {
-      if (!follow) {
-        await messageSyncService.shutdown();
-        await telegramClient.destroy();
-        release();
-      }
+  if (!options.follow && !options.once) {
+    const backfill = CLI_PROGRAM.commands.find((command) => command.name() === 'backfill');
+    if (backfill) {
+      process.stderr.write(backfill.helpInformation());
     }
-  }, timeoutMs);
+    return;
+  }
+  // `--once` is a deprecated alias of `backfill wait`: drain quietly and exit.
+  return runBackfillWait(globalFlags);
 }
 
 async function runServer(globalFlags, options = {}) {
@@ -2308,28 +2230,31 @@ async function runSyncJobsList(globalFlags, options = {}) {
   });
 }
 
+// Enqueue a job on the always-on server (auto-starting it); the server's queue
+// processes it. Returns immediately after enqueue.
 async function runSyncJobsAdd(globalFlags, options = {}) {
   if (!options.chat) {
     throw new Error('--chat is required');
   }
-  return withCommand(globalFlags, { need: 'worker', lock: 'write' }, async ({ telegramClient, messageSyncService }) => {
-    if (!(await telegramClient.isAuthorized().catch(() => false))) {
-      throw new Error('Not authenticated. Run `node cli.js auth` first.');
-    }
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
     const depth = parsePositiveInt(options.depth, '--depth');
-    const job = messageSyncService.addJob(options.chat, {
+    await ensureServer(storeDir, { idleExit: '60s' });
+    const job = await enqueueBackfill(storeDir, {
+      chatId: options.chat,
       depth,
       minDate: options.minDate ?? null,
     });
-    void messageSyncService.processQueue();
     if (globalFlags.json) {
       writeJson(job);
     } else {
-      console.log(`Job scheduled for ${job.channel_id} (#${job.id}).`);
+      console.log(`Job scheduled for ${job.channelId} (#${job.jobId}).`);
     }
-  });
+  }, globalFlags.timeoutMs);
 }
 
+// Reset errored job(s) to pending on the always-on server (auto-starting it); the
+// server's queue reprocesses them.
 async function runSyncJobsRetry(globalFlags, options = {}) {
   const jobId = parsePositiveInt(options.jobId, '--job-id');
   const channelId = options.channel ?? null;
@@ -2340,22 +2265,16 @@ async function runSyncJobsRetry(globalFlags, options = {}) {
   if (allErrors && (jobId || channelId)) {
     throw new Error('Use --all-errors without --job-id/--channel');
   }
-  return withCommand(globalFlags, { need: 'worker', lock: 'write' }, async ({ telegramClient, messageSyncService }) => {
-    const result = messageSyncService.retryJobs({
-      jobId,
-      channelId,
-      allErrors,
-    });
-    const authed = await telegramClient.isAuthorized().catch(() => false);
-    if (authed && result.updated > 0) {
-      void messageSyncService.processQueue();
-    }
+  return runWithTimeout(async () => {
+    const storeDir = resolveStoreDir();
+    await ensureServer(storeDir, { idleExit: '60s' });
+    const result = await retryBackfill(storeDir, { jobId, channelId, allErrors });
     if (globalFlags.json) {
       writeJson(result);
     } else {
       console.log(`Re-queued ${result.updated} job(s).`);
     }
-  });
+  }, globalFlags.timeoutMs);
 }
 
 async function runSyncJobsCancel(globalFlags, options = {}) {
@@ -2686,19 +2605,6 @@ function normalizeSendCommandError(error, { method, retries, attempt = 1 } = {})
   if (error instanceof SendCommandError) return error;
   if (error instanceof TypeError || error instanceof ReferenceError || error instanceof SyntaxError || error instanceof RangeError) return error;
   return new SendCommandError(classifySendError(error, { method, retries, attempt }));
-}
-
-function logSendRetry(details, globalFlags) {
-  if (globalFlags.json) {
-    process.stderr.write(`${JSON.stringify({ event: 'retry', type: details.type, method: details.method, message: details.message, attempt: details.attempt, retries: details.retries })}\n`);
-    return;
-  }
-  const totalAttempts = (details.retries ?? 0) + 1;
-  const codeSuffix = details.code !== undefined && details.code !== null && details.code !== ''
-    ? ` (${details.code})` : '';
-  process.stderr.write(
-    `${details.method} transient ${details.type} error on attempt ${details.attempt}/${totalAttempts}${codeSuffix}; retrying...\n`,
-  );
 }
 
 function buildSendPhotoSuccessPayload({ method, inputChatId, result, attempts }) {
@@ -3557,7 +3463,6 @@ export {
   formatSendTimeoutMessage,
   getFeedbackCooldownRemainingSeconds,
   isCliEntrypoint,
-  logSendRetry,
   main,
   normalizeSendCommandError,
   parseNonNegativeInt,

--- a/core/control-client.js
+++ b/core/control-client.js
@@ -124,6 +124,25 @@ export async function cancelBackfill(storeDir, { chatId, jobId } = {}) {
   return json;
 }
 
+// POST /control/retry → { updated, jobIds }. Resets the matching errored job(s)
+// to pending on the server so its queue reprocesses them. Throws on a non-2xx
+// response.
+export async function retryBackfill(storeDir, { jobId, channelId, allErrors } = {}) {
+  const control = readControlFile(storeDir);
+  if (!control) {
+    throw new Error('No control server is running. Start one with `tgcli server`.');
+  }
+  const { status, json } = await controlFetch(control, '/control/retry', {
+    method: 'POST',
+    body: { jobId, channelId, allErrors },
+    timeoutMs: ENQUEUE_TIMEOUT_MS,
+  });
+  if (status !== 200) {
+    throw new Error(json?.error ?? `Retry request failed (HTTP ${status})`);
+  }
+  return json;
+}
+
 // POST /control/invoke { op, args } → the operation's result. Runs the shared
 // operation handler against the server's warm services and returns `result`.
 // timeoutMs bounds the request wait (defaults to the enqueue budget); a value of

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -169,6 +169,32 @@ export function createControlRequestHandler({
         return;
       }
 
+      if (req.method === 'POST' && url.pathname === '/control/retry') {
+        const body = await readJsonBody(req);
+        const jobId = body?.jobId;
+        const channelId = body?.channelId;
+        const allErrors = Boolean(body?.allErrors);
+        if (
+          !allErrors &&
+          (jobId === undefined || jobId === null) &&
+          (channelId === undefined || channelId === null || String(channelId).trim() === '')
+        ) {
+          sendJson(res, 400, { error: 'Provide jobId, channelId, or allErrors' });
+          return;
+        }
+        // Same logic as `sync jobs retry`: reset the errored job(s) to pending,
+        // then kick the queue so the server's worker picks them back up.
+        const result = service.retryJobs({ jobId, channelId, allErrors });
+        if (result.updated > 0) {
+          void service.processQueue();
+        }
+        sendJson(res, 200, {
+          updated: result.updated,
+          jobIds: result.jobIds,
+        });
+        return;
+      }
+
       if (req.method === 'POST' && url.pathname === '/control/cancel') {
         const body = await readJsonBody(req);
         const chatId = body?.chatId;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -28,8 +28,11 @@ Store location: OS app data dir (override with TGCLI_STORE).
 MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP).
 
 ## auth
-- auth [--qr] [--qr-file <path>] [--force-sms] [--follow] [--idle-exit <duration>] [--download-media]
-  - Interactive login. Use --qr for QR code login (scan in Telegram app).
+- auth [--qr] [--qr-file <path>] [--force-sms]
+  - Interactive login + session bootstrap only: writes the session and exits. It
+    does not sync or run a worker. Archiving runs in the always-on server, which
+    auto-starts on the next command that needs it (or via `tgcli server`).
+  - --qr for QR code login (scan in Telegram app).
   - --qr-file saves the QR code as a PNG image (useful for agents).
   - --force-sms forces code delivery via SMS instead of in-app notification.
 - auth status
@@ -64,11 +67,17 @@ one-shot client.
 - backfill cancel --chat <id|username>
   - Cancel a chat's backfills via the server when one is up; falls back to a
     direct cancel (same as `backfill jobs cancel --channel`) when none is.
-- backfill (no --chat): legacy in-process sync (alias: `sync`)
-  - Flags: --once | --follow, --idle-exit 30s, --download-media, --refresh-contacts, --refresh-groups
+- backfill (no --chat): track the server's queue (alias: `sync`)
+  - `--follow`: auto-start the server if needed, track the queue with live
+    progress, and exit once it drains. The server keeps running on its own
+    (realtime continues while it is up / has watched chats).
+  - `--once`: deprecated alias of `backfill wait` — drain quietly and exit.
+  - With no flag: prints usage (there is no queue to track).
 - backfill jobs list [--status] [--limit] [--channel]
 - backfill jobs add --chat <id|username> [--min-date ISO] [--depth N]
+  - Enqueue a job on the server (auto-starting it); the server's queue processes it.
 - backfill jobs retry [--job-id] [--channel] [--all-errors]
+  - Reset errored job(s) to pending on the server; the server's queue reprocesses them.
 - backfill jobs cancel --job-id|--channel
 - `sync` remains a silent alias of `backfill` (and every subcommand), so existing `sync …` invocations keep working unchanged.
 

--- a/tests/backfill-client.test.js
+++ b/tests/backfill-client.test.js
@@ -12,6 +12,7 @@ const control = vi.hoisted(() => ({
   pingServer: vi.fn(() => Promise.resolve(null)),
   enqueueBackfill: vi.fn(() => Promise.resolve({ jobId: 11, channelId: '-100', status: 'pending' })),
   cancelBackfill: vi.fn(() => Promise.resolve({ canceled: 1, jobIds: [11] })),
+  retryBackfill: vi.fn(() => Promise.resolve({ updated: 2, jobIds: [11, 12] })),
 }));
 
 vi.mock('../core/services.js', () => ({
@@ -74,10 +75,12 @@ afterEach(() => {
   control.pingServer.mockClear();
   control.enqueueBackfill.mockClear();
   control.cancelBackfill.mockClear();
+  control.retryBackfill.mockClear();
   control.ensureServer.mockResolvedValue({ ok: true, pid: 7, version: '2' });
   control.pingServer.mockResolvedValue(null);
   control.enqueueBackfill.mockResolvedValue({ jobId: 11, channelId: '-100', status: 'pending' });
   control.cancelBackfill.mockResolvedValue({ canceled: 1, jobIds: [11] });
+  control.retryBackfill.mockResolvedValue({ updated: 2, jobIds: [11, 12] });
   vi.clearAllMocks();
 });
 
@@ -220,5 +223,79 @@ describe('backfill cancel', () => {
     await runProgram(['backfill', 'cancel', '--chat', '@chan']);
     expect(control.cancelBackfill).not.toHaveBeenCalled();
     expect(services.current.messageSyncService.cancelJobs).toHaveBeenCalledWith({ channelId: '@chan' });
+  });
+});
+
+describe('backfill (no --chat): queue draining via the server', () => {
+  it('--once starts the server and tracks the queue to completion', async () => {
+    services.current = makeFakeServices({
+      getJobCounts: vi.fn(() => ({ pending: 0, inProgress: 0 })),
+    });
+    await runProgram(['backfill', '--once']);
+    expect(control.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-test-store', { idleExit: '60s' });
+    // No in-process worker: never created services for queue processing, only the
+    // brief read snapshot the drain poll uses.
+    expect(services.current.messageSyncService.processQueue).toBeUndefined();
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Backfill queue drained.');
+  });
+
+  it('--follow tracks the queue with progress, then exits when drained', async () => {
+    const getJobCounts = vi
+      .fn()
+      .mockReturnValueOnce({ pending: 0, inProgress: 1 })
+      .mockReturnValue({ pending: 0, inProgress: 0 });
+    services.current = makeFakeServices({
+      getJobCounts,
+      listJobs: vi.fn((q) => (q.status === 'in_progress'
+        ? [{ id: 11, channel_id: '-100', peer_title: 'Chan', status: 'in_progress', message_count: 5, target_message_count: 100 }]
+        : [])),
+    });
+    await runProgram(['sync', '--follow']);
+    expect(control.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-test-store', { idleExit: '60s' });
+    expect(stderrText()).toContain('Backfilling Chan');
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Backfill queue drained.');
+  });
+
+  it('bare backfill (no flags) prints usage and does not touch the server', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill']);
+    expect(control.ensureServer).not.toHaveBeenCalled();
+    expect(stderrText()).toContain('Usage:');
+  });
+});
+
+describe('backfill jobs add / retry route through the control API', () => {
+  it('jobs add enqueues via the control client (no in-process queue)', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill', 'jobs', 'add', '--chat', '@chan', '--depth', '5']);
+    expect(control.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-test-store', { idleExit: '60s' });
+    expect(control.enqueueBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      chatId: '@chan',
+      depth: 5,
+      minDate: null,
+    });
+    expect(services.current.messageSyncService.processQueue).toBeUndefined();
+  });
+
+  it('jobs retry resets via the control client and lets the server process', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill', 'jobs', 'retry', '--all-errors']);
+    expect(control.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-test-store', { idleExit: '60s' });
+    expect(control.retryBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      jobId: null,
+      channelId: null,
+      allErrors: true,
+    });
+    expect(logSpy.mock.calls.flat().join(' ')).toContain('Re-queued 2 job(s).');
+  });
+
+  it('jobs retry by channel routes the channel filter to the server', async () => {
+    services.current = makeFakeServices();
+    await runProgram(['backfill', 'jobs', 'retry', '--channel', '@chan']);
+    expect(control.retryBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      jobId: null,
+      channelId: '@chan',
+      allErrors: false,
+    });
   });
 });

--- a/tests/backfill-rename.test.js
+++ b/tests/backfill-rename.test.js
@@ -13,7 +13,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const services = vi.hoisted(() => ({ current: null }));
-const control = vi.hoisted(() => ({ ensureServer: null, invoke: null }));
+const control = vi.hoisted(() => ({ ensureServer: null, invoke: null, enqueueBackfill: null }));
 
 vi.mock('../core/services.js', () => ({
   createServices: vi.fn(() => services.current),
@@ -31,8 +31,9 @@ vi.mock('../core/control-client.js', () => ({
   ensureServer: (...args) => control.ensureServer(...args),
   invoke: (...args) => control.invoke(...args),
   pingServer: vi.fn(),
-  enqueueBackfill: vi.fn(),
+  enqueueBackfill: (...args) => control.enqueueBackfill(...args),
   cancelBackfill: vi.fn(),
+  retryBackfill: vi.fn(),
 }));
 
 vi.mock('../store-lock.js', () => ({
@@ -85,6 +86,12 @@ describe('backfill is a canonical alias of sync', () => {
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    control.ensureServer = vi.fn().mockResolvedValue({ ok: true });
+    control.enqueueBackfill = vi.fn(async (_storeDir, { chatId }) => ({
+      jobId: 1,
+      channelId: chatId,
+      status: 'pending',
+    }));
   });
 
   afterEach(() => {
@@ -118,17 +125,24 @@ describe('backfill is a canonical alias of sync', () => {
     expect(backfillOut.join('\n')).toContain('QUEUE:');
   });
 
-  it('`backfill jobs add` resolves the nested subcommand and queues a job (like `sync jobs add`)', async () => {
+  it('`backfill jobs add` resolves the nested subcommand and queues a job on the server (like `sync jobs add`)', async () => {
     services.current = makeFakeServices();
     await runProgram(['backfill', 'jobs', 'add', '--chat', '@chan']);
-    expect(services.current.messageSyncService.addJob).toHaveBeenCalledWith('@chan', {
+    expect(control.ensureServer).toHaveBeenCalledWith('/tmp/tgcli-test-store', { idleExit: '60s' });
+    expect(control.enqueueBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      chatId: '@chan',
       depth: null,
       minDate: null,
     });
+    // No in-process job/queue work.
+    expect(services.current.messageSyncService.addJob).not.toHaveBeenCalled();
+    expect(services.current.messageSyncService.processQueue).not.toHaveBeenCalled();
 
+    control.enqueueBackfill.mockClear();
     services.current = makeFakeServices();
     await runProgram(['sync', 'jobs', 'add', '--chat', '@chan']);
-    expect(services.current.messageSyncService.addJob).toHaveBeenCalledWith('@chan', {
+    expect(control.enqueueBackfill).toHaveBeenCalledWith('/tmp/tgcli-test-store', {
+      chatId: '@chan',
       depth: null,
       minDate: null,
     });

--- a/tests/cli-send-photo.test.js
+++ b/tests/cli-send-photo.test.js
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildSendPhotoSuccessPayload, logSendRetry, normalizeSendCommandError, parseNonNegativeInt, shouldRunMain, writeError } from '../cli.js';
+import { buildSendPhotoSuccessPayload, normalizeSendCommandError, parseNonNegativeInt, shouldRunMain, writeError } from '../cli.js';
 import { SendCommandError, buildSendErrorPayload } from '../core/send-utils.js';
 
 describe('tgcli send photo CLI validation', () => {
@@ -155,30 +155,3 @@ describe('writeError', () => {
   });
 });
 
-describe('logSendRetry', () => {
-  let stderrSpy;
-
-  beforeEach(() => {
-    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-  });
-
-  afterEach(() => {
-    stderrSpy.mockRestore();
-  });
-
-  it('writes structured JSON event to stderr in JSON mode', () => {
-    const details = { type: 'network', method: 'sendPhoto', message: 'ECONNRESET', attempt: 1, retries: 3 };
-    logSendRetry(details, { json: true });
-    const written = JSON.parse(stderrSpy.mock.calls[0][0]);
-    expect(written).toEqual({ event: 'retry', type: 'network', method: 'sendPhoto', message: 'ECONNRESET', attempt: 1, retries: 3 });
-  });
-
-  it('writes human-readable retry message to stderr in text mode', () => {
-    const details = { type: 'network', method: 'sendPhoto', message: 'ECONNRESET', code: 'ECONNRESET', attempt: 1, retries: 3 };
-    logSendRetry(details, { json: false });
-    const output = stderrSpy.mock.calls[0][0];
-    expect(output).toContain('sendPhoto transient network error');
-    expect(output).toContain('attempt 1/4');
-    expect(output).toContain('(ECONNRESET)');
-  });
-});

--- a/tests/control-client.test.js
+++ b/tests/control-client.test.js
@@ -18,6 +18,7 @@ import {
   invoke,
   pingServer,
   readControlFile,
+  retryBackfill,
 } from '../core/control-client.js';
 import { CONTROL_TOKEN_HEADER } from '../core/control-server.js';
 import { SendCommandError } from '../core/send-utils.js';
@@ -120,6 +121,21 @@ describe('enqueueBackfill / cancelBackfill', () => {
     const [url, init] = global.fetch.mock.calls[0];
     expect(url).toBe('http://127.0.0.1:8765/control/cancel');
     expect(JSON.parse(init.body)).toEqual({ chatId: '@c', jobId: undefined });
+  });
+
+  it('POSTs to /control/retry and returns the reset result', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(200, { updated: 3, jobIds: [1, 2, 3] }));
+    const result = await retryBackfill(storeDir, { allErrors: true });
+    expect(result).toEqual({ updated: 3, jobIds: [1, 2, 3] });
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:8765/control/retry');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ jobId: undefined, channelId: undefined, allErrors: true });
+  });
+
+  it('throws the server error message on a non-200 retry response', async () => {
+    global.fetch.mockResolvedValue(jsonResponse(400, { error: 'Provide jobId, channelId, or allErrors' }));
+    await expect(retryBackfill(storeDir, {})).rejects.toThrow('Provide jobId, channelId, or allErrors');
   });
 });
 

--- a/tests/control-server.test.js
+++ b/tests/control-server.test.js
@@ -20,6 +20,7 @@ function makeService(overrides = {}) {
     })),
     processQueue: vi.fn(() => Promise.resolve()),
     cancelJobs: vi.fn(() => ({ canceled: 1, jobIds: [42] })),
+    retryJobs: vi.fn(() => ({ updated: 1, jobIds: [42] })),
     ...overrides,
   };
 }
@@ -142,6 +143,53 @@ describe('control API request handler', () => {
     });
     expect(status).toBe(400);
     expect(service.cancelJobs).not.toHaveBeenCalled();
+  });
+
+  it('POST /control/retry resets via retryJobs and kicks the queue', async () => {
+    const { status, json } = await request(port, 'POST', '/control/retry', {
+      token: TOKEN,
+      body: { channelId: '777' },
+    });
+    expect(status).toBe(200);
+    expect(service.retryJobs).toHaveBeenCalledWith({
+      jobId: undefined,
+      channelId: '777',
+      allErrors: false,
+    });
+    expect(service.processQueue).toHaveBeenCalledTimes(1);
+    expect(json).toEqual({ updated: 1, jobIds: [42] });
+  });
+
+  it('POST /control/retry accepts allErrors', async () => {
+    const { status } = await request(port, 'POST', '/control/retry', {
+      token: TOKEN,
+      body: { allErrors: true },
+    });
+    expect(status).toBe(200);
+    expect(service.retryJobs).toHaveBeenCalledWith({
+      jobId: undefined,
+      channelId: undefined,
+      allErrors: true,
+    });
+  });
+
+  it('POST /control/retry does not kick the queue when nothing was reset', async () => {
+    service.retryJobs.mockReturnValueOnce({ updated: 0, jobIds: [] });
+    const { status } = await request(port, 'POST', '/control/retry', {
+      token: TOKEN,
+      body: { jobId: 99 },
+    });
+    expect(status).toBe(200);
+    expect(service.processQueue).not.toHaveBeenCalled();
+  });
+
+  it('POST /control/retry requires jobId, channelId, or allErrors', async () => {
+    const { status } = await request(port, 'POST', '/control/retry', {
+      token: TOKEN,
+      body: {},
+    });
+    expect(status).toBe(400);
+    expect(service.retryJobs).not.toHaveBeenCalled();
   });
 
   it('rejects requests with a missing token', async () => {

--- a/tests/send-timeout.test.js
+++ b/tests/send-timeout.test.js
@@ -273,9 +273,11 @@ describe('send command default timeout (CLI integration)', () => {
   });
 
   it('(b) a long-running command (sync) is NOT bounded by the send default', async () => {
-    // refreshChannelsFromDialogs hangs forever; if the send default leaked into
-    // sync it would reject at 30s. It must not.
-    services.current = makeFakeServices({ refreshImpl: () => new Promise(() => {}) });
+    // The queue never drains (one job stays in-flight forever); if the send
+    // default leaked into sync it would reject at 30s. It must not.
+    services.current = makeFakeServices();
+    services.current.messageSyncService.getJobCounts = vi.fn(() => ({ pending: 0, inProgress: 1 }));
+    services.current.messageSyncService.listJobs = vi.fn(() => []);
 
     let settled = false;
     const done = runProgram(['sync', '--once']).then(
@@ -283,7 +285,7 @@ describe('send command default timeout (CLI integration)', () => {
       () => { settled = true; },
     );
 
-    // Advance to 2x the send default; sync must still be running.
+    // Advance to 2x the send default; sync must still be tracking the queue.
     await vi.advanceTimersByTimeAsync(60000);
     expect(settled).toBe(false);
     expect(process.exitCode).toBeUndefined();


### PR DESCRIPTION
**Step 2 of #45 — completes the warm-backend arc.** No CLI command runs the in-process queue worker, the realtime loop, or takes the exclusive store write lock for queue processing anymore. The server (`mcp-server.js`) is the **sole writer**.

Closes #45.

## Changes
- **`runSync` (bare `backfill`/`sync`) no longer runs the worker in-process** (no `acquireStoreLock`/`createServices`/`processQueue`/`startRealtimeSync`/`refreshChannelsFromDialogs`/`resumePendingJobs`):
  - `--follow` → `ensureServer` + drain the queue while streaming live per-chat progress, exit when drained. The server keeps running on its own (realtime continues while up / watched).
  - `--once` → deprecated, hidden alias of `backfill wait` (drain quietly, exit).
  - bare (no flags) → prints usage; runs nothing.
  - Extracted a shared `drainBackfillQueue` (used by `wait` and `--follow`); removed the orphaned `waitForIdle`/`withShutdown` and an unused import.
- **`jobs add` / `jobs retry` → control API** (no in-process `processQueue`): `add` → `POST /control/backfill`; `retry` → new `POST /control/retry` (resets the matching errored job(s) via `service.retryJobs` and lets the server's queue reprocess). New `retryBackfill` client added. `jobs list`/`cancel` unchanged.
- **`auth`** — removed `--follow` and the entire post-login sync block. Auth is interactive login + session write (bootstrap) only; it never runs the worker.
- **Removed the dead `logSendRetry`** (+ its test). Send retries run server-side; restoring client-visible retry/progress is tracked in #50.

## Verified
`grep` confirms **zero** worker primitives remain in `cli.js`. The only remaining `acquireStoreLock` sites are auth login/logout, feedback, and the no-server cancel fallback — none process the queue or run realtime. `sync` stays a silent alias of `backfill`; `tgcli server`/`service` untouched.

## Out of scope (separate issues)
#51 (drop legacy dialog-cache seeding), #49 (operations-layer audit/dedup), #50 (stream server-side events to the CLI), #40 (rename `mcp-server.js`).

## Tests
`npm test` → **336 passing** (324 + 12 new: `--once`/`--follow`/bare-backfill routing, `jobs add`/`retry` via control API, the `/control/retry` endpoint + `retryBackfill` client). No `node_modules` committed; comments behavioral. Docs updated (`docs/cli.md`, `SKILL.md`).
