### PR TITLE
media download reports "(0 bytes)" for successfully downloaded files

### DIFF
--- a/telegram-client.js
+++ b/telegram-client.js
@@ -11,6 +11,7 @@ import os from 'os';
 import path from 'path';
 import readline from 'readline';
 import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { nodeReadableToFuman } from '@fuman/node';
 import { resolveStoreDir, resolveStorePaths } from './core/store.js';
 
@@ -1233,7 +1234,19 @@ class TelegramClient {
       summary,
     });
     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    await this.client.downloadToFile(targetPath, location);
+    // pipeline resolves only after the write stream has fully flushed to disk,
+    // so the stat below always sees the complete file (mtcute's downloadToFile
+    // resolves before the flush, which made the reported size race to 0).
+    try {
+      await pipeline(this.client.downloadAsNodeStream(location), fs.createWriteStream(targetPath));
+    } catch (error) {
+      try {
+        fs.rmSync(targetPath, { force: true });
+      } catch {
+        // Best-effort cleanup of the partial file; surface the original error.
+      }
+      throw error;
+    }
     const stats = fs.statSync(targetPath);
 
     return {

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -1234,9 +1234,10 @@ class TelegramClient {
       summary,
     });
     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-    // pipeline resolves only after the write stream has fully flushed to disk,
