### PR TITLE
Group chat addressing: normalize peer IDs, make resolution errors actionable

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -73,6 +73,20 @@ function buildProgram() {
     .version(readVersion(), '--version', 'Print version and exit')
     .showHelpAfterError(true);
 
+  // A bare negative chat id (`--chat -100123` works, but a stray `-100123`
+  // parses as a flag) trips commander's unknown-option error; append the exact
+  // workaround. Subcommands share this output configuration by reference, so
+  // one root-level hook covers the whole command tree.
+  program.configureOutput({
+    outputError: (str, write) => {
+      write(str);
+      const match = /unknown option '(-\d+)'/.exec(str);
+      if (match) {
+        write(`Negative chat ids must be quoted or attached with '=': --chat="${match[1]}" or --chat=${match[1]}\n`);
+      }
+    },
+  });
+
   const auth = program.command('auth').description('Authentication and session setup');
   auth
     .option('--force-sms', 'Force SMS code delivery instead of in-app')

--- a/cli.js
+++ b/cli.js
@@ -710,12 +710,25 @@ function negativeChatIdWorkaround(id) {
   return `Negative chat ids must be quoted or attached with '=': --chat="${id}" or --chat=${id}`;
 }
 
+// The client layer suggests retrying with the negative id in frontend-neutral
+// wording; restate it in this CLI's flag syntax, including the quoting trap a
+// bare negative value falls into.
+function writeSignRetryHint(message) {
+  const signRetry = PEER_SIGN_RETRY_PATTERN.exec(message ?? '');
+  if (signRetry) {
+    process.stderr.write(`${negativeChatIdWorkaround(signRetry[1])}\n`);
+  }
+}
+
 function writeError(error, asJson) {
   if (error instanceof SendCommandError) {
     if (asJson) {
       process.stderr.write(`${JSON.stringify(buildSendErrorPayload(error.details), null, 2)}\n`);
     } else {
+      // Send failures carry the underlying message in details; a failed peer
+      // resolution surfaces its sign-retry suggestion through there.
       process.stderr.write(`${formatSendErrorMessage(error.details)}\n`);
+      writeSignRetryHint(error.details?.message);
     }
     return;
   }
@@ -725,13 +738,7 @@ function writeError(error, asJson) {
     return;
   }
   process.stderr.write(`${message}\n`);
-  // The client layer suggests retrying with the negative id in
-  // frontend-neutral wording; restate it here in this CLI's flag syntax,
-  // including the quoting trap a bare negative value falls into.
-  const signRetry = PEER_SIGN_RETRY_PATTERN.exec(message);
-  if (signRetry) {
-    process.stderr.write(`${negativeChatIdWorkaround(signRetry[1])}\n`);
-  }
+  writeSignRetryHint(message);
 }
 
 function supportsColorOutput() {

--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,7 @@ import {
 } from './core/send-utils.js';
 import { resolveStoreDir } from './core/store.js';
 import { parseDuration } from './core/duration.js';
+import { PEER_SIGN_RETRY_PATTERN } from './core/peer-hints.js';
 import {
   cancelBackfill,
   enqueueBackfill,
@@ -82,7 +83,7 @@ function buildProgram() {
       write(str);
       const match = /unknown option '(-\d+)'/.exec(str);
       if (match) {
-        write(`Negative chat ids must be quoted or attached with '=': --chat="${match[1]}" or --chat=${match[1]}\n`);
+        write(`${negativeChatIdWorkaround(match[1])}\n`);
       }
     },
   });
@@ -702,6 +703,13 @@ function writeJson(payload) {
   process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
+// The exact flag-quoting workaround for a negative chat id. Shared by the
+// parser's unknown-option hook and writeError so both surfaces phrase it the
+// same way.
+function negativeChatIdWorkaround(id) {
+  return `Negative chat ids must be quoted or attached with '=': --chat="${id}" or --chat=${id}`;
+}
+
 function writeError(error, asJson) {
   if (error instanceof SendCommandError) {
     if (asJson) {
@@ -714,8 +722,15 @@ function writeError(error, asJson) {
   const message = error?.message ?? String(error);
   if (asJson) {
     process.stderr.write(`${JSON.stringify({ ok: false, error: message })}\n`);
-  } else {
-    process.stderr.write(`${message}\n`);
+    return;
+  }
+  process.stderr.write(`${message}\n`);
+  // The client layer suggests retrying with the negative id in
+  // frontend-neutral wording; restate it here in this CLI's flag syntax,
+  // including the quoting trap a bare negative value falls into.
+  const signRetry = PEER_SIGN_RETRY_PATTERN.exec(message);
+  if (signRetry) {
+    process.stderr.write(`${negativeChatIdWorkaround(signRetry[1])}\n`);
   }
 }
 

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -129,9 +129,17 @@ export function createControlRequestHandler({
         if (typeof ensureLogin === 'function') {
           await ensureLogin();
         }
+        // Canonicalize the chat reference before enqueueing so the job row and
+        // the backfilled messages share the marked-id key the live-sync writer
+        // uses. Unresolvable ids fail here (500 with the resolution hint, via
+        // the outer catch) instead of leaving a phantom channels row plus a
+        // job that errors later.
+        const canonicalChatId = typeof warmServices?.telegramClient?.canonicalizeChannelId === 'function'
+          ? await warmServices.telegramClient.canonicalizeChannelId(chatId)
+          : chatId;
         // Same path as the scheduleMessageSync MCP tool: enqueue then kick the
         // queue so processing starts without waiting for the next trigger.
-        const job = service.addJob(chatId, { depth: body?.depth, minDate: body?.minDate });
+        const job = service.addJob(canonicalChatId, { depth: body?.depth, minDate: body?.minDate });
         void service.processQueue();
         sendJson(res, 200, {
           jobId: job?.id ?? null,

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -63,9 +63,11 @@ export function isIdle({ jobCounts, watchedCount, lastActivityAt, now, idleExitM
  *
  * @param {object} deps
  * @param {object} deps.service       MessageSyncService (or compatible stub).
- * @param {object} [deps.warmServices] Warm { telegramClient, messageSyncService }
- *                                     the shared operation handlers run against
- *                                     for /control/invoke.
+ * @param {object} deps.warmServices  Warm { telegramClient, messageSyncService }.
+ *                                    The shared operation handlers run against
+ *                                    it for /control/invoke, and /control/backfill
+ *                                    canonicalizes chat ids through its
+ *                                    telegramClient.
  * @param {string} deps.token         Secret required in the control token header.
  * @param {number} deps.pid           Server process id.
  * @param {string} deps.version       Server version string.
@@ -134,9 +136,7 @@ export function createControlRequestHandler({
         // uses. Unresolvable ids fail here (500 with the resolution hint, via
         // the outer catch) instead of leaving a phantom channels row plus a
         // job that errors later.
-        const canonicalChatId = typeof warmServices?.telegramClient?.canonicalizeChannelId === 'function'
-          ? await warmServices.telegramClient.canonicalizeChannelId(chatId)
-          : chatId;
+        const canonicalChatId = await warmServices.telegramClient.canonicalizeChannelId(chatId);
         // Same path as the scheduleMessageSync MCP tool: enqueue then kick the
         // queue so processing starts without waiting for the next trigger.
         const job = service.addJob(canonicalChatId, { depth: body?.depth, minDate: body?.minDate });

--- a/core/control-server.js
+++ b/core/control-server.js
@@ -133,9 +133,9 @@ export function createControlRequestHandler({
         }
         // Canonicalize the chat reference before enqueueing so the job row and
         // the backfilled messages share the marked-id key the live-sync writer
-        // uses. Unresolvable ids fail here (500 with the resolution hint, via
-        // the outer catch) instead of leaving a phantom channels row plus a
-        // job that errors later.
+        // uses. Positive ids that resolve to nothing fail here (500 with the
+        // resolution hint, via the outer catch); explicitly negative basic-chat
+        // ids resolve structurally in mtcute and are enqueued as given.
         const canonicalChatId = await warmServices.telegramClient.canonicalizeChannelId(chatId);
         // Same path as the scheduleMessageSync MCP tool: enqueue then kick the
         // queue so processing starts without waiting for the next trigger.

--- a/core/operations.js
+++ b/core/operations.js
@@ -211,9 +211,10 @@ async function channelShow(ctx, args = {}) {
 async function channelSetSync(ctx, args = {}) {
   // Enabling resolves the canonical archive key live so the channels row, the
   // job, and the backfilled messages all share the key the live-sync writer
-  // uses (unresolvable chats fail here, before anything is persisted).
-  // Disabling stays a pure DB lookup so unwatching a chat that is no longer
-  // accessible keeps working.
+  // uses (positive ids that resolve to nothing fail here, before anything is
+  // persisted; explicitly negative basic-chat ids resolve structurally in
+  // mtcute and are enabled as given). Disabling stays a pure DB lookup so
+  // unwatching a chat that is no longer accessible keeps working.
   const enable = Boolean(args.enable);
   const chatKey = enable
     ? await ctx.telegramClient.canonicalizeChannelId(args.chat)

--- a/core/operations.js
+++ b/core/operations.js
@@ -209,15 +209,24 @@ async function channelShow(ctx, args = {}) {
 // args: { chat, enable }. Toggle the per-chat archive flag; enabling also queues
 // a backfill job when none exists. Returns the new sync state plus job info.
 async function channelSetSync(ctx, args = {}) {
-  const result = ctx.messageSyncService.setChannelSync(args.chat, Boolean(args.enable));
+  // Enabling resolves the canonical archive key live so the channels row, the
+  // job, and the backfilled messages all share the key the live-sync writer
+  // uses (unresolvable chats fail here, before anything is persisted).
+  // Disabling stays a pure DB lookup so unwatching a chat that is no longer
+  // accessible keeps working.
+  const enable = Boolean(args.enable);
+  const chatKey = enable
+    ? await ctx.telegramClient.canonicalizeChannelId(args.chat)
+    : ctx.messageSyncService.resolveArchiveChannelKey(args.chat);
+  const result = ctx.messageSyncService.setChannelSync(chatKey, enable);
   let job = null;
   let jobQueued = false;
-  if (args.enable) {
-    const existing = ctx.messageSyncService.listJobs({ channelId: args.chat, limit: 1 });
+  if (enable) {
+    const existing = ctx.messageSyncService.listJobs({ channelId: chatKey, limit: 1 });
     if (existing.length > 0) {
       job = existing[0];
     } else {
-      job = ctx.messageSyncService.addJob(args.chat);
+      job = ctx.messageSyncService.addJob(chatKey);
       jobQueued = true;
       void ctx.messageSyncService.processQueue();
     }

--- a/core/peer-hints.js
+++ b/core/peer-hints.js
@@ -1,0 +1,16 @@
+// Vocabulary shared between the client layer's peer resolution hints and the
+// frontends that restate them. The client appends frontend-neutral hints to
+// resolution errors (it backs the CLI, the MCP server, and the control API,
+// so no flag or command syntax belongs there); a frontend recognizes the
+// sign-retry suggestion via PEER_SIGN_RETRY_PATTERN and rephrases it in its
+// own argument vocabulary. Kept dependency-free so frontends can import it
+// without pulling in the client module.
+
+// The neutral suggestion appended when a bare positive group/channel id fails
+// to resolve in any sign form.
+export function peerSignRetryHint(positiveId) {
+  return `group and channel ids are negative — retry with the negative id "-${positiveId}"`;
+}
+
+// Matches the peerSignRetryHint phrasing, capturing the suggested negative id.
+export const PEER_SIGN_RETRY_PATTERN = /retry with the negative id "(-\d+)"/;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,14 @@ Commands that stay local (no server): `config`, `service`, `doctor`, and `auth`
 Store location: OS app data dir (override with TGCLI_STORE).
 MCP: disabled by default (set `mcp.enabled` in config.json to true to serve MCP).
 
+## Chat identifiers
+`--chat` accepts a numeric chat id or a @username. Group and channel ids are
+negative, but the positive form works too — it resolves to the same chat. A
+bare negative value parses as a flag, so quote it or attach it with `=`:
+`--chat="-4701666782"` or `--chat=-4701666782` (the spaced form
+`--chat -4701666782` also works). Display names are not identifiers; find the
+id with `tgcli channels list --query "<title>"`.
+
 ## auth
 - auth [--qr] [--qr-file <path>] [--force-sms]
   - Interactive login + session bootstrap only: writes the session and exits. It

--- a/mcp-server.js
+++ b/mcp-server.js
@@ -1442,7 +1442,10 @@ function createServerInstance() {
     scheduleMessageSyncSchema,
     async ({ channelId, depth, minDate }) => {
       await ensureTelegramConnected();
-      const job = messageSyncService.addJob(channelId, { depth, minDate });
+      // Canonicalize before enqueueing so the job and its backfilled messages
+      // land under the same marked-id key the live-sync writer uses.
+      const canonicalChannelId = await telegramClient.canonicalizeChannelId(channelId);
+      const job = messageSyncService.addJob(canonicalChannelId, { depth, minDate });
       void messageSyncService.processQueue();
 
       return {

--- a/message-sync-service.js
+++ b/message-sync-service.js
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { setTimeout as delay } from 'timers/promises';
-import { Message, PeersIndex, _messageMediaFromTl } from '@mtcute/core';
+import { Message, PeersIndex, _messageMediaFromTl, toggleChannelIdMark } from '@mtcute/core';
 import { normalizeChannelId, summarizeMedia } from './telegram-client.js';
 import { resolveStoreDir, resolveStorePaths } from './core/store.js';
 
@@ -1551,8 +1551,63 @@ export default class MessageSyncService {
     return rows.map((row) => formatContactRow(row));
   }
 
+  // True when the archive holds real data under this key: a channels row with
+  // resolved metadata, or at least one archived message. Bare channels rows
+  // (side effects of addJob/tag inserts) do not count, so a leftover row from
+  // an old failed positive-id enqueue cannot pin the wrong key.
+  _channelKeyHasData(key) {
+    const channelRow = this.db.prepare(`
+      SELECT 1
+      FROM channels
+      WHERE channel_id = ? AND (peer_title IS NOT NULL OR peer_type IS NOT NULL)
+    `).get(key);
+    if (channelRow) {
+      return true;
+    }
+    const messageRow = this.db.prepare(`
+      SELECT 1 FROM messages WHERE channel_id = ? LIMIT 1
+    `).get(key);
+    return Boolean(messageRow);
+  }
+
+  // Maps a chat reference to the archive key that actually holds its data.
+  // Group/channel data is keyed by the marked (negative) id, so a bare positive
+  // id falls back to its channel (-100...) form, then its basic-chat (-id)
+  // form. Keys that already hold data — including user DMs under a positive
+  // key — are returned unchanged; no stored keys are rewritten.
+  resolveArchiveChannelKey(channelId) {
+    const key = normalizeChannelKey(channelId);
+    if (!/^\d+$/.test(key) || this._channelKeyHasData(key)) {
+      return key;
+    }
+    for (const candidate of [String(toggleChannelIdMark(Number(key))), `-${key}`]) {
+      if (this._channelKeyHasData(candidate)) {
+        return candidate;
+      }
+    }
+    return key;
+  }
+
+  // Same sign tolerance for job lookups (status/retry/cancel by chat): a job
+  // enqueued under the canonical negative key is found from the positive id.
+  _resolveJobChannelKey(channelId) {
+    const key = normalizeChannelKey(channelId);
+    const hasJob = (candidate) => Boolean(
+      this.db.prepare('SELECT 1 FROM jobs WHERE channel_id = ? LIMIT 1').get(candidate),
+    );
+    if (!/^\d+$/.test(key) || hasJob(key)) {
+      return key;
+    }
+    for (const candidate of [String(toggleChannelIdMark(Number(key))), `-${key}`]) {
+      if (hasJob(candidate)) {
+        return candidate;
+      }
+    }
+    return key;
+  }
+
   getChannelMetadata(channelId) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const row = this.db.prepare(`
       SELECT
         channels.channel_id,
@@ -1585,7 +1640,7 @@ export default class MessageSyncService {
   }
 
   getChannel(channelId) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const row = this.db.prepare(`
       SELECT
         channels.channel_id,
@@ -1839,7 +1894,7 @@ export default class MessageSyncService {
 
   listJobs(options = {}) {
     const status = options.status ? String(options.status) : null;
-    const channelId = options.channelId ? normalizeChannelKey(options.channelId) : null;
+    const channelId = options.channelId ? this._resolveJobChannelKey(options.channelId) : null;
     const limit = options.limit && options.limit > 0 ? Number(options.limit) : null;
     const clauses = [];
     const params = [];
@@ -1886,7 +1941,7 @@ export default class MessageSyncService {
 
   retryJobs(options = {}) {
     const allErrors = Boolean(options.allErrors);
-    const channelId = options.channelId ? normalizeChannelKey(options.channelId) : null;
+    const channelId = options.channelId ? this._resolveJobChannelKey(options.channelId) : null;
     const jobId = options.jobId !== undefined && options.jobId !== null ? Number(options.jobId) : null;
 
     if (!allErrors && jobId === null && !channelId) {
@@ -1938,7 +1993,7 @@ export default class MessageSyncService {
   }
 
   cancelJobs(options = {}) {
-    const channelId = options.channelId ? normalizeChannelKey(options.channelId) : null;
+    const channelId = options.channelId ? this._resolveJobChannelKey(options.channelId) : null;
     const jobId = options.jobId !== undefined && options.jobId !== null ? Number(options.jobId) : null;
 
     if (jobId === null && !channelId) {
@@ -2208,7 +2263,7 @@ export default class MessageSyncService {
 
   listArchivedMessages({ channelIds, topicId, fromDate, toDate, beforeId, afterId, limit = 50 }) {
     const resolvedIds = Array.isArray(channelIds) ? channelIds : (channelIds ? [channelIds] : []);
-    const normalizedIds = resolvedIds.map((id) => normalizeChannelKey(id)).filter(Boolean);
+    const normalizedIds = resolvedIds.map((id) => this.resolveArchiveChannelKey(id)).filter(Boolean);
     const clauses = [];
     const params = [];
 
@@ -2274,7 +2329,7 @@ export default class MessageSyncService {
   }
 
   getArchivedMessage({ channelId, messageId }) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const row = this.db.prepare(`
       SELECT
         messages.channel_id,
@@ -2305,7 +2360,7 @@ export default class MessageSyncService {
   }
 
   getArchivedMessageContext({ channelId, messageId, before = 20, after = 20 }) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const target = this.getArchivedMessage({ channelId: normalizedId, messageId });
     if (!target) {
       return { target: null, before: [], after: [] };
@@ -2384,7 +2439,7 @@ export default class MessageSyncService {
     const resolvedIds = Array.isArray(options.channelIds)
       ? options.channelIds
       : (options.channelIds ? [options.channelIds] : []);
-    const normalizedIds = resolvedIds.map((id) => normalizeChannelKey(id)).filter(Boolean);
+    const normalizedIds = resolvedIds.map((id) => this.resolveArchiveChannelKey(id)).filter(Boolean);
     const topicId = typeof options.topicId === 'number' ? options.topicId : null;
     const finalLimit = options.limit && options.limit > 0 ? Number(options.limit) : 100;
     const caseInsensitive = options.caseInsensitive !== false;

--- a/message-sync-service.js
+++ b/message-sync-service.js
@@ -1268,7 +1268,7 @@ export default class MessageSyncService {
   }
 
   upsertTopics(channelId, topics = []) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const entries = [];
     for (const topic of topics || []) {
       const id = typeof topic.id === 'number' ? topic.id : Number(topic.id);
@@ -1312,7 +1312,7 @@ export default class MessageSyncService {
   }
 
   setChannelTags(channelId, tags, options = {}) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const source = options.source ? String(options.source) : 'manual';
     const uniqueTags = new Set();
     for (const tag of tags || []) {
@@ -1334,7 +1334,7 @@ export default class MessageSyncService {
   }
 
   listChannelTags(channelId, options = {}) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const source = options.source ? String(options.source) : null;
     const rows = this.db.prepare(`
       SELECT tag, source, confidence, created_at, updated_at
@@ -1570,40 +1570,37 @@ export default class MessageSyncService {
     return Boolean(messageRow);
   }
 
-  // Maps a chat reference to the archive key that actually holds its data.
-  // Group/channel data is keyed by the marked (negative) id, so a bare positive
-  // id falls back to its channel (-100...) form, then its basic-chat (-id)
-  // form. Keys that already hold data — including user DMs under a positive
-  // key — are returned unchanged; no stored keys are rewritten.
-  resolveArchiveChannelKey(channelId) {
+  // Sign-fallback core shared by archive and job key lookups. Group/channel
+  // rows are keyed by the marked (negative) id, so a bare positive key that
+  // `hasData` rejects is retried in its channel (-100...) form, then its
+  // basic-chat (-id) form, keeping the first form that holds data. Non-numeric
+  // keys and keys that already hold data — including user DMs under a positive
+  // key — are returned unchanged.
+  _resolveKeyBySign(channelId, hasData) {
     const key = normalizeChannelKey(channelId);
-    if (!/^\d+$/.test(key) || this._channelKeyHasData(key)) {
+    if (!/^\d+$/.test(key) || hasData(key)) {
       return key;
     }
     for (const candidate of [String(toggleChannelIdMark(Number(key))), `-${key}`]) {
-      if (this._channelKeyHasData(candidate)) {
+      if (hasData(candidate)) {
         return candidate;
       }
     }
     return key;
   }
 
+  // Maps a chat reference to the archive key that actually holds its data;
+  // no stored keys are rewritten.
+  resolveArchiveChannelKey(channelId) {
+    return this._resolveKeyBySign(channelId, (key) => this._channelKeyHasData(key));
+  }
+
   // Same sign tolerance for job lookups (status/retry/cancel by chat): a job
   // enqueued under the canonical negative key is found from the positive id.
   _resolveJobChannelKey(channelId) {
-    const key = normalizeChannelKey(channelId);
-    const hasJob = (candidate) => Boolean(
-      this.db.prepare('SELECT 1 FROM jobs WHERE channel_id = ? LIMIT 1').get(candidate),
-    );
-    if (!/^\d+$/.test(key) || hasJob(key)) {
-      return key;
-    }
-    for (const candidate of [String(toggleChannelIdMark(Number(key))), `-${key}`]) {
-      if (hasJob(candidate)) {
-        return candidate;
-      }
-    }
-    return key;
+    return this._resolveKeyBySign(channelId, (key) => Boolean(
+      this.db.prepare('SELECT 1 FROM jobs WHERE channel_id = ? LIMIT 1').get(key),
+    ));
   }
 
   getChannelMetadata(channelId) {
@@ -1696,7 +1693,7 @@ export default class MessageSyncService {
 
     let rows;
     if (channelIds && channelIds.length) {
-      rows = channelIds.map((id) => this._getChannelWithMetadata(normalizeChannelKey(id))).filter(Boolean);
+      rows = channelIds.map((id) => this._getChannelWithMetadata(this.resolveArchiveChannelKey(id))).filter(Boolean);
     } else {
       rows = this.db.prepare(`
         SELECT
@@ -1773,7 +1770,7 @@ export default class MessageSyncService {
 
     let rows;
     if (channelIds && channelIds.length) {
-      rows = channelIds.map((id) => this._getChannelWithMetadata(normalizeChannelKey(id))).filter(Boolean);
+      rows = channelIds.map((id) => this._getChannelWithMetadata(this.resolveArchiveChannelKey(id))).filter(Boolean);
     } else {
       rows = this.db.prepare(`
         SELECT
@@ -2212,7 +2209,7 @@ export default class MessageSyncService {
   }
 
   searchMessages({ channelId, topicId, pattern, limit = 50, caseInsensitive = true }) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const flags = caseInsensitive ? 'i' : '';
     let regex;
     try {
@@ -2554,7 +2551,7 @@ export default class MessageSyncService {
   }
 
   getArchivedMessages({ channelId, topicId, limit = 50 }) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const topicClause = typeof topicId === 'number' ? 'AND topic_id = ?' : '';
     const params = typeof topicId === 'number'
       ? [normalizedId, topicId, limit]
@@ -2588,7 +2585,7 @@ export default class MessageSyncService {
   }
 
   getMessageStats(channelId) {
-    const normalizedId = normalizeChannelKey(channelId);
+    const normalizedId = this.resolveArchiveChannelKey(channelId);
     const summary = this.db.prepare(`
       SELECT
         COUNT(*) AS total,

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -1,5 +1,5 @@
 import { TelegramClient as MtCuteClient } from '@mtcute/node';
-import { InputMedia } from '@mtcute/core';
+import { InputMedia, MtPeerNotFoundError, getMarkedPeerId, toggleChannelIdMark } from '@mtcute/core';
 import { randomLong } from '@mtcute/core/utils.js';
 import { html } from '@mtcute/html-parser';
 import { md } from '@mtcute/markdown-parser';
@@ -469,6 +469,12 @@ function resolveDownloadLocation(media) {
   return null;
 }
 
+// Telegram usernames are ASCII word characters; anything else in a string chat
+// reference (spaces, Cyrillic, punctuation) is a display name, which is not an
+// identifier — reject it before any network call with a pointer to the lookup
+// command.
+const USERNAME_SHAPE_PATTERN = /^@?[A-Za-z0-9_]{1,32}$/;
+
 export function normalizeChannelId(channelId) {
   if (typeof channelId === 'number') {
     return channelId;
@@ -937,6 +943,82 @@ class TelegramClient {
     return results;
   }
 
+  // Resolves a chat reference (numeric id in either sign form, @username, or
+  // 'me'/'self') to `{ peer, canonicalId }`: the mtcute input peer plus the
+  // marked-id key the archive uses (`null` for inputPeerSelf, which has no
+  // marked id). Positive numeric ids that miss the cache are retried in their
+  // channel (-100...) form, then the basic-chat (-id) form, so users can
+  // address groups without knowing Telegram's sign conventions. Resolution
+  // failures rethrow the original error with an actionable hint appended.
+  async resolveInputPeer(channelId) {
+    const peerRef = normalizeChannelId(channelId);
+    if (
+      typeof peerRef === 'string'
+      && peerRef !== 'me'
+      && peerRef !== 'self'
+      && !USERNAME_SHAPE_PATTERN.test(peerRef)
+    ) {
+      throw new Error(
+        `"${peerRef}" looks like a display name, not a peer id. Use a numeric chat id or `
+        + `@username — find it with \`tgcli channels list --query "${peerRef}"\`.`,
+      );
+    }
+
+    let peer = null;
+    try {
+      peer = await this.client.resolvePeer(peerRef);
+    } catch (error) {
+      if (!(error instanceof MtPeerNotFoundError)) {
+        throw error;
+      }
+      if (typeof peerRef === 'number' && Number.isInteger(peerRef) && peerRef > 0) {
+        // The channel form is tried first because it is verifiable against the
+        // cache/server; the basic-chat form resolves structurally, so it would
+        // otherwise shadow supergroups.
+        for (const candidate of [toggleChannelIdMark(peerRef), -peerRef]) {
+          try {
+            peer = await this.client.resolvePeer(candidate);
+            break;
+          } catch (fallbackError) {
+            if (!(fallbackError instanceof MtPeerNotFoundError)) {
+              throw fallbackError;
+            }
+          }
+        }
+      }
+      if (!peer) {
+        error.message = `${error.message} — ${this._peerResolutionHint(peerRef)}`;
+        throw error;
+      }
+    }
+
+    // inputPeerSelf has no marked id; callers keep their raw key (e.g. 'me').
+    const canonicalId = peer?._ === 'inputPeerSelf' ? null : String(getMarkedPeerId(peer));
+    return { peer, canonicalId };
+  }
+
+  _peerResolutionHint(peerRef) {
+    if (typeof peerRef === 'number' && peerRef > 0) {
+      return `Group and channel ids are negative — try --chat="-${peerRef}"; list ids with \`tgcli channels list\``;
+    }
+    if (typeof peerRef === 'number') {
+      return 'open the chat once or run `tgcli channels list` to seed the local cache';
+    }
+    return 'if this is a chat title, use the numeric id — see `tgcli channels list --query`';
+  }
+
+  // Canonical archive key for a chat reference. Numeric ids collapse to the
+  // marked id the live-sync writer keys messages by; usernames and 'me'/'self'
+  // pass through unchanged so existing username keying is untouched.
+  async canonicalizeChannelId(channelId) {
+    const peerRef = normalizeChannelId(channelId);
+    if (typeof peerRef !== 'number') {
+      return String(peerRef);
+    }
+    const { canonicalId } = await this.resolveInputPeer(peerRef);
+    return canonicalId ?? String(peerRef);
+  }
+
   async getMessagesByChannelId(channelId, limit = 100, options = {}) {
     await this.ensureLogin();
 
@@ -948,8 +1030,7 @@ class TelegramClient {
       beforeId = 0,
       afterId = 0,
     } = options;
-    const peerRef = normalizeChannelId(channelId);
-    const peer = await this.client.resolvePeer(peerRef);
+    const { peer } = await this.resolveInputPeer(channelId);
 
     const effectiveLimit = limit && limit > 0 ? limit : 100;
     const effectiveBeforeId = normalizePositiveMessageId(beforeId)
@@ -1010,13 +1091,12 @@ class TelegramClient {
 
   async getMessageById(channelId, messageId) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    const [message] = await this.client.getMessages(peerRef, Number(messageId));
+    const { peer } = await this.resolveInputPeer(channelId);
+    const [message] = await this.client.getMessages(peer, Number(messageId));
     if (!message) {
       return null;
     }
-    const peer = message.chat ?? await this.client.resolvePeer(peerRef);
-    return this._serializeMessage(message, peer);
+    return this._serializeMessage(message, message.chat ?? peer);
   }
 
   async getMessageContext(channelId, messageId, options = {}) {
@@ -1029,8 +1109,8 @@ class TelegramClient {
       : 20;
     const total = safeBefore + safeAfter + 1;
 
-    const peerRef = normalizeChannelId(channelId);
-    const [message] = await this.client.getMessages(peerRef, Number(messageId));
+    const { peer: resolvedPeer } = await this.resolveInputPeer(channelId);
+    const [message] = await this.client.getMessages(resolvedPeer, Number(messageId));
     if (!message) {
       return { target: null, before: [], after: [] };
     }
@@ -1042,7 +1122,7 @@ class TelegramClient {
       dateSeconds = Math.floor(message.date);
     }
 
-    const history = await this.client.getHistory(peerRef, {
+    const history = await this.client.getHistory(resolvedPeer, {
       offset: {
         id: message.id,
         date: dateSeconds,
@@ -1051,7 +1131,7 @@ class TelegramClient {
       limit: total,
     });
 
-    const peer = message.chat ?? await this.client.resolvePeer(peerRef);
+    const peer = message.chat ?? resolvedPeer;
     const target = this._serializeMessage(message, peer);
     const before = [];
     const after = [];
@@ -1080,10 +1160,11 @@ class TelegramClient {
     const query = typeof options.query === 'string' ? options.query : '';
     const limit = options.limit && options.limit > 0 ? Number(options.limit) : 50;
     const threadId = typeof options.topicId === 'number' ? options.topicId : undefined;
-    const peerRef = normalizeChannelId(channelId);
-    const peer = await this.client.resolvePeer(peerRef);
+    // Pass the resolved peer object onward: searchMessages re-resolves its
+    // chatId internally, which would discard the sign-fallback work above.
+    const { peer } = await this.resolveInputPeer(channelId);
     const results = await this.client.searchMessages({
-      chatId: peerRef,
+      chatId: peer,
       threadId,
       limit,
       query,
@@ -1216,8 +1297,8 @@ class TelegramClient {
 
   async downloadMessageMedia(channelId, messageId, options = {}) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    const [message] = await this.client.getMessages(peerRef, Number(messageId));
+    const { peer } = await this.resolveInputPeer(channelId);
+    const [message] = await this.client.getMessages(peer, Number(messageId));
     if (!message) {
       throw new Error('Message not found.');
     }
@@ -1397,18 +1478,19 @@ class TelegramClient {
     if (!Number.isInteger(msgId) || msgId <= 0) {
       throw new Error('messageId must be a positive integer');
     }
-    const peerRef = normalizeChannelId(channelId);
-    const peer = await this.client.resolvePeer(peerRef);
+    const { peer } = await this.resolveInputPeer(channelId);
     await this.client.readHistory(peer, { maxId: msgId });
     return { channelId: peer?.id?.toString?.() ?? String(channelId), messageId: msgId };
   }
 
   async getPeerMetadata(channelId, peerType) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
+    // Resolve once up front and feed the peer object to every lookup below;
+    // each of them re-resolves a raw reference internally otherwise.
+    const { peer } = await this.resolveInputPeer(channelId);
 
     const buildUserMetadata = async () => {
-      const user = await this.client.getFullUser(peerRef);
+      const user = await this.client.getFullUser(peer);
       return {
         peerTitle: user.displayName || 'Unknown',
         username: user.username ?? null,
@@ -1429,7 +1511,7 @@ class TelegramClient {
     let chatType = null;
     let isForum = null;
     try {
-      const chat = await this.client.getChat(peerRef);
+      const chat = await this.client.getChat(peer);
       peerTitle = chat.displayName || chat.title || 'Unknown';
       username = chat.username ?? null;
       resolvedType = normalizePeerType(chat);
@@ -1441,7 +1523,7 @@ class TelegramClient {
 
     let about = null;
     try {
-      const fullChat = await this.client.getFullChat(peerRef);
+      const fullChat = await this.client.getFullChat(peer);
       about = fullChat.bio || null;
     } catch (error) {
       about = null;
@@ -1608,9 +1690,11 @@ class TelegramClient {
 
   async getTopicMessages(channelId, topicId, limit = 50, options = {}) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
+    // As in searchChannelMessages: hand searchMessages the resolved peer object
+    // so it does not re-resolve the raw reference internally.
+    const { peer } = await this.resolveInputPeer(channelId);
     const results = await this.client.searchMessages({
-      chatId: peerRef,
+      chatId: peer,
       threadId: topicId,
       limit,
       query: options.query ?? '',

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -1,5 +1,5 @@
 import { TelegramClient as MtCuteClient } from '@mtcute/node';
-import { InputMedia, MtPeerNotFoundError, getMarkedPeerId, toggleChannelIdMark } from '@mtcute/core';
+import { InputMedia, MtPeerNotFoundError, getMarkedPeerId, tl, toggleChannelIdMark } from '@mtcute/core';
 import { randomLong } from '@mtcute/core/utils.js';
 import { html } from '@mtcute/html-parser';
 import { md } from '@mtcute/markdown-parser';
@@ -470,10 +470,10 @@ function resolveDownloadLocation(media) {
   return null;
 }
 
-// Telegram usernames are ASCII word characters; anything else in a string chat
-// reference (spaces, Cyrillic, punctuation) is a display name, which is not an
-// identifier — reject it before any network call with guidance to look the id
-// up in the chat list.
+// Telegram usernames are ASCII word characters; any other string chat
+// reference (spaces, Cyrillic, punctuation, "+7..." phone numbers) is not
+// addressable here — reject it before any network call with guidance to look
+// the id up in the chat list.
 const USERNAME_SHAPE_PATTERN = /^@?[A-Za-z0-9_]{1,32}$/;
 
 export function normalizeChannelId(channelId) {
@@ -960,8 +960,8 @@ class TelegramClient {
       && !USERNAME_SHAPE_PATTERN.test(peerRef)
     ) {
       throw new Error(
-        `"${peerRef}" looks like a display name, not a peer id. Use a numeric chat id or `
-        + `@username — search the chat list for "${peerRef}" to find its id.`,
+        `"${peerRef}" is not a peer id (it looks like a display name or phone number). Use a `
+        + `numeric chat id or @username — search the chat list for "${peerRef}" to find its id.`,
       );
     }
 
@@ -973,12 +973,23 @@ class TelegramClient {
         throw error;
       }
       if (typeof peerRef === 'number' && Number.isInteger(peerRef) && peerRef > 0) {
-        // The channel form is tried first because it is verifiable against the
-        // cache/server; the basic-chat form resolves structurally, so it would
-        // otherwise shadow supergroups.
+        // The channel form is tried first because resolvePeer verifies it
+        // against the cache/server. The basic-chat form NEVER fails in mtcute —
+        // resolvePeer builds inputPeerChat structurally, without consulting
+        // cache or server — so it is only accepted after an existence probe;
+        // otherwise any positive id would "resolve" here and die downstream
+        // with a raw CHAT_ID_INVALID. A bare positive id cannot carry its peer
+        // type, so this fallback can in principle route an uncached user id to
+        // a group with the same bare id; that ambiguity is inherent to
+        // sign-tolerant addressing and accepted here, since cached user ids
+        // resolve directly above and never reach the fallback.
         for (const candidate of [toggleChannelIdMark(peerRef), -peerRef]) {
           try {
-            peer = await this.client.resolvePeer(candidate);
+            const resolved = await this.client.resolvePeer(candidate);
+            if (resolved?._ === 'inputPeerChat' && !(await this._basicChatExists(resolved))) {
+              continue;
+            }
+            peer = resolved;
             break;
           } catch (fallbackError) {
             if (!(fallbackError instanceof MtPeerNotFoundError)) {
@@ -996,6 +1007,32 @@ class TelegramClient {
     // inputPeerSelf has no marked id; callers keep their raw key (e.g. 'me').
     const canonicalId = peer?._ === 'inputPeerSelf' ? null : String(getMarkedPeerId(peer));
     return { peer, canonicalId };
+  }
+
+  // Existence probe for a structurally-resolved basic chat. mtcute's
+  // resolvePeer returns inputPeerChat for any basic-chat-form id without
+  // consulting cache or server, so the peer object alone proves nothing.
+  // The local peer storage answers without a network call for chats seen
+  // before; otherwise getChat asks the server (messages.getChats). A missing
+  // chat surfaces as MtPeerNotFoundError or as Telegram rejecting the id.
+  async _basicChatExists(peer) {
+    const cached = await this.client.storage.peers.getById(getMarkedPeerId(peer));
+    if (cached) {
+      return true;
+    }
+    try {
+      await this.client.getChat(peer);
+      return true;
+    } catch (error) {
+      if (
+        error instanceof MtPeerNotFoundError
+        || tl.RpcError.is(error, 'CHAT_ID_INVALID')
+        || tl.RpcError.is(error, 'PEER_ID_INVALID')
+      ) {
+        return false;
+      }
+      throw error;
+    }
   }
 
   // Hints stay frontend-neutral (this client backs the CLI, the MCP server,
@@ -1197,8 +1234,8 @@ class TelegramClient {
     const parseMode = normalizeParseMode(options.parseMode);
     const inputText = applyParseMode(messageText, parseMode);
     const params = buildTextSendParams(options);
-    const peerRef = normalizeChannelId(channelId);
-    const sent = await this.client.sendText(peerRef, inputText, params);
+    const { peer } = await this.resolveInputPeer(channelId);
+    const sent = await this.client.sendText(peer, inputText, params);
     return { messageId: sent.id };
   }
 
@@ -1220,8 +1257,8 @@ class TelegramClient {
     if (options.spoiler) mediaOptions.spoiler = true;
     if (options.forceDocument) mediaOptions.forceDocument = true;
     const media = InputMedia.auto(uploadPath, mediaOptions);
-    const peerRef = normalizeChannelId(channelId);
-    const sent = await this.client.sendMedia(peerRef, media, buildMediaSendParams(options));
+    const { peer } = await this.resolveInputPeer(channelId);
+    const sent = await this.client.sendMedia(peer, media, buildMediaSendParams(options));
     return buildSendMessageResult(sent, { method: 'sendDocument', defaultMediaType: 'document' });
   }
 
@@ -1264,7 +1301,7 @@ class TelegramClient {
   }
 
   async sendPreparedPhotoMessage(prepared) {
-    const peer = await this.client.resolvePeer(prepared.peerRef);
+    const { peer } = await this.resolveInputPeer(prepared.peerRef);
     const chatId = peer?._ === 'inputPeerSelf'
       ? String(prepared.peerRef)
       : this._extractPeerId(peer);
@@ -1278,7 +1315,7 @@ class TelegramClient {
     }
     let sent;
     try {
-      [sent] = await this.client.getMessages(prepared.peerRef, Number(messageId));
+      [sent] = await this.client.getMessages(peer, Number(messageId));
     } catch (error) {
       console.error(`[sendPhoto] getMessages enrichment failed for peer ${prepared.peerRef}, message ${messageId}: ${error.message}`);
     }
@@ -1390,9 +1427,9 @@ class TelegramClient {
 
   async getGroupInfo(channelId) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    const chat = await this.client.getChat(peerRef);
-    const full = await this.client.getFullChat(peerRef).catch(() => null);
+    const { peer } = await this.resolveInputPeer(channelId);
+    const chat = await this.client.getChat(peer);
+    const full = await this.client.getFullChat(peer).catch(() => null);
     return {
       id: chat.id?.toString?.() ?? String(channelId),
       title: chat.displayName || chat.title || 'Unknown',
@@ -1413,8 +1450,8 @@ class TelegramClient {
     if (!value) {
       throw new Error('Group title must be a non-empty string.');
     }
-    const peerRef = normalizeChannelId(channelId);
-    await this.client.setChatTitle(peerRef, value);
+    const { peer } = await this.resolveInputPeer(channelId);
+    await this.client.setChatTitle(peer, value);
     return true;
   }
 
@@ -1424,8 +1461,8 @@ class TelegramClient {
     if (!users.length) {
       throw new Error('userIds must include at least one entry.');
     }
-    const peerRef = normalizeChannelId(channelId);
-    const failed = await this.client.addChatMembers(peerRef, users);
+    const { peer } = await this.resolveInputPeer(channelId);
+    const failed = await this.client.addChatMembers(peer, users);
     return failed.map((entry) => ({
       userId: entry.userId?.toString?.() ?? null,
       error: entry.error ?? null,
@@ -1438,12 +1475,12 @@ class TelegramClient {
     if (!users.length) {
       throw new Error('userIds must include at least one entry.');
     }
-    const peerRef = normalizeChannelId(channelId);
+    const { peer } = await this.resolveInputPeer(channelId);
     const removed = [];
     const failed = [];
     for (const userId of users) {
       try {
-        await this.client.kickChatMember({ chatId: peerRef, userId });
+        await this.client.kickChatMember({ chatId: peer, userId });
         removed.push(String(userId));
       } catch (error) {
         failed.push({ userId: String(userId), error: error?.message ?? String(error) });
@@ -1454,14 +1491,14 @@ class TelegramClient {
 
   async getGroupInviteLink(channelId) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    return this.client.getPrimaryInviteLink(peerRef);
+    const { peer } = await this.resolveInputPeer(channelId);
+    return this.client.getPrimaryInviteLink(peer);
   }
 
   async revokeGroupInviteLink(channelId, link) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    return this.client.revokeInviteLink(peerRef, link);
+    const { peer } = await this.resolveInputPeer(channelId);
+    return this.client.revokeInviteLink(peer, link);
   }
 
   async joinGroup(invite) {
@@ -1471,8 +1508,8 @@ class TelegramClient {
 
   async leaveGroup(channelId) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    await this.client.leaveChat(peerRef);
+    const { peer } = await this.resolveInputPeer(channelId);
+    await this.client.leaveChat(peer);
     return true;
   }
 
@@ -1688,8 +1725,8 @@ class TelegramClient {
 
   async listForumTopics(channelId, options = {}) {
     await this.ensureLogin();
-    const peerRef = normalizeChannelId(channelId);
-    return this.client.getForumTopics(peerRef, options);
+    const { peer } = await this.resolveInputPeer(channelId);
+    return this.client.getForumTopics(peer, options);
   }
 
   async getTopicMessages(channelId, topicId, limit = 50, options = {}) {

--- a/telegram-client.js
+++ b/telegram-client.js
@@ -14,6 +14,7 @@ import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import { nodeReadableToFuman } from '@fuman/node';
 import { resolveStoreDir, resolveStorePaths } from './core/store.js';
+import { peerSignRetryHint } from './core/peer-hints.js';
 
 const timeoutPatchKey = Symbol.for('tgcli.timeoutPatch');
 if (!globalThis[timeoutPatchKey]) {
@@ -471,8 +472,8 @@ function resolveDownloadLocation(media) {
 
 // Telegram usernames are ASCII word characters; anything else in a string chat
 // reference (spaces, Cyrillic, punctuation) is a display name, which is not an
-// identifier — reject it before any network call with a pointer to the lookup
-// command.
+// identifier — reject it before any network call with guidance to look the id
+// up in the chat list.
 const USERNAME_SHAPE_PATTERN = /^@?[A-Za-z0-9_]{1,32}$/;
 
 export function normalizeChannelId(channelId) {
@@ -960,7 +961,7 @@ class TelegramClient {
     ) {
       throw new Error(
         `"${peerRef}" looks like a display name, not a peer id. Use a numeric chat id or `
-        + `@username — find it with \`tgcli channels list --query "${peerRef}"\`.`,
+        + `@username — search the chat list for "${peerRef}" to find its id.`,
       );
     }
 
@@ -997,14 +998,17 @@ class TelegramClient {
     return { peer, canonicalId };
   }
 
+  // Hints stay frontend-neutral (this client backs the CLI, the MCP server,
+  // and the control API); the sign-retry phrasing comes from the shared
+  // peer-hints vocabulary so frontends can recognize and restate it.
   _peerResolutionHint(peerRef) {
     if (typeof peerRef === 'number' && peerRef > 0) {
-      return `Group and channel ids are negative — try --chat="-${peerRef}"; list ids with \`tgcli channels list\``;
+      return peerSignRetryHint(peerRef);
     }
     if (typeof peerRef === 'number') {
-      return 'open the chat once or run `tgcli channels list` to seed the local cache';
+      return 'open the chat once or list the chats to seed the local cache';
     }
-    return 'if this is a chat title, use the numeric id — see `tgcli channels list --query`';
+    return 'if this is a chat title, search the chat list for the numeric id';
   }
 
   // Canonical archive key for a chat reference. Numeric ids collapse to the

--- a/tests/auth-recovery.test.js
+++ b/tests/auth-recovery.test.js
@@ -1,7 +1,10 @@
 vi.mock('@mtcute/node', () => ({
   TelegramClient: vi.fn(),
 }));
-vi.mock('@mtcute/core', () => ({
+// Spread the real module so the peer-resolution imports (MtPeerNotFoundError,
+// toggleChannelIdMark, getMarkedPeerId) stay real; only InputMedia is stubbed.
+vi.mock('@mtcute/core', async (importOriginal) => ({
+  ...(await importOriginal()),
   InputMedia: {
     auto: vi.fn(),
   },

--- a/tests/cli-peer-hints.test.js
+++ b/tests/cli-peer-hints.test.js
@@ -1,0 +1,64 @@
+// The negative-chat-id parser hint: a bare `-100...` value parses as a flag and
+// trips commander's unknown-option error, which must carry the exact quoting
+// workaround. The hook is installed once on the root program and shared with
+// every subcommand by reference (commander's copyInheritedSettings).
+
+import { describe, expect, it } from 'vitest';
+
+import { buildProgram } from '../cli.js';
+
+const NEGATIVE_ID = '-4701666782';
+
+// exitOverride must be applied to every command: subcommands copy the exit
+// callback at creation time, so setting it on the root after buildProgram()
+// would not reach them.
+function applyExitOverride(command) {
+  command.exitOverride();
+  for (const sub of command.commands) {
+    applyExitOverride(sub);
+  }
+}
+
+function parseCapturingErrors(args) {
+  const program = buildProgram();
+  applyExitOverride(program);
+  let output = '';
+  program.configureOutput({
+    writeErr: (str) => {
+      output += str;
+    },
+  });
+  let thrown = null;
+  try {
+    program.parse(args, { from: 'user' });
+  } catch (error) {
+    thrown = error;
+  }
+  return { output, thrown };
+}
+
+describe('negative chat id parser hint', () => {
+  it('appends the quoting workaround when a bare negative id parses as a flag', () => {
+    const { output, thrown } = parseCapturingErrors(['messages', 'list', NEGATIVE_ID]);
+
+    expect(thrown?.code).toBe('commander.unknownOption');
+    expect(output).toContain(`error: unknown option '${NEGATIVE_ID}'`);
+    expect(output).toContain(`--chat="${NEGATIVE_ID}"`);
+    expect(output).toContain(`--chat=${NEGATIVE_ID}`);
+  });
+
+  it('leaves non-numeric unknown-option errors without the hint', () => {
+    const { output, thrown } = parseCapturingErrors(['messages', 'list', '--definitely-not-an-option']);
+
+    expect(thrown?.code).toBe('commander.unknownOption');
+    expect(output).toContain("error: unknown option '--definitely-not-an-option'");
+    expect(output).not.toContain('Negative chat ids');
+  });
+
+  it('fires on nested subcommands via the shared output configuration', () => {
+    const { output, thrown } = parseCapturingErrors(['backfill', 'jobs', 'add', NEGATIVE_ID]);
+
+    expect(thrown?.code).toBe('commander.unknownOption');
+    expect(output).toContain(`--chat="${NEGATIVE_ID}"`);
+  });
+});

--- a/tests/cli-peer-hints.test.js
+++ b/tests/cli-peer-hints.test.js
@@ -1,11 +1,14 @@
-// The negative-chat-id parser hint: a bare `-100...` value parses as a flag and
-// trips commander's unknown-option error, which must carry the exact quoting
-// workaround. The hook is installed once on the root program and shared with
-// every subcommand by reference (commander's copyInheritedSettings).
+// CLI-boundary hints for negative chat ids: the parser hook appends the exact
+// quoting workaround when a bare `-100...` value trips commander's
+// unknown-option error (the hook is installed once on the root program and
+// shared with every subcommand by reference, via commander's
+// copyInheritedSettings), and writeError restates the client layer's neutral
+// sign-retry suggestion in --chat flag syntax.
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { buildProgram } from '../cli.js';
+import { buildProgram, writeError } from '../cli.js';
+import { PEER_SIGN_RETRY_PATTERN } from '../core/peer-hints.js';
 
 const NEGATIVE_ID = '-4701666782';
 
@@ -60,5 +63,49 @@ describe('negative chat id parser hint', () => {
 
     expect(thrown?.code).toBe('commander.unknownOption');
     expect(output).toContain(`--chat="${NEGATIVE_ID}"`);
+  });
+});
+
+describe('peer resolution sign-retry hint at the writeError boundary', () => {
+  function captureStderr(fn) {
+    const writes = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((str) => {
+      writes.push(String(str));
+      return true;
+    });
+    try {
+      fn();
+    } finally {
+      spy.mockRestore();
+    }
+    return writes.join('');
+  }
+
+  it('restates the client layer\'s neutral suggestion in --chat flag syntax', () => {
+    const error = new Error(
+      'Peer 4701666782 is not found in local cache — group and channel ids are '
+      + `negative — retry with the negative id "${NEGATIVE_ID}"`,
+    );
+
+    const output = captureStderr(() => writeError(error, false));
+
+    expect(PEER_SIGN_RETRY_PATTERN.test(error.message)).toBe(true);
+    expect(output).toContain(error.message);
+    expect(output).toContain(`--chat="${NEGATIVE_ID}"`);
+    expect(output).toContain(`--chat=${NEGATIVE_ID}`);
+  });
+
+  it('leaves unrelated errors without the flag hint', () => {
+    const output = captureStderr(() => writeError(new Error('connection lost'), false));
+
+    expect(output).toBe('connection lost\n');
+  });
+
+  it('keeps JSON error output machine-readable, without the appended hint', () => {
+    const error = new Error(`retry with the negative id "${NEGATIVE_ID}"`);
+
+    const output = captureStderr(() => writeError(error, true));
+
+    expect(JSON.parse(output)).toEqual({ ok: false, error: error.message });
   });
 });

--- a/tests/cli-peer-hints.test.js
+++ b/tests/cli-peer-hints.test.js
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { buildProgram, writeError } from '../cli.js';
 import { PEER_SIGN_RETRY_PATTERN } from '../core/peer-hints.js';
+import { SendCommandError } from '../core/send-utils.js';
 
 const NEGATIVE_ID = '-4701666782';
 
@@ -99,6 +100,23 @@ describe('peer resolution sign-retry hint at the writeError boundary', () => {
     const output = captureStderr(() => writeError(new Error('connection lost'), false));
 
     expect(output).toBe('connection lost\n');
+  });
+
+  it('restates the suggestion for send failures that carry it in details', () => {
+    const error = new SendCommandError({
+      type: 'telegram',
+      method: 'sendText',
+      message: 'Peer 4701666782 is not found in local cache — group and channel ids are '
+        + `negative — retry with the negative id "${NEGATIVE_ID}"`,
+      attempt: 1,
+      retries: 0,
+      retryable: false,
+    });
+
+    const output = captureStderr(() => writeError(error, false));
+
+    expect(output).toContain('sendText failed [telegram]');
+    expect(output).toContain(`--chat="${NEGATIVE_ID}"`);
   });
 
   it('keeps JSON error output machine-readable, without the appended hint', () => {

--- a/tests/control-server.test.js
+++ b/tests/control-server.test.js
@@ -67,6 +67,12 @@ describe('control API request handler', () => {
     onActivity = vi.fn();
     const handler = createControlRequestHandler({
       service,
+      // Backfill canonicalizes through the warm client; identity keeps these
+      // routing tests focused on the endpoint contract.
+      warmServices: {
+        telegramClient: { canonicalizeChannelId: vi.fn(async (chatId) => String(chatId)) },
+        messageSyncService: service,
+      },
       token: TOKEN,
       pid: 12345,
       version: '9.9.9',

--- a/tests/control-server.test.js
+++ b/tests/control-server.test.js
@@ -229,6 +229,7 @@ describe('POST /control/invoke', () => {
         listDialogs: vi.fn(() => Promise.resolve([{ id: '1', title: 'Warm' }])),
         searchDialogs: vi.fn(() => Promise.resolve([])),
         getGroupInviteLink: vi.fn(() => Promise.resolve({ link: 'https://t.me/+warm' })),
+        canonicalizeChannelId: vi.fn(async (id) => String(id)),
       },
       messageSyncService: {
         setChannelSync: vi.fn(() => ({ channel_id: '@g', sync_enabled: 1 })),

--- a/tests/media-download.test.js
+++ b/tests/media-download.test.js
@@ -10,7 +10,10 @@ vi.mock('@mtcute/node', () => ({
   TelegramClient: mtcuteClientCtor,
 }));
 
-vi.mock('@mtcute/core', () => ({
+// Spread the real module so the peer-resolution imports (MtPeerNotFoundError,
+// toggleChannelIdMark, getMarkedPeerId) stay real; only InputMedia is stubbed.
+vi.mock('@mtcute/core', async (importOriginal) => ({
+  ...(await importOriginal()),
   InputMedia: {},
 }));
 
@@ -46,6 +49,7 @@ function createClient({ message, downloadAsNodeStream }) {
   const client = new TelegramClient(12345, 'hash', '+1234567890', '/tmp/tgcli-media-download.session');
   client.ensureLogin = async () => {};
   client.client = {
+    resolvePeer: vi.fn().mockResolvedValue({ _: 'inputPeerUser', userId: 123, accessHash: 0 }),
     getMessages: vi.fn().mockResolvedValue([message]),
     downloadAsNodeStream,
   };

--- a/tests/operations-seam.test.js
+++ b/tests/operations-seam.test.js
@@ -44,6 +44,7 @@ beforeEach(() => {
     searchDialogs: vi.fn().mockResolvedValue([{ id: '2', title: 'WarmSearch' }]),
     getGroupInviteLink: vi.fn().mockResolvedValue({ link: 'https://t.me/+warm' }),
     markChannelRead: vi.fn().mockResolvedValue({ channelId: '1', messageId: 9 }),
+    canonicalizeChannelId: vi.fn(async (id) => String(id)),
   };
   hooks.messageSyncService = {
     setChannelSync: vi.fn(() => ({ channel_id: '1', sync_enabled: 1 })),

--- a/tests/peer-addressing-ops.test.js
+++ b/tests/peer-addressing-ops.test.js
@@ -1,0 +1,255 @@
+// End-to-end coverage of positive-id addressing through the real operation
+// registry (core/operations.js): each op runs against a real TelegramClient
+// instance whose fake mtcute inner client only resolves the canonical negative
+// form, mirroring how a plain group chat behaves when addressed by its bare
+// positive id.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MtPeerNotFoundError, toggleChannelIdMark } from '@mtcute/core';
+
+import TelegramClient from '../telegram-client.js';
+import { OPERATIONS } from '../core/operations.js';
+
+const GROUP_ID = '4701666782';
+const CANONICAL_ID = `-${GROUP_ID}`;
+const INPUT_PEER_CHAT = { _: 'inputPeerChat', chatId: Number(GROUP_ID) };
+
+function groupResolvePeer() {
+  return vi.fn(async (ref) => {
+    if (ref === -Number(GROUP_ID)) {
+      return INPUT_PEER_CHAT;
+    }
+    throw new MtPeerNotFoundError(`Peer ${ref} is not found in local cache`);
+  });
+}
+
+function searchResults(messages) {
+  const results = [...messages];
+  results.total = messages.length;
+  results.next = null;
+  return results;
+}
+
+// Real TelegramClient methods over a fake mtcute inner client.
+function makeTelegramClient(inner = {}) {
+  const tc = Object.create(TelegramClient.prototype);
+  tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
+  tc.client = { resolvePeer: groupResolvePeer(), ...inner };
+  return tc;
+}
+
+// Archive stub: metadata is cached so live ops never need a metadata roundtrip
+// unless a test overrides it.
+function makeSyncService(overrides = {}) {
+  return {
+    getChannelMetadata: vi.fn(() => ({ peerTitle: 'Group', username: 'grp' })),
+    getChannel: vi.fn(() => null),
+    listArchivedMessages: vi.fn(() => []),
+    searchArchiveMessages: vi.fn(() => []),
+    getArchivedMessage: vi.fn(() => null),
+    getArchivedMessageContext: vi.fn(() => ({ target: null, before: [], after: [] })),
+    listTaggedChannels: vi.fn(() => []),
+    resolveArchiveChannelKey: vi.fn((id) => String(id)),
+    setChannelSync: vi.fn((id) => ({ channel_id: String(id), sync_enabled: 1 })),
+    listJobs: vi.fn(() => []),
+    addJob: vi.fn((id) => ({ id: 7, channel_id: String(id), status: 'pending' })),
+    processQueue: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('positive-id addressing through the operation registry', () => {
+  it('messagesSearch source=live returns live messages for a positive group id', async () => {
+    const searchMessages = vi.fn().mockResolvedValue(
+      searchResults([{ id: 10, date: 1700000000, text: 'x marks the spot' }]),
+    );
+    const ctx = {
+      telegramClient: makeTelegramClient({ searchMessages }),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.messagesSearch(ctx, {
+      channelId: GROUP_ID,
+      source: 'live',
+      query: 'x',
+    });
+
+    expect(searchMessages.mock.calls[0][0].chatId).toBe(INPUT_PEER_CHAT);
+    expect(result.source).toBe('live');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe('x marks the spot');
+  });
+
+  it('messagesSearch source=archive falls back to live when the archive is empty', async () => {
+    const searchMessages = vi.fn().mockResolvedValue(
+      searchResults([{ id: 11, date: 1700000000, text: 'fallback hit' }]),
+    );
+    const ctx = {
+      telegramClient: makeTelegramClient({ searchMessages }),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.messagesSearch(ctx, {
+      channelId: GROUP_ID,
+      source: 'archive',
+      query: 'fallback',
+    });
+
+    expect(ctx.messageSyncService.searchArchiveMessages).toHaveBeenCalledTimes(1);
+    expect(result.usedLiveFallback).toBe(true);
+    expect(result.source).toBe('live');
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('messagesList source=live works with a positive group id', async () => {
+    const iterHistory = vi.fn(() => (async function* () {
+      yield { id: 5, date: 1700000000, text: 'listed' };
+    })());
+    const ctx = {
+      telegramClient: makeTelegramClient({ iterHistory }),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.messagesList(ctx, { channelId: GROUP_ID, source: 'live' });
+
+    expect(iterHistory.mock.calls[0][0]).toBe(INPUT_PEER_CHAT);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('messagesGet source=live works with a positive group id', async () => {
+    const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, text: 'one' }]);
+    const ctx = {
+      telegramClient: makeTelegramClient({ getMessages }),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.messagesGet(ctx, {
+      channelId: GROUP_ID,
+      messageId: 5,
+      source: 'live',
+    });
+
+    expect(getMessages).toHaveBeenCalledWith(INPUT_PEER_CHAT, 5);
+    expect(result.message.messageId ?? result.message.id).toBeDefined();
+  });
+
+  it('messagesContext source=live works with a positive group id', async () => {
+    const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, text: 'target' }]);
+    const getHistory = vi.fn().mockResolvedValue([
+      { id: 4, date: 1699999999, text: 'before' },
+      { id: 5, date: 1700000000, text: 'target' },
+    ]);
+    const ctx = {
+      telegramClient: makeTelegramClient({ getMessages, getHistory }),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.messagesContext(ctx, {
+      channelId: GROUP_ID,
+      messageId: 5,
+      source: 'live',
+    });
+
+    expect(getHistory.mock.calls[0][0]).toBe(INPUT_PEER_CHAT);
+    expect(result.target).toBeTruthy();
+  });
+
+  it('mediaDownload works with a positive group id', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-peer-ops-'));
+    try {
+      const message = {
+        id: 5,
+        media: {
+          type: 'document',
+          mimeType: 'application/pdf',
+          fileName: 'doc.pdf',
+          location: { _: 'inputDocumentFileLocation' },
+        },
+      };
+      const ctx = {
+        telegramClient: makeTelegramClient({
+          getMessages: vi.fn().mockResolvedValue([message]),
+          downloadAsNodeStream: vi.fn(() => Readable.from([new Uint8Array([1, 2, 3])])),
+        }),
+        messageSyncService: makeSyncService(),
+      };
+
+      const result = await OPERATIONS.mediaDownload(ctx, {
+        channelId: GROUP_ID,
+        messageId: 5,
+        outputPath: path.join(tmpDir, 'doc.pdf'),
+      });
+
+      expect(ctx.telegramClient.client.getMessages).toHaveBeenCalledWith(INPUT_PEER_CHAT, 5);
+      expect(result.bytes).toBe(3);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('channelShow falls back to live metadata with a positive group id', async () => {
+    const getChat = vi.fn().mockResolvedValue({ displayName: 'Group', chatType: 'group' });
+    const getFullChat = vi.fn().mockResolvedValue({ bio: 'about' });
+    const ctx = {
+      telegramClient: makeTelegramClient({ getChat, getFullChat }),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.channelShow(ctx, { chat: GROUP_ID });
+
+    expect(getChat).toHaveBeenCalledWith(INPUT_PEER_CHAT);
+    expect(result.peerTitle).toBe('Group');
+    expect(result.source).toBe('live');
+  });
+
+  it('metadataGet falls back to live metadata with a positive group id', async () => {
+    const getChat = vi.fn().mockResolvedValue({ displayName: 'Group', chatType: 'group' });
+    const getFullChat = vi.fn().mockResolvedValue({ bio: 'about' });
+    const ctx = {
+      telegramClient: makeTelegramClient({ getChat, getFullChat }),
+      messageSyncService: makeSyncService({ getChannelMetadata: vi.fn(() => null) }),
+    };
+
+    const result = await OPERATIONS.metadataGet(ctx, { chat: GROUP_ID });
+
+    expect(result.peerTitle).toBe('Group');
+    expect(result.source).toBe('live');
+  });
+
+  it('channelSetSync enable canonicalizes the chat key for every service call', async () => {
+    const ctx = {
+      telegramClient: makeTelegramClient(),
+      messageSyncService: makeSyncService(),
+    };
+
+    const result = await OPERATIONS.channelSetSync(ctx, { chat: GROUP_ID, enable: true });
+
+    expect(ctx.messageSyncService.setChannelSync).toHaveBeenCalledWith(CANONICAL_ID, true);
+    expect(ctx.messageSyncService.listJobs).toHaveBeenCalledWith({ channelId: CANONICAL_ID, limit: 1 });
+    expect(ctx.messageSyncService.addJob).toHaveBeenCalledWith(CANONICAL_ID);
+    expect(result.channelId).toBe(CANONICAL_ID);
+    expect(result.jobQueued).toBe(true);
+  });
+
+  it('channelSetSync disable uses archive-key disambiguation, never live resolution', async () => {
+    const ctx = {
+      telegramClient: makeTelegramClient(),
+      messageSyncService: makeSyncService({
+        resolveArchiveChannelKey: vi.fn(() => CANONICAL_ID),
+        setChannelSync: vi.fn((id, enabled) => ({ channel_id: String(id), sync_enabled: enabled ? 1 : 0 })),
+      }),
+    };
+
+    const result = await OPERATIONS.channelSetSync(ctx, { chat: GROUP_ID, enable: false });
+
+    expect(ctx.messageSyncService.resolveArchiveChannelKey).toHaveBeenCalledWith(GROUP_ID);
+    expect(ctx.messageSyncService.setChannelSync).toHaveBeenCalledWith(CANONICAL_ID, false);
+    expect(ctx.telegramClient.client.resolvePeer).not.toHaveBeenCalled();
+    expect(ctx.messageSyncService.addJob).not.toHaveBeenCalled();
+    expect(result.syncEnabled).toBe(false);
+  });
+});

--- a/tests/peer-addressing-ops.test.js
+++ b/tests/peer-addressing-ops.test.js
@@ -27,6 +27,16 @@ function groupResolvePeer() {
   });
 }
 
+// Peer storage holding the basic chat (as after a dialog sync), so the
+// existence probe for the structurally-resolved chat form passes locally.
+function cachedChatStorage() {
+  return {
+    peers: {
+      getById: vi.fn(async (id) => (id === -Number(GROUP_ID) ? INPUT_PEER_CHAT : null)),
+    },
+  };
+}
+
 function searchResults(messages) {
   const results = [...messages];
   results.total = messages.length;
@@ -38,7 +48,7 @@ function searchResults(messages) {
 function makeTelegramClient(inner = {}) {
   const tc = Object.create(TelegramClient.prototype);
   tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
-  tc.client = { resolvePeer: groupResolvePeer(), ...inner };
+  tc.client = { resolvePeer: groupResolvePeer(), storage: cachedChatStorage(), ...inner };
   return tc;
 }
 

--- a/tests/peer-canonicalization.test.js
+++ b/tests/peer-canonicalization.test.js
@@ -154,8 +154,8 @@ describe('peer canonicalization', () => {
       makeService();
       const canonicalizeChannelId = vi.fn(async () => {
         throw new Error(
-          `Peer ${GROUP_ID} is not found in local cache — Group and channel ids are negative — `
-          + `try --chat="-${GROUP_ID}"; list ids with \`tgcli channels list\``,
+          `Peer ${GROUP_ID} is not found in local cache — group and channel ids are negative — `
+          + `retry with the negative id "-${GROUP_ID}"`,
         );
       });
       const addJobSpy = vi.spyOn(service, 'addJob');
@@ -176,7 +176,7 @@ describe('peer canonicalization', () => {
         });
 
         expect(status).toBe(500);
-        expect(json.error).toContain(`--chat="-${GROUP_ID}"`);
+        expect(json.error).toContain(`retry with the negative id "-${GROUP_ID}"`);
         expect(addJobSpy).not.toHaveBeenCalled();
 
         const channelRows = service.db.prepare(
@@ -287,6 +287,38 @@ describe('peer canonicalization', () => {
       expect(service.getChannel(String(bareId))?.channelId).toBe(markedKey);
       expect(service.getArchivedMessage({ channelId: String(bareId), messageId: 12 })?.channelId)
         .toBe(markedKey);
+    });
+  });
+
+  describe('sign tolerance across the remaining archive entry points', () => {
+    it('stats, plain reads, and regex search find negative-keyed data from the positive id', () => {
+      makeService();
+      seedChannel(service, CANONICAL_ID);
+      seedMessage(service, CANONICAL_ID, { id: 100, date: 1700000100, text: 'hello world' });
+
+      expect(service.getMessageStats(GROUP_ID).total).toBe(1);
+      expect(service.getArchivedMessages({ channelId: GROUP_ID })).toHaveLength(1);
+
+      const matches = service.searchMessages({ channelId: GROUP_ID, pattern: 'hello' });
+      expect(matches).toHaveLength(1);
+      expect(matches[0].messageId).toBe(100);
+    });
+
+    it('tags and topics written via the positive id attach to the negative key', () => {
+      makeService();
+      seedChannel(service, CANONICAL_ID);
+      seedMessage(service, CANONICAL_ID, { id: 100, date: 1700000100, text: 'data' });
+
+      service.setChannelTags(GROUP_ID, ['work']);
+      const tagKeys = service.db.prepare('SELECT DISTINCT channel_id FROM channel_tags').all()
+        .map((row) => row.channel_id);
+      expect(tagKeys).toEqual([CANONICAL_ID]);
+      expect(service.listChannelTags(GROUP_ID).map((entry) => entry.tag)).toEqual(['work']);
+
+      service.upsertTopics(GROUP_ID, [{ id: 7, title: 'General' }]);
+      const topicKeys = service.db.prepare('SELECT DISTINCT channel_id FROM topics').all()
+        .map((row) => row.channel_id);
+      expect(topicKeys).toEqual([CANONICAL_ID]);
     });
   });
 

--- a/tests/peer-canonicalization.test.js
+++ b/tests/peer-canonicalization.test.js
@@ -1,0 +1,311 @@
+// Regression coverage for archive-key canonicalization: enqueue-time
+// canonicalization on /control/backfill, single-key convergence of live-written
+// and backfilled rows, and sign-tolerant read/job lookups — all against a real
+// MessageSyncService on a real sqlite store.
+
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toggleChannelIdMark } from '@mtcute/core';
+
+import MessageSyncService from '../message-sync-service.js';
+import {
+  createControlRequestHandler,
+  CONTROL_TOKEN_HEADER,
+} from '../core/control-server.js';
+
+const TOKEN = 'test-token-abc123';
+const GROUP_ID = '4701666782';
+const CANONICAL_ID = `-${GROUP_ID}`;
+
+function makeFakeTelegramClient(batches = []) {
+  let call = 0;
+  return {
+    client: {
+      resolvePeer: async () => ({ id: Number(CANONICAL_ID) }),
+      iterHistory() {
+        const batch = batches[call] ?? [];
+        call += 1;
+        return (async function* () {
+          for (const message of batch) {
+            yield message;
+          }
+        })();
+      },
+    },
+    _serializeMessage(message) {
+      return {
+        id: message.id,
+        date: message.date,
+        from_id: message.from_id ?? null,
+        text: message.text ?? `msg ${message.id}`,
+      };
+    },
+  };
+}
+
+function seedChannel(service, channelId, { peerTitle = 'Group', peerType = 'chat', lastMessageId = null } = {}) {
+  service.db.prepare(`
+    INSERT INTO channels (channel_id, peer_title, peer_type, sync_enabled, last_message_id, updated_at)
+    VALUES (?, ?, ?, 1, ?, CURRENT_TIMESTAMP)
+  `).run(channelId, peerTitle, peerType, lastMessageId);
+}
+
+function seedMessage(service, channelId, { id, date, text }) {
+  service.insertMessagesTx([
+    service._buildMessageRecord(channelId, { id, date, text }),
+  ]);
+}
+
+function startServer(handler) {
+  const server = http.createServer((req, res) => {
+    void handler(req, res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, port });
+    });
+  });
+}
+
+async function request(port, method, pathname, { token, body } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token !== undefined) {
+    headers[CONTROL_TOKEN_HEADER] = token;
+  }
+  const res = await fetch(`http://127.0.0.1:${port}${pathname}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  let json = null;
+  try {
+    json = await res.json();
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json };
+}
+
+describe('peer canonicalization', () => {
+  let storeDir;
+  let service;
+
+  beforeEach(() => {
+    storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tgcli-canon-test-'));
+  });
+
+  afterEach(() => {
+    if (service?.db?.open) {
+      service.db.close();
+    }
+    fs.rmSync(storeDir, { recursive: true, force: true });
+  });
+
+  function makeService(batches = []) {
+    service = new MessageSyncService(makeFakeTelegramClient(batches), {
+      dbPath: path.join(storeDir, 'messages.db'),
+      batchSize: 5,
+      interJobDelayMs: 0,
+      interBatchDelayMs: 0,
+    });
+    // The control handler kicks the queue after enqueue; keep the worker out
+    // of these tests.
+    service.processQueue = vi.fn();
+    return service;
+  }
+
+  describe('POST /control/backfill enqueue-time canonicalization', () => {
+    it('enqueues under the canonical key returned by canonicalizeChannelId', async () => {
+      makeService();
+      const canonicalizeChannelId = vi.fn(async () => CANONICAL_ID);
+      const handler = createControlRequestHandler({
+        service,
+        warmServices: { telegramClient: { canonicalizeChannelId }, messageSyncService: service },
+        token: TOKEN,
+        pid: 1,
+        version: '1',
+        startedAt: 's',
+        ensureLogin: vi.fn(() => Promise.resolve()),
+      });
+      const { server, port } = await startServer(handler);
+      try {
+        const { status, json } = await request(port, 'POST', '/control/backfill', {
+          token: TOKEN,
+          body: { chatId: GROUP_ID, depth: 50 },
+        });
+
+        expect(status).toBe(200);
+        expect(canonicalizeChannelId).toHaveBeenCalledWith(GROUP_ID);
+        expect(json.channelId).toBe(CANONICAL_ID);
+
+        const jobKeys = service.db.prepare('SELECT DISTINCT channel_id FROM jobs').all()
+          .map((row) => row.channel_id);
+        expect(jobKeys).toEqual([CANONICAL_ID]);
+      } finally {
+        server.close();
+      }
+    });
+
+    it('fails the enqueue with the resolution hint and persists nothing when canonicalization rejects', async () => {
+      makeService();
+      const canonicalizeChannelId = vi.fn(async () => {
+        throw new Error(
+          `Peer ${GROUP_ID} is not found in local cache — Group and channel ids are negative — `
+          + `try --chat="-${GROUP_ID}"; list ids with \`tgcli channels list\``,
+        );
+      });
+      const addJobSpy = vi.spyOn(service, 'addJob');
+      const handler = createControlRequestHandler({
+        service,
+        warmServices: { telegramClient: { canonicalizeChannelId }, messageSyncService: service },
+        token: TOKEN,
+        pid: 1,
+        version: '1',
+        startedAt: 's',
+        ensureLogin: vi.fn(() => Promise.resolve()),
+      });
+      const { server, port } = await startServer(handler);
+      try {
+        const { status, json } = await request(port, 'POST', '/control/backfill', {
+          token: TOKEN,
+          body: { chatId: GROUP_ID },
+        });
+
+        expect(status).toBe(500);
+        expect(json.error).toContain(`--chat="-${GROUP_ID}"`);
+        expect(addJobSpy).not.toHaveBeenCalled();
+
+        const channelRows = service.db.prepare(
+          "SELECT COUNT(*) AS cnt FROM channels WHERE channel_id LIKE ?",
+        ).get(`%${GROUP_ID}`);
+        expect(channelRows.cnt).toBe(0);
+        const jobRows = service.db.prepare('SELECT COUNT(*) AS cnt FROM jobs').get();
+        expect(jobRows.cnt).toBe(0);
+      } finally {
+        server.close();
+      }
+    });
+  });
+
+  describe('archive-key convergence (live writer + backfill)', () => {
+    it('keeps live-written and backfilled rows under one canonical key', async () => {
+      const baseDate = 2_000_000;
+      makeService([
+        [
+          { id: 199, date: baseDate - 199, text: 'older 199' },
+          { id: 198, date: baseDate - 198, text: 'older 198' },
+        ],
+      ]);
+
+      // Live writer state: a real channels row plus a message keyed by the
+      // marked id, exactly what realtime sync produces.
+      seedChannel(service, CANONICAL_ID, { lastMessageId: 200 });
+      seedMessage(service, CANONICAL_ID, { id: 200, date: baseDate - 200, text: 'live row' });
+
+      // Backfill enqueued under the canonical key (as the control server now
+      // guarantees) backfills under the same key.
+      const job = service.addJob(CANONICAL_ID, { depth: 3 });
+      const result = await service._backfillHistory(job, 1, 3);
+      expect(result.insertedCount).toBe(2);
+
+      const messageKeys = service.db.prepare('SELECT DISTINCT channel_id FROM messages').all()
+        .map((row) => row.channel_id);
+      expect(messageKeys).toEqual([CANONICAL_ID]);
+
+      const channelKeys = service.db.prepare(
+        'SELECT channel_id FROM channels WHERE channel_id LIKE ?',
+      ).all(`%${GROUP_ID}`).map((row) => row.channel_id);
+      expect(channelKeys).toEqual([CANONICAL_ID]);
+    });
+  });
+
+  describe('read-side key disambiguation', () => {
+    it('routes positive-id reads to the negative key holding the data', () => {
+      makeService();
+      seedChannel(service, CANONICAL_ID);
+      seedMessage(service, CANONICAL_ID, { id: 99, date: 1700000000, text: 'context before' });
+      seedMessage(service, CANONICAL_ID, { id: 100, date: 1700000100, text: 'hello world' });
+      seedMessage(service, CANONICAL_ID, { id: 101, date: 1700000200, text: 'context after' });
+
+      expect(service.getChannel(GROUP_ID)?.channelId).toBe(CANONICAL_ID);
+      expect(service.getChannelMetadata(GROUP_ID)?.channelId).toBe(CANONICAL_ID);
+
+      const listed = service.listArchivedMessages({ channelIds: [GROUP_ID] });
+      expect(listed).toHaveLength(3);
+      expect(listed[0].channelId).toBe(CANONICAL_ID);
+
+      const searched = service.searchArchiveMessages({ query: 'hello', channelIds: [GROUP_ID] });
+      expect(searched).toHaveLength(1);
+      expect(searched[0].messageId).toBe(100);
+
+      const single = service.getArchivedMessage({ channelId: GROUP_ID, messageId: 100 });
+      expect(single?.channelId).toBe(CANONICAL_ID);
+
+      const context = service.getArchivedMessageContext({ channelId: GROUP_ID, messageId: 100 });
+      expect(context.target?.messageId).toBe(100);
+      expect(context.before).toHaveLength(1);
+      expect(context.after).toHaveLength(1);
+    });
+
+    it('ignores a phantom positive-key channels row (no metadata, no messages)', () => {
+      makeService();
+      seedChannel(service, CANONICAL_ID);
+      seedMessage(service, CANONICAL_ID, { id: 100, date: 1700000100, text: 'real data' });
+      // Bare row left behind by an old failed positive-id enqueue: NULL
+      // peer_title/peer_type and no messages must not pin the positive key.
+      service.db.prepare(
+        'INSERT INTO channels (channel_id, updated_at) VALUES (?, CURRENT_TIMESTAMP)',
+      ).run(GROUP_ID);
+
+      expect(service.getChannel(GROUP_ID)?.channelId).toBe(CANONICAL_ID);
+      expect(service.getArchivedMessage({ channelId: GROUP_ID, messageId: 100 })?.channelId)
+        .toBe(CANONICAL_ID);
+    });
+
+    it('does not reroute a positive key that holds real data (user DM)', () => {
+      makeService();
+      seedChannel(service, '555', { peerTitle: 'Alice', peerType: 'user' });
+      seedMessage(service, '555', { id: 7, date: 1700000000, text: 'dm text' });
+
+      expect(service.getChannel('555')?.channelId).toBe('555');
+      const listed = service.listArchivedMessages({ channelIds: ['555'] });
+      expect(listed).toHaveLength(1);
+      expect(listed[0].channelId).toBe('555');
+    });
+
+    it('finds marked supergroup (-100...) data from the bare positive id', () => {
+      makeService();
+      const bareId = 888999777;
+      const markedKey = String(toggleChannelIdMark(bareId));
+      seedChannel(service, markedKey, { peerTitle: 'Supergroup', peerType: 'channel' });
+      seedMessage(service, markedKey, { id: 12, date: 1700000000, text: 'super' });
+
+      expect(service.getChannel(String(bareId))?.channelId).toBe(markedKey);
+      expect(service.getArchivedMessage({ channelId: String(bareId), messageId: 12 })?.channelId)
+        .toBe(markedKey);
+    });
+  });
+
+  describe('job-key disambiguation', () => {
+    it('listJobs/retryJobs/cancelJobs match canonical-keyed jobs from the positive id', () => {
+      makeService();
+      const job = service.addJob(CANONICAL_ID, { depth: 10 });
+
+      const listed = service.listJobs({ channelId: GROUP_ID });
+      expect(listed).toHaveLength(1);
+      expect(listed[0].id).toBe(job.id);
+
+      const retried = service.retryJobs({ channelId: GROUP_ID });
+      expect(retried.updated).toBe(1);
+      expect(retried.jobIds).toEqual([job.id]);
+
+      const canceled = service.cancelJobs({ channelId: GROUP_ID });
+      expect(canceled.canceled).toBe(1);
+      expect(canceled.jobIds).toEqual([job.id]);
+    });
+  });
+});

--- a/tests/peer-resolution.test.js
+++ b/tests/peer-resolution.test.js
@@ -1,0 +1,296 @@
+// Unit tests for TelegramClient.resolveInputPeer / canonicalizeChannelId and
+// the live read paths that must hand the *resolved peer object* (not the raw
+// reference) to mtcute methods that re-resolve internally. Uses the real
+// @mtcute/core module so MtPeerNotFoundError and toggleChannelIdMark behave
+// exactly as in production.
+
+import { describe, expect, it, vi } from 'vitest';
+import { MtPeerNotFoundError, toggleChannelIdMark } from '@mtcute/core';
+
+import TelegramClient from '../telegram-client.js';
+
+const GROUP_ID = 4701666782;
+const CHANNEL_FORM = toggleChannelIdMark(GROUP_ID); // -1004701666782
+const CHAT_FORM = -GROUP_ID; // -4701666782
+
+const INPUT_PEER_CHAT = { _: 'inputPeerChat', chatId: GROUP_ID };
+const INPUT_PEER_CHANNEL = { _: 'inputPeerChannel', channelId: GROUP_ID, accessHash: 99 };
+
+function notFound(ref) {
+  return new MtPeerNotFoundError(`Peer ${ref} is not found in local cache`);
+}
+
+// Bare prototype instance with a fake mtcute inner client, mirroring the
+// pattern in send-messages.test.js.
+function makeClient(client = {}) {
+  const tc = Object.create(TelegramClient.prototype);
+  tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
+  tc.client = client;
+  return tc;
+}
+
+// resolvePeer fake that rejects the positive and channel (-100...) forms with
+// MtPeerNotFoundError and resolves the basic-chat (-id) form — the shape of a
+// plain group chat addressed by its bare positive id.
+function groupResolvePeer() {
+  return vi.fn(async (ref) => {
+    if (ref === CHAT_FORM) {
+      return INPUT_PEER_CHAT;
+    }
+    throw notFound(ref);
+  });
+}
+
+describe('resolveInputPeer', () => {
+  it('resolves a positive user id directly with a single resolvePeer call', async () => {
+    const peer = { _: 'inputPeerUser', userId: 42, accessHash: 7 };
+    const tc = makeClient({ resolvePeer: vi.fn().mockResolvedValue(peer) });
+
+    const result = await tc.resolveInputPeer('42');
+
+    expect(result.peer).toBe(peer);
+    expect(result.canonicalId).toBe('42');
+    expect(tc.client.resolvePeer).toHaveBeenCalledTimes(1);
+    expect(tc.client.resolvePeer).toHaveBeenCalledWith(42);
+  });
+
+  it('falls back from a positive group id to the chat form, channel form first', async () => {
+    const tc = makeClient({ resolvePeer: groupResolvePeer() });
+
+    const result = await tc.resolveInputPeer(String(GROUP_ID));
+
+    expect(result.peer).toBe(INPUT_PEER_CHAT);
+    expect(result.canonicalId).toBe(String(CHAT_FORM));
+    expect(tc.client.resolvePeer.mock.calls.map(([ref]) => ref))
+      .toEqual([GROUP_ID, CHANNEL_FORM, CHAT_FORM]);
+  });
+
+  it('resolves a positive supergroup id via the channel form without trying the chat form', async () => {
+    const tc = makeClient({
+      resolvePeer: vi.fn(async (ref) => {
+        if (ref === CHANNEL_FORM) {
+          return INPUT_PEER_CHANNEL;
+        }
+        throw notFound(ref);
+      }),
+    });
+
+    const result = await tc.resolveInputPeer(GROUP_ID);
+
+    expect(result.peer).toBe(INPUT_PEER_CHANNEL);
+    expect(result.canonicalId).toBe(String(CHANNEL_FORM));
+    expect(tc.client.resolvePeer.mock.calls.map(([ref]) => ref))
+      .toEqual([GROUP_ID, CHANNEL_FORM]);
+  });
+
+  it('decorates an uncached marked channel id miss with a cache-seeding hint', async () => {
+    const tc = makeClient({
+      resolvePeer: vi.fn(async (ref) => {
+        throw notFound(ref);
+      }),
+    });
+
+    const promise = tc.resolveInputPeer(String(CHANNEL_FORM));
+    await expect(promise).rejects.toThrow(/channels list/);
+    await tc.resolveInputPeer(String(CHANNEL_FORM)).catch((error) => {
+      // The original mtcute text is preserved ahead of the hint.
+      expect(error.message).toContain(`Peer ${CHANNEL_FORM} is not found in local cache`);
+    });
+    // Negative refs get no sign fallback: one resolvePeer call per attempt.
+    expect(tc.client.resolvePeer).toHaveBeenCalledTimes(2);
+  });
+
+  it('decorates a positive id miss with the negative-id workaround', async () => {
+    const tc = makeClient({
+      resolvePeer: vi.fn(async (ref) => {
+        throw notFound(ref);
+      }),
+    });
+
+    expect.assertions(4);
+    await tc.resolveInputPeer(GROUP_ID).catch((error) => {
+      expect(error).toBeInstanceOf(MtPeerNotFoundError);
+      expect(error.message).toContain(`Peer ${GROUP_ID} is not found in local cache`);
+      expect(error.message).toContain(`--chat="-${GROUP_ID}"`);
+      expect(error.message).toContain('tgcli channels list');
+    });
+  });
+
+  it('rethrows non-MtPeerNotFoundError failures unmodified, with no fallback attempts', async () => {
+    const networkError = new Error('connection lost');
+    const tc = makeClient({ resolvePeer: vi.fn().mockRejectedValue(networkError) });
+
+    await expect(tc.resolveInputPeer(GROUP_ID)).rejects.toBe(networkError);
+    expect(networkError.message).toBe('connection lost');
+    expect(tc.client.resolvePeer).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a display name before any network call', async () => {
+    const tc = makeClient({ resolvePeer: vi.fn() });
+
+    await expect(tc.resolveInputPeer('ИП Фастов К.Ю: Ольга Кожан'))
+      .rejects.toThrow(/display name/);
+    await expect(tc.resolveInputPeer('ИП Фастов К.Ю: Ольга Кожан'))
+      .rejects.toThrow(/channels list --query/);
+    expect(tc.client.resolvePeer).not.toHaveBeenCalled();
+  });
+
+  it('decorates a username miss with a title-vs-id hint', async () => {
+    const tc = makeClient({
+      resolvePeer: vi.fn(async () => {
+        throw new MtPeerNotFoundError('Peer with username someuser was not found');
+      }),
+    });
+
+    expect.assertions(3);
+    await tc.resolveInputPeer('@someuser').catch((error) => {
+      expect(error.message).toContain('Peer with username someuser was not found');
+      expect(error.message).toContain('channels list --query');
+    });
+    expect(tc.client.resolvePeer).toHaveBeenCalledWith('@someuser');
+  });
+
+  it('returns a null canonicalId for inputPeerSelf', async () => {
+    const tc = makeClient({ resolvePeer: vi.fn().mockResolvedValue({ _: 'inputPeerSelf' }) });
+
+    const result = await tc.resolveInputPeer('me');
+
+    expect(result.peer).toEqual({ _: 'inputPeerSelf' });
+    expect(result.canonicalId).toBeNull();
+  });
+});
+
+describe('canonicalizeChannelId', () => {
+  it('passes usernames through without resolution', async () => {
+    const tc = makeClient({ resolvePeer: vi.fn() });
+
+    await expect(tc.canonicalizeChannelId('@someuser')).resolves.toBe('@someuser');
+    expect(tc.client.resolvePeer).not.toHaveBeenCalled();
+  });
+
+  it("passes 'me' through unchanged", async () => {
+    const tc = makeClient({ resolvePeer: vi.fn() });
+
+    await expect(tc.canonicalizeChannelId('me')).resolves.toBe('me');
+    expect(tc.client.resolvePeer).not.toHaveBeenCalled();
+  });
+
+  it('collapses a positive group id to the marked key the live writer uses', async () => {
+    const tc = makeClient({ resolvePeer: groupResolvePeer() });
+
+    await expect(tc.canonicalizeChannelId(String(GROUP_ID))).resolves.toBe(String(CHAT_FORM));
+  });
+
+  it('keeps a directly-resolvable positive id positive', async () => {
+    const tc = makeClient({
+      resolvePeer: vi.fn().mockResolvedValue({ _: 'inputPeerUser', userId: 42, accessHash: 7 }),
+    });
+
+    await expect(tc.canonicalizeChannelId('42')).resolves.toBe('42');
+  });
+});
+
+describe('live read paths pass the resolved peer object onward', () => {
+  function searchResults(messages = [{ id: 10, date: 1700000000, text: 'hit' }]) {
+    const results = [...messages];
+    results.total = messages.length;
+    results.next = null;
+    return results;
+  }
+
+  it('searchChannelMessages hands searchMessages the peer object for a positive group id', async () => {
+    const searchMessages = vi.fn().mockResolvedValue(searchResults());
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), searchMessages });
+
+    const result = await tc.searchChannelMessages(String(GROUP_ID), { query: 'hit' });
+
+    expect(searchMessages).toHaveBeenCalledTimes(1);
+    expect(searchMessages.mock.calls[0][0].chatId).toBe(INPUT_PEER_CHAT);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe('hit');
+  });
+
+  it('getTopicMessages hands searchMessages the peer object', async () => {
+    const searchMessages = vi.fn().mockResolvedValue(searchResults());
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), searchMessages });
+
+    const result = await tc.getTopicMessages(String(GROUP_ID), 7, 50);
+
+    expect(searchMessages.mock.calls[0][0].chatId).toBe(INPUT_PEER_CHAT);
+    expect(searchMessages.mock.calls[0][0].threadId).toBe(7);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('getMessagesByChannelId iterates history with the peer object', async () => {
+    const iterHistory = vi.fn(() => (async function* () {
+      yield { id: 5, date: 1700000000, text: 'old' };
+    })());
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), iterHistory });
+
+    const result = await tc.getMessagesByChannelId(String(GROUP_ID), 10);
+
+    expect(iterHistory.mock.calls[0][0]).toBe(INPUT_PEER_CHAT);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('getMessageById fetches via the peer object', async () => {
+    const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, text: 'one' }]);
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getMessages });
+
+    const message = await tc.getMessageById(String(GROUP_ID), 5);
+
+    expect(getMessages).toHaveBeenCalledWith(INPUT_PEER_CHAT, 5);
+    expect(message.id).toBe(5);
+  });
+
+  it('getMessageContext fetches target and history via the peer object', async () => {
+    const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, text: 'target' }]);
+    const getHistory = vi.fn().mockResolvedValue([
+      { id: 4, date: 1699999999, text: 'before' },
+      { id: 5, date: 1700000000, text: 'target' },
+      { id: 6, date: 1700000001, text: 'after' },
+    ]);
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getMessages, getHistory });
+
+    const context = await tc.getMessageContext(String(GROUP_ID), 5, { before: 1, after: 1 });
+
+    expect(getMessages).toHaveBeenCalledWith(INPUT_PEER_CHAT, 5);
+    expect(getHistory.mock.calls[0][0]).toBe(INPUT_PEER_CHAT);
+    expect(context.target.id).toBe(5);
+    expect(context.before).toHaveLength(1);
+    expect(context.after).toHaveLength(1);
+  });
+
+  it('downloadMessageMedia looks the message up via the peer object', async () => {
+    const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, media: null }]);
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getMessages });
+
+    // No media on the message: the relevant assertion is that the lookup got
+    // past peer resolution and used the resolved peer object.
+    await expect(tc.downloadMessageMedia(String(GROUP_ID), 5)).rejects.toThrow(/no downloadable media/);
+    expect(getMessages).toHaveBeenCalledWith(INPUT_PEER_CHAT, 5);
+  });
+
+  it('getPeerMetadata resolves a positive group id and feeds the peer to chat lookups', async () => {
+    const getChat = vi.fn().mockResolvedValue({ displayName: 'Group', chatType: 'group' });
+    const getFullChat = vi.fn().mockResolvedValue({ bio: 'about' });
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat, getFullChat });
+
+    const metadata = await tc.getPeerMetadata(String(GROUP_ID));
+
+    expect(getChat).toHaveBeenCalledWith(INPUT_PEER_CHAT);
+    expect(getFullChat).toHaveBeenCalledWith(INPUT_PEER_CHAT);
+    expect(metadata.peerTitle).toBe('Group');
+    expect(metadata.about).toBe('about');
+  });
+
+  it('markChannelRead resolves through the sign fallback', async () => {
+    const readHistory = vi.fn().mockResolvedValue(undefined);
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), readHistory });
+
+    const result = await tc.markChannelRead(String(GROUP_ID), 9);
+
+    expect(readHistory).toHaveBeenCalledWith(INPUT_PEER_CHAT, { maxId: 9 });
+    expect(result.messageId).toBe(9);
+  });
+});

--- a/tests/peer-resolution.test.js
+++ b/tests/peer-resolution.test.js
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { MtPeerNotFoundError, toggleChannelIdMark } from '@mtcute/core';
 
 import TelegramClient from '../telegram-client.js';
+import { PEER_SIGN_RETRY_PATTERN } from '../core/peer-hints.js';
 
 const GROUP_ID = 4701666782;
 const CHANNEL_FORM = toggleChannelIdMark(GROUP_ID); // -1004701666782
@@ -91,7 +92,7 @@ describe('resolveInputPeer', () => {
     });
 
     const promise = tc.resolveInputPeer(String(CHANNEL_FORM));
-    await expect(promise).rejects.toThrow(/channels list/);
+    await expect(promise).rejects.toThrow(/seed the local cache/);
     await tc.resolveInputPeer(String(CHANNEL_FORM)).catch((error) => {
       // The original mtcute text is preserved ahead of the hint.
       expect(error.message).toContain(`Peer ${CHANNEL_FORM} is not found in local cache`);
@@ -107,12 +108,16 @@ describe('resolveInputPeer', () => {
       }),
     });
 
-    expect.assertions(4);
+    expect.assertions(5);
     await tc.resolveInputPeer(GROUP_ID).catch((error) => {
       expect(error).toBeInstanceOf(MtPeerNotFoundError);
       expect(error.message).toContain(`Peer ${GROUP_ID} is not found in local cache`);
-      expect(error.message).toContain(`--chat="-${GROUP_ID}"`);
-      expect(error.message).toContain('tgcli channels list');
+      // The hint stays frontend-neutral (the client also backs the MCP server
+      // and control API): no CLI flag syntax, and it matches the pattern the
+      // CLI boundary uses to restate it in flag vocabulary.
+      expect(error.message).not.toContain('--chat');
+      expect(error.message).toContain(`retry with the negative id "-${GROUP_ID}"`);
+      expect(PEER_SIGN_RETRY_PATTERN.exec(error.message)?.[1]).toBe(`-${GROUP_ID}`);
     });
   });
 
@@ -131,7 +136,7 @@ describe('resolveInputPeer', () => {
     await expect(tc.resolveInputPeer('ИП Фастов К.Ю: Ольга Кожан'))
       .rejects.toThrow(/display name/);
     await expect(tc.resolveInputPeer('ИП Фастов К.Ю: Ольга Кожан'))
-      .rejects.toThrow(/channels list --query/);
+      .rejects.toThrow(/search the chat list/);
     expect(tc.client.resolvePeer).not.toHaveBeenCalled();
   });
 
@@ -145,7 +150,7 @@ describe('resolveInputPeer', () => {
     expect.assertions(3);
     await tc.resolveInputPeer('@someuser').catch((error) => {
       expect(error.message).toContain('Peer with username someuser was not found');
-      expect(error.message).toContain('channels list --query');
+      expect(error.message).toContain('search the chat list');
     });
     expect(tc.client.resolvePeer).toHaveBeenCalledWith('@someuser');
   });

--- a/tests/peer-resolution.test.js
+++ b/tests/peer-resolution.test.js
@@ -5,7 +5,7 @@
 // exactly as in production.
 
 import { describe, expect, it, vi } from 'vitest';
-import { MtPeerNotFoundError, toggleChannelIdMark } from '@mtcute/core';
+import { MtPeerNotFoundError, tl, toggleChannelIdMark } from '@mtcute/core';
 
 import TelegramClient from '../telegram-client.js';
 import { PEER_SIGN_RETRY_PATTERN } from '../core/peer-hints.js';
@@ -22,17 +22,34 @@ function notFound(ref) {
 }
 
 // Bare prototype instance with a fake mtcute inner client, mirroring the
-// pattern in send-messages.test.js.
+// pattern in send-messages.test.js. Peer storage defaults to empty so the
+// basic-chat existence probe takes the same path as a fresh session.
 function makeClient(client = {}) {
   const tc = Object.create(TelegramClient.prototype);
   tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
-  tc.client = client;
+  tc.client = {
+    storage: emptyPeerStorage(),
+    ...client,
+  };
   return tc;
 }
 
-// resolvePeer fake that rejects the positive and channel (-100...) forms with
-// MtPeerNotFoundError and resolves the basic-chat (-id) form — the shape of a
-// plain group chat addressed by its bare positive id.
+function emptyPeerStorage() {
+  return { peers: { getById: vi.fn(async () => null) } };
+}
+
+// Peer storage holding the basic chat, as after a dialog sync: the existence
+// probe accepts the structurally-resolved chat without a getChat round-trip.
+function cachedChatStorage() {
+  return { peers: { getById: vi.fn(async (id) => (id === CHAT_FORM ? INPUT_PEER_CHAT : null)) } };
+}
+
+// resolvePeer fake mirroring real mtcute for a bare positive group id: the
+// positive (user-marked) and channel (-100...) forms miss and throw, while the
+// basic-chat (-id) form ALWAYS resolves structurally — real resolvePeer builds
+// inputPeerChat without consulting cache or server and never throws for it.
+// Whether the chat actually exists is decided by the existence probe (peer
+// storage, then getChat), not by resolvePeer.
 function groupResolvePeer() {
   return vi.fn(async (ref) => {
     if (ref === CHAT_FORM) {
@@ -40,6 +57,13 @@ function groupResolvePeer() {
     }
     throw notFound(ref);
   });
+}
+
+// Inner-client fakes for a plain group the account is a member of, addressed
+// by its bare positive id: structural chat-form resolution plus a storage hit
+// in the existence probe.
+function cachedGroupClient(extra = {}) {
+  return { resolvePeer: groupResolvePeer(), storage: cachedChatStorage(), ...extra };
 }
 
 describe('resolveInputPeer', () => {
@@ -56,7 +80,7 @@ describe('resolveInputPeer', () => {
   });
 
   it('falls back from a positive group id to the chat form, channel form first', async () => {
-    const tc = makeClient({ resolvePeer: groupResolvePeer() });
+    const tc = makeClient(cachedGroupClient());
 
     const result = await tc.resolveInputPeer(String(GROUP_ID));
 
@@ -64,6 +88,19 @@ describe('resolveInputPeer', () => {
     expect(result.canonicalId).toBe(String(CHAT_FORM));
     expect(tc.client.resolvePeer.mock.calls.map(([ref]) => ref))
       .toEqual([GROUP_ID, CHANNEL_FORM, CHAT_FORM]);
+    // The structural inputPeerChat was accepted via the storage probe.
+    expect(tc.client.storage.peers.getById).toHaveBeenCalledWith(CHAT_FORM);
+  });
+
+  it('confirms an uncached basic chat with getChat before accepting the structural peer', async () => {
+    const getChat = vi.fn().mockResolvedValue({ id: GROUP_ID, displayName: 'Group' });
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat });
+
+    const result = await tc.resolveInputPeer(GROUP_ID);
+
+    expect(result.peer).toBe(INPUT_PEER_CHAT);
+    expect(result.canonicalId).toBe(String(CHAT_FORM));
+    expect(getChat).toHaveBeenCalledWith(INPUT_PEER_CHAT);
   });
 
   it('resolves a positive supergroup id via the channel form without trying the chat form', async () => {
@@ -102,13 +139,16 @@ describe('resolveInputPeer', () => {
   });
 
   it('decorates a positive id miss with the negative-id workaround', async () => {
-    const tc = makeClient({
-      resolvePeer: vi.fn(async (ref) => {
-        throw notFound(ref);
-      }),
-    });
+    // Real failure shape for a nonexistent id (and for an uncached supergroup):
+    // the positive and channel forms throw, the basic-chat form resolves
+    // structurally, and the existence probe (storage miss, then getChat)
+    // rejects it — the structural inputPeerChat must NOT be accepted.
+    const getChat = vi.fn().mockRejectedValue(
+      new MtPeerNotFoundError(`Chat ${GROUP_ID} was not found`),
+    );
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat });
 
-    expect.assertions(5);
+    expect.assertions(7);
     await tc.resolveInputPeer(GROUP_ID).catch((error) => {
       expect(error).toBeInstanceOf(MtPeerNotFoundError);
       expect(error.message).toContain(`Peer ${GROUP_ID} is not found in local cache`);
@@ -119,6 +159,25 @@ describe('resolveInputPeer', () => {
       expect(error.message).toContain(`retry with the negative id "-${GROUP_ID}"`);
       expect(PEER_SIGN_RETRY_PATTERN.exec(error.message)?.[1]).toBe(`-${GROUP_ID}`);
     });
+    expect(tc.client.resolvePeer.mock.calls.map(([ref]) => ref))
+      .toEqual([GROUP_ID, CHANNEL_FORM, CHAT_FORM]);
+    expect(getChat).toHaveBeenCalledWith(INPUT_PEER_CHAT);
+  });
+
+  it('treats a Telegram id rejection in the probe as a miss', async () => {
+    const getChat = vi.fn().mockRejectedValue(new tl.RpcError(400, 'CHAT_ID_INVALID'));
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat });
+
+    await expect(tc.resolveInputPeer(GROUP_ID))
+      .rejects.toThrow(/retry with the negative id/);
+  });
+
+  it('propagates unexpected probe failures instead of swallowing them', async () => {
+    const networkError = new Error('connection lost');
+    const getChat = vi.fn().mockRejectedValue(networkError);
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat });
+
+    await expect(tc.resolveInputPeer(GROUP_ID)).rejects.toBe(networkError);
   });
 
   it('rethrows non-MtPeerNotFoundError failures unmodified, with no fallback attempts', async () => {
@@ -181,7 +240,7 @@ describe('canonicalizeChannelId', () => {
   });
 
   it('collapses a positive group id to the marked key the live writer uses', async () => {
-    const tc = makeClient({ resolvePeer: groupResolvePeer() });
+    const tc = makeClient(cachedGroupClient());
 
     await expect(tc.canonicalizeChannelId(String(GROUP_ID))).resolves.toBe(String(CHAT_FORM));
   });
@@ -205,7 +264,7 @@ describe('live read paths pass the resolved peer object onward', () => {
 
   it('searchChannelMessages hands searchMessages the peer object for a positive group id', async () => {
     const searchMessages = vi.fn().mockResolvedValue(searchResults());
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), searchMessages });
+    const tc = makeClient(cachedGroupClient({ searchMessages }));
 
     const result = await tc.searchChannelMessages(String(GROUP_ID), { query: 'hit' });
 
@@ -217,7 +276,7 @@ describe('live read paths pass the resolved peer object onward', () => {
 
   it('getTopicMessages hands searchMessages the peer object', async () => {
     const searchMessages = vi.fn().mockResolvedValue(searchResults());
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), searchMessages });
+    const tc = makeClient(cachedGroupClient({ searchMessages }));
 
     const result = await tc.getTopicMessages(String(GROUP_ID), 7, 50);
 
@@ -230,7 +289,7 @@ describe('live read paths pass the resolved peer object onward', () => {
     const iterHistory = vi.fn(() => (async function* () {
       yield { id: 5, date: 1700000000, text: 'old' };
     })());
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), iterHistory });
+    const tc = makeClient(cachedGroupClient({ iterHistory }));
 
     const result = await tc.getMessagesByChannelId(String(GROUP_ID), 10);
 
@@ -240,7 +299,7 @@ describe('live read paths pass the resolved peer object onward', () => {
 
   it('getMessageById fetches via the peer object', async () => {
     const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, text: 'one' }]);
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), getMessages });
+    const tc = makeClient(cachedGroupClient({ getMessages }));
 
     const message = await tc.getMessageById(String(GROUP_ID), 5);
 
@@ -255,7 +314,7 @@ describe('live read paths pass the resolved peer object onward', () => {
       { id: 5, date: 1700000000, text: 'target' },
       { id: 6, date: 1700000001, text: 'after' },
     ]);
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), getMessages, getHistory });
+    const tc = makeClient(cachedGroupClient({ getMessages, getHistory }));
 
     const context = await tc.getMessageContext(String(GROUP_ID), 5, { before: 1, after: 1 });
 
@@ -268,7 +327,7 @@ describe('live read paths pass the resolved peer object onward', () => {
 
   it('downloadMessageMedia looks the message up via the peer object', async () => {
     const getMessages = vi.fn().mockResolvedValue([{ id: 5, date: 1700000000, media: null }]);
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), getMessages });
+    const tc = makeClient(cachedGroupClient({ getMessages }));
 
     // No media on the message: the relevant assertion is that the lookup got
     // past peer resolution and used the resolved peer object.
@@ -279,7 +338,7 @@ describe('live read paths pass the resolved peer object onward', () => {
   it('getPeerMetadata resolves a positive group id and feeds the peer to chat lookups', async () => {
     const getChat = vi.fn().mockResolvedValue({ displayName: 'Group', chatType: 'group' });
     const getFullChat = vi.fn().mockResolvedValue({ bio: 'about' });
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat, getFullChat });
+    const tc = makeClient(cachedGroupClient({ getChat, getFullChat }));
 
     const metadata = await tc.getPeerMetadata(String(GROUP_ID));
 
@@ -291,11 +350,56 @@ describe('live read paths pass the resolved peer object onward', () => {
 
   it('markChannelRead resolves through the sign fallback', async () => {
     const readHistory = vi.fn().mockResolvedValue(undefined);
-    const tc = makeClient({ resolvePeer: groupResolvePeer(), readHistory });
+    const tc = makeClient(cachedGroupClient({ readHistory }));
 
     const result = await tc.markChannelRead(String(GROUP_ID), 9);
 
     expect(readHistory).toHaveBeenCalledWith(INPUT_PEER_CHAT, { maxId: 9 });
     expect(result.messageId).toBe(9);
+  });
+});
+
+describe('send and group-management paths resolve through the sign fallback', () => {
+  it('sendTextMessage sends to the resolved peer for a positive group id', async () => {
+    const sendText = vi.fn().mockResolvedValue({ id: 11 });
+    const tc = makeClient(cachedGroupClient({ sendText }));
+
+    const result = await tc.sendTextMessage(String(GROUP_ID), 'hello');
+
+    expect(sendText).toHaveBeenCalledWith(INPUT_PEER_CHAT, 'hello', undefined);
+    expect(result.messageId).toBe(11);
+  });
+
+  it('sendTextMessage surfaces the hinted resolution error for a dead positive id', async () => {
+    const sendText = vi.fn();
+    const getChat = vi.fn().mockRejectedValue(
+      new MtPeerNotFoundError(`Chat ${GROUP_ID} was not found`),
+    );
+    const tc = makeClient({ resolvePeer: groupResolvePeer(), getChat, sendText });
+
+    await expect(tc.sendTextMessage(String(GROUP_ID), 'hello'))
+      .rejects.toThrow(/retry with the negative id/);
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it('renameGroup and invite-link calls hand mtcute the resolved peer', async () => {
+    const setChatTitle = vi.fn().mockResolvedValue(undefined);
+    const getPrimaryInviteLink = vi.fn().mockResolvedValue({ link: 'https://t.me/+x' });
+    const tc = makeClient(cachedGroupClient({ setChatTitle, getPrimaryInviteLink }));
+
+    await tc.renameGroup(String(GROUP_ID), 'New title');
+    await tc.getGroupInviteLink(String(GROUP_ID));
+
+    expect(setChatTitle).toHaveBeenCalledWith(INPUT_PEER_CHAT, 'New title');
+    expect(getPrimaryInviteLink).toHaveBeenCalledWith(INPUT_PEER_CHAT);
+  });
+
+  it('addGroupMembers passes the resolved peer to addChatMembers', async () => {
+    const addChatMembers = vi.fn().mockResolvedValue([]);
+    const tc = makeClient(cachedGroupClient({ addChatMembers }));
+
+    await tc.addGroupMembers(String(GROUP_ID), ['@user1']);
+
+    expect(addChatMembers).toHaveBeenCalledWith(INPUT_PEER_CHAT, ['@user1']);
   });
 });

--- a/tests/send-messages.test.js
+++ b/tests/send-messages.test.js
@@ -1,7 +1,10 @@
 vi.mock('@mtcute/node', () => ({
   TelegramClient: vi.fn(),
 }));
-vi.mock('@mtcute/core', () => ({
+// Spread the real module so the peer-resolution imports (MtPeerNotFoundError,
+// toggleChannelIdMark, getMarkedPeerId) stay real; only InputMedia is stubbed.
+vi.mock('@mtcute/core', async (importOriginal) => ({
+  ...(await importOriginal()),
   InputMedia: {
     auto: vi.fn((path, opts) => ({ path, ...opts })),
     photo: vi.fn((path, opts) => ({ path, ...opts })),

--- a/tests/send-messages.test.js
+++ b/tests/send-messages.test.js
@@ -26,13 +26,17 @@ import { md } from '@mtcute/markdown-parser';
 import { html } from '@mtcute/html-parser';
 import TelegramClient from '../telegram-client.js';
 
+// Send paths resolve the chat reference up front (resolveInputPeer) and hand
+// mtcute the resolved input peer, not the raw '@chat' ref.
+const RESOLVED_PEER = { _: 'inputPeerChannel', channelId: 999, accessHash: 1 };
+
 function createMockClient() {
   const tc = Object.create(TelegramClient.prototype);
   tc.ensureLogin = vi.fn().mockResolvedValue(undefined);
   tc.client = {
     sendText: vi.fn().mockResolvedValue({ id: 101 }),
     sendMedia: vi.fn().mockResolvedValue({ id: 202 }),
-    resolvePeer: vi.fn().mockResolvedValue({ _: 'inputPeerChannel', channelId: 999 }),
+    resolvePeer: vi.fn().mockResolvedValue(RESOLVED_PEER),
     _normalizeInputMedia: vi.fn(async (media) => ({ _: 'inputMediaUploadedPhoto', media })),
     call: vi.fn().mockResolvedValue({
       updates: [
@@ -71,12 +75,12 @@ describe('send message reply targeting', () => {
       replyToMessageId: 77,
       topicId: 42,
     });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { replyTo: 77 });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { replyTo: 77 });
   });
 
   it('sendTextMessage falls back to topicId when replyToMessageId is missing', async () => {
     await tc.sendTextMessage('@chat', 'hello', { topicId: 42 });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { replyTo: 42 });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { replyTo: 42 });
   });
 
   it('sendFileMessage uses replyToMessageId when both replyToMessageId and topicId are provided', async () => {
@@ -84,17 +88,17 @@ describe('send message reply targeting', () => {
       replyToMessageId: 77,
       topicId: 42,
     });
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), { replyTo: 77 });
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), { replyTo: 77 });
   });
 
   it('sendFileMessage falls back to topicId when replyToMessageId is missing', async () => {
     await tc.sendFileMessage('@chat', temp.filePath, { topicId: 42 });
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), { replyTo: 42 });
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), { replyTo: 42 });
   });
 
   it('sendFileMessage sends without replyTo params when neither replyToMessageId nor topicId is provided', async () => {
     await tc.sendFileMessage('@chat', temp.filePath, {});
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), undefined);
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), undefined);
   });
 });
 
@@ -111,7 +115,7 @@ describe('sendTextMessage parse-mode', () => {
     expect(md).toHaveBeenCalledTimes(1);
     expect(md).toHaveBeenCalledWith('hello **bold**');
     expect(tc.client.sendText).toHaveBeenCalledWith(
-      '@chat',
+      RESOLVED_PEER,
       { text: 'hello **bold**', entities: [{ type: 'bold' }] },
       undefined,
     );
@@ -122,7 +126,7 @@ describe('sendTextMessage parse-mode', () => {
     expect(html).toHaveBeenCalledTimes(1);
     expect(html).toHaveBeenCalledWith('hello <b>bold</b>');
     expect(tc.client.sendText).toHaveBeenCalledWith(
-      '@chat',
+      RESOLVED_PEER,
       { text: 'hello <b>bold</b>', entities: [{ type: 'italic' }] },
       undefined,
     );
@@ -132,14 +136,14 @@ describe('sendTextMessage parse-mode', () => {
     await tc.sendTextMessage('@chat', 'plain text', { parseMode: 'none' });
     expect(md).not.toHaveBeenCalled();
     expect(html).not.toHaveBeenCalled();
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'plain text', undefined);
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'plain text', undefined);
   });
 
   it('no parseMode sends text as-is (backward compat)', async () => {
     await tc.sendTextMessage('@chat', 'plain text');
     expect(md).not.toHaveBeenCalled();
     expect(html).not.toHaveBeenCalled();
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'plain text', undefined);
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'plain text', undefined);
   });
 
   it('parseMode is case-insensitive', async () => {
@@ -169,40 +173,40 @@ describe('sendTextMessage new send parameters', () => {
 
   it('--silent passes silent: true in params', async () => {
     await tc.sendTextMessage('@chat', 'hello', { silent: true });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { silent: true });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { silent: true });
   });
 
   it('--no-forwards passes forbidForwards: true in params', async () => {
     await tc.sendTextMessage('@chat', 'hello', { noforwards: true });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { forbidForwards: true });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { forbidForwards: true });
   });
 
   it('--schedule passes scheduleDate as unix timestamp in params', async () => {
     const scheduleDate = Math.floor(Date.now() / 1000) + 3600;
     await tc.sendTextMessage('@chat', 'hello', { scheduleDate });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { scheduleDate });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { scheduleDate });
   });
 
   it('combined silent + replyTo passes both in params', async () => {
     await tc.sendTextMessage('@chat', 'hello', { silent: true, replyToMessageId: 55 });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { silent: true, replyTo: 55 });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { silent: true, replyTo: 55 });
   });
 
   it('noForwards (camelCase) passes forbidForwards: true in params', async () => {
     await tc.sendTextMessage('@chat', 'hello', { noForwards: true });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { forbidForwards: true });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { forbidForwards: true });
   });
 
   it('schedule (ISO string) passes scheduleDate as unix timestamp', async () => {
     const iso = '2027-01-15T09:00:00Z';
     const expected = Math.floor(new Date(iso).getTime() / 1000);
     await tc.sendTextMessage('@chat', 'hello', { schedule: iso });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', { scheduleDate: expected });
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', { scheduleDate: expected });
   });
 
   it('no new params still sends undefined params (backward compat)', async () => {
     await tc.sendTextMessage('@chat', 'hello');
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', undefined);
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', undefined);
   });
 });
 
@@ -221,17 +225,17 @@ describe('sendFileMessage new send parameters', () => {
 
   it('--silent passes silent: true in params', async () => {
     await tc.sendFileMessage('@chat', temp.filePath, { silent: true });
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), { silent: true });
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), { silent: true });
   });
 
   it('--no-forwards passes forbidForwards: true in params', async () => {
     await tc.sendFileMessage('@chat', temp.filePath, { noforwards: true });
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), { forbidForwards: true });
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), { forbidForwards: true });
   });
 
   it('--caption-above passes invert: true in params', async () => {
     await tc.sendFileMessage('@chat', temp.filePath, { caption: 'my caption', captionAbove: true });
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), { invert: true });
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), { invert: true });
   });
 
   it('--caption-above without caption throws error', async () => {
@@ -260,7 +264,7 @@ describe('sendFileMessage new send parameters', () => {
 
   it('no new params still sends undefined params (backward compat)', async () => {
     await tc.sendFileMessage('@chat', temp.filePath, {});
-    expect(tc.client.sendMedia).toHaveBeenCalledWith('@chat', expect.anything(), undefined);
+    expect(tc.client.sendMedia).toHaveBeenCalledWith(RESOLVED_PEER, expect.anything(), undefined);
   });
 });
 
@@ -386,11 +390,11 @@ describe('resolveScheduleDate error handling', () => {
 
   it('scheduleDate: 0 is treated as absent', async () => {
     await tc.sendTextMessage('@chat', 'hello', { scheduleDate: 0 });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', undefined);
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', undefined);
   });
 
   it('scheduleDate: null is treated as absent', async () => {
     await tc.sendTextMessage('@chat', 'hello', { scheduleDate: null });
-    expect(tc.client.sendText).toHaveBeenCalledWith('@chat', 'hello', undefined);
+    expect(tc.client.sendText).toHaveBeenCalledWith(RESOLVED_PEER, 'hello', undefined);
   });
 });

--- a/tests/telegram-client-auth.test.js
+++ b/tests/telegram-client-auth.test.js
@@ -10,7 +10,10 @@ vi.mock('@mtcute/node', () => ({
   TelegramClient: mtcuteClientCtor,
 }));
 
-vi.mock('@mtcute/core', () => ({
+// Spread the real module so the peer-resolution imports (MtPeerNotFoundError,
+// toggleChannelIdMark, getMarkedPeerId) stay real; only InputMedia is stubbed.
+vi.mock('@mtcute/core', async (importOriginal) => ({
+  ...(await importOriginal()),
   InputMedia: {},
 }));
 

--- a/tests/telegram-client-qr.test.js
+++ b/tests/telegram-client-qr.test.js
@@ -23,7 +23,10 @@ vi.mock('@mtcute/node', () => ({
   TelegramClient: mtcuteClientCtor,
 }));
 
-vi.mock('@mtcute/core', () => ({
+// Spread the real module so the peer-resolution imports (MtPeerNotFoundError,
+// toggleChannelIdMark, getMarkedPeerId) stay real; only InputMedia is stubbed.
+vi.mock('@mtcute/core', async (importOriginal) => ({
+  ...(await importOriginal()),
   InputMedia: {},
 }));
 


### PR DESCRIPTION
Backlog item: ops-hub `knowledge/projects/tgcli/backlog/2026-06-12-peer-addressing-ux.md`

## What

- Sign-tolerant peer resolution: positive and negative group ids resolve to the same chat. Structurally-resolved `inputPeerChat` is accepted only after an existence probe (local peer storage first, then `messages.getChats`) — real mtcute never throws for basic-chat-form ids, so blind acceptance would fabricate bogus peers.
- Unquoted negative id misuse (`--chat -123…`) gets the exact `--chat="-<id>"` workaround appended by the commander output hook and `writeError` (including the `SendCommandError` path).
- Cache-miss and display-name/phone errors carry actionable, frontend-neutral hints (shared vocabulary in `core/peer-hints.js`, CLI-specific phrasing injected at the CLI boundary).
- Sign-tolerant keying applied consistently across archive entry points (single `_resolveKeyBySign` core); backfill/control-server enqueue canonicalized keys only after the id is verified resolvable.
- All send/group-management surfaces routed through `resolveInputPeer` (eleven methods previously passed raw refs to mtcute).

## Review (lean dev-loop)

Independent three-lens review (correctness / quality / goal): 1 must-fix (structural `inputPeerChat` accepted blindly — hint was dead code in production, bogus ids leaked into job keys), 1 should-fix (send/group surfaces bypassing the resolver), nits. All fixed and re-verified against vendored mtcute source; reviewer verdict: approve.

## Tests

Full suite green: 31 files, 394 tests (`npm test`, vitest). +13 vs branch start, covering: candidate-sequence fallback with existence probe, `CHAT_ID_INVALID`-as-miss, probe error propagation, send-path resolution with positive ids, CLI hint restating, sign-tolerant archive reads/writes against real sqlite.