-    // so the stat below always sees the complete file (mtcute's downloadToFile
-    // resolves before the flush, which made the reported size race to 0).
+    // Do not switch to mtcute's downloadToFile: it resolves before its write
+    // stream flushes, so an immediate stat can report 0 bytes. pipeline
+    // resolves only after the destination stream finishes, so the stat below
+    // always sees the complete file.
     try {
       await pipeline(this.client.downloadAsNodeStream(location), fs.createWriteStream(targetPath));
     } catch (error) {

--- a/tests/media-download.test.js
+++ b/tests/media-download.test.js
@@ -1,0 +1,117 @@
+const mtcuteClientCtor = vi.hoisted(() => vi.fn(function () {
+  return {
+    destroy: vi.fn().mockResolvedValue(undefined),
+    stopUpdatesLoop: vi.fn().mockResolvedValue(undefined),
+    onRawUpdate: { remove: vi.fn() },
+  };
+}));
+
+vi.mock('@mtcute/node', () => ({
+  TelegramClient: mtcuteClientCtor,
+}));
+
+vi.mock('@mtcute/core', () => ({
+  InputMedia: {},
+}));
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+import { setImmediate as setImmediateAsync } from 'timers/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TelegramClient from '../telegram-client.js';
+
+function makeChunks(chunkSize, chunkCount) {
+  const chunks = [];
+  for (let i = 0; i < chunkCount; i += 1) {
+    chunks.push(new Uint8Array(chunkSize).fill(i % 256));
+  }
+  return chunks;
+}
+
+function makeDocumentMessage() {
+  return {
+    media: {
+      type: 'document',
+      mimeType: 'application/pdf',
+      fileName: 'doc.pdf',
+      location: { _: 'inputDocumentFileLocation' },
+    },
+  };
+}
+
+function createClient({ message, downloadAsNodeStream }) {
+  const client = new TelegramClient(12345, 'hash', '+1234567890', '/tmp/tgcli-media-download.session');
+  client.ensureLogin = async () => {};
+  client.client = {
+    getMessages: vi.fn().mockResolvedValue([message]),
+    downloadAsNodeStream,
+  };
+  return client;
+}
+
+describe('downloadMessageMedia', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-media-download-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reports the same byte count as the file on disk', async () => {
+    const chunks = makeChunks(8192, 10); // ~80 KB across multiple chunks
+    const totalBytes = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const client = createClient({
+      message: makeDocumentMessage(),
+      downloadAsNodeStream: vi.fn(() => Readable.from(chunks)),
+    });
+
+    const result = await client.downloadMessageMedia('123', 5, { outputPath: tmpDir });
+
+    expect(result.path).toBe(path.join(tmpDir, 'doc.pdf'));
+    expect(result.bytes).toBe(totalBytes);
+    expect(result.bytes).toBe(fs.statSync(result.path).size);
+    expect(fs.readFileSync(result.path)).toEqual(Buffer.concat(chunks));
+    expect(result.mimeType).toBe('application/pdf');
+  });
+
+  it('waits for the full flush when chunks arrive slowly', async () => {
+    const chunks = makeChunks(8192, 6);
+    const totalBytes = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    async function* slowChunks() {
+      for (const chunk of chunks) {
+        await setImmediateAsync();
+        yield chunk;
+      }
+    }
+    const client = createClient({
+      message: makeDocumentMessage(),
+      downloadAsNodeStream: vi.fn(() => Readable.from(slowChunks())),
+    });
+
+    const result = await client.downloadMessageMedia('123', 5, { outputPath: tmpDir });
+
+    expect(result.bytes).toBe(totalBytes);
+    expect(result.bytes).toBe(fs.statSync(result.path).size);
+  });
+
+  it('rejects on download error without leaving a partial file', async () => {
+    async function* failingChunks() {
+      yield new Uint8Array(8192).fill(1);
+      throw new Error('connection lost');
+    }
+    const client = createClient({
+      message: makeDocumentMessage(),
+      downloadAsNodeStream: vi.fn(() => Readable.from(failingChunks())),
+    });
+
+    await expect(client.downloadMessageMedia('123', 5, { outputPath: tmpDir }))
+      .rejects.toThrow('connection lost');
+    expect(fs.existsSync(path.join(tmpDir, 'doc.pdf'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`media download` prints `Downloaded to … (0 bytes)` while the file is actually written correctly (observed: 75,700 bytes). The agent consuming the output trusted it and went into a second diagnostic loop (`--help`, `ls`) before realizing the file was intact. Root cause: the size was stat'ed before the write flush completed. Acceptance criterion: the reported size matches the file on disk after the download completes.

## Plan outline

1. Root cause: in `telegram-client.js`, `downloadMessageMedia()` used mtcute's `client.downloadToFile()`, which resolves before its internal `WriteStream` flushes, so the immediate `fs.statSync` raced the flush and could report 0 bytes.
2. Fix: replace it with `await pipeline(this.client.downloadAsNodeStream(location), fs.createWriteStream(targetPath))` using `stream/promises`, which resolves only after the destination stream finishes — the stat then always sees the complete file.
3. Optional hardening: on pipeline error, remove the partial file (best-effort) and rethrow, so a failed download cannot be misreported as success.
4. Tests: unit tests with a stubbed inner client covering reported-size accuracy, a slow-consumer timing variant, and mid-stream error handling.
5. Manual acceptance: spot-check a real download against a live Telegram message, comparing printed bytes vs `ls -l` (requires an authenticated session; left for human review).

## Implementation

Implemented the backlog fix for media download reporting "(0 bytes)" on branch `pipeline/media-download-reports-zero-bytes`. In `telegram-client.js`, `downloadMessageMedia()` previously called mtcute's `client.downloadToFile()`, which resolves before its internal WriteStream flushes, so the immediate `fs.statSync` raced the flush and reported 0 bytes. Replaced it with `await pipeline(this.client.downloadAsNodeStream(location), fs.createWriteStream(targetPath))` using `stream/promises` pipeline (new import), which resolves only after the destination stream finishes — the stat now always sees the complete file. Added the plan's optional hardening: on pipeline error, the partial file is removed best-effort (`fs.rmSync` force) and the original error is rethrown, so a failed download can no longer be misreported as success. No other changes (path resolution, return shape, CLI output format untouched); the single fix covers CLI human output, `--json`, and the MCP `mediaDownload` tool since all share `downloadMessageMedia`.

## Test results

Added `tests/media-download.test.js` following the `vi.hoisted`/`vi.mock` pattern from `tests/telegram-client-auth.test.js`, with a stubbed inner client (`getMessages` + `downloadAsNodeStream`) and a tmp dir per test:

1. Reported bytes equal `fs.statSync` size and file content equals the ~80 KB multi-chunk payload; path/name and mimeType asserted.
2. Slow-consumer variant with awaited `setImmediate` between chunks still reports full size (locks in flush-awaiting regardless of timing).
3. Mid-stream error rejects with the original error and leaves no partial file.

Ran the new file (3/3 pass) and the full suite `npm test` (vitest run): 27 files, 339 tests, all green — including the unchanged `tests/operations-seam.test.js` pinning the `mediaDownload` op seam.

Not performed: the plan's manual acceptance step against a real Telegram message (requires a live authenticated session, which this pipeline run does not have) — recommend a quick `node cli.js media download --chat=<chat> --id=<msg> --output <path>` spot check comparing printed bytes vs `ls -l` before merging.

## Review findings and resolutions

Addressed the single should-fix finding. The history-style comment in `telegram-client.js` (`downloadMessageMedia`, ~line 1237) was rephrased into a present-tense contract warning per `docs/ROADMAP.md`'s no-history rule: "Do not switch to mtcute's downloadToFile: it resolves before its write stream flushes, so an immediate stat can report 0 bytes. pipeline resolves only after the destination stream finishes, so the stat below always sees the complete file." Committed as 015629c ("Rephrase download comment as a present-tense API contract warning"). The npm-install-induced `package-lock.json` churn was discarded, not committed.

Re-verification after the fix: full suite green — vitest run, 27 test files passed, 339 tests passed (vitest 4.1.2, duration 3.45s).

Unaddressed findings: none.

## Backlog item

`knowledge/projects/tgcli/backlog/2026-06-12-media-download-reports-zero-bytes.md` (ops-hub repo; local checkout: `/Users/konstantinfastov/.ops-hub/repo/knowledge/projects/tgcli/backlog/2026-06-12-media-download-reports-zero-bytes.md`)